### PR TITLE
feat: add PTLinearDiscountPriceOracle for non-stablecoin PT assets

### DIFF
--- a/src/oracle/PTLinearDiscountPriceOracle.sol
+++ b/src/oracle/PTLinearDiscountPriceOracle.sol
@@ -1,0 +1,82 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import { IOracle } from "../moolah/interfaces/IOracle.sol";
+import { ILinearDiscountOracle } from "./interfaces/ILinearDiscountOracle.sol";
+
+contract PTLinearDiscountPriceOracle is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
+  /// @dev PT token address
+  address public asset;
+
+  /// @dev Linear discount oracle address
+  address public discountOracle;
+
+  /// @dev Base token address
+  address public baseToken;
+
+  /// @dev Base token oracle address which implements `peek` function
+  IOracle public baseTokenOracle;
+
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @notice Initializes the contract
+  /// @param admin The address of the admin
+  /// @param manager The address of the manager
+  /// @param _asset The address of the PT asset
+  /// @param linearDiscount The address of the linear discount oracle for the PT asset
+  /// @param _baseToken The address of the base token; WBNB for pt-clisBnb
+  /// @param _baseTokenOracle The address of the base token oracle, for example: Lista ResilientOracle
+  function initialize(
+    address admin,
+    address manager,
+    address _asset,
+    address linearDiscount,
+    address _baseToken,
+    address _baseTokenOracle
+  ) external initializer {
+    require(admin != address(0), "Invalid admin address");
+    require(manager != address(0), "Invalid manager address");
+    require(_asset != address(0), "Invalid asset address");
+    require(linearDiscount != address(0), "Invalid linear discount oracle address");
+    require(_baseToken != address(0), "Invalid base token address");
+    require(_baseTokenOracle != address(0), "Invalid base token oracle address");
+
+    require(_asset == ILinearDiscountOracle(linearDiscount).PT(), "Asset mismatch");
+    require(ILinearDiscountOracle(linearDiscount).decimals() == 18, "Invalid discount oracle");
+
+    IOracle(_baseTokenOracle).peek(_baseToken);
+    baseToken = _baseToken;
+    baseTokenOracle = IOracle(_baseTokenOracle);
+
+    asset = _asset;
+    discountOracle = linearDiscount;
+    __AccessControl_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+  }
+
+  function peek(address _asset) public view returns (uint256) {
+    require(_asset == asset, "PTLinearDiscountOracle: Invalid asset");
+    (, int256 answer, , , ) = ILinearDiscountOracle(discountOracle).latestRoundData();
+    uint256 basePrice = baseTokenOracle.peek(baseToken);
+    uint256 price = basePrice * uint256(answer) / 1e18;
+
+    require(price > 0, "PTLinearDiscountOracle: Invalid price");
+    return price;
+  }
+
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/test/oracle/PTLinearDiscountOracle.t.sol
+++ b/test/oracle/PTLinearDiscountOracle.t.sol
@@ -39,7 +39,7 @@ contract PTLinearDiscountOracleTest is Test {
     assertEq(ptLinearDiscountOracle.decimals(), 8);
   }
 
-  function test_peek() public {
+  function test_peek() public view {
     uint256 price = ptLinearDiscountOracle.peek(ptSusde26Jun2025);
     uint256 maturity = IPTExpiry(ptSusde26Jun2025).expiry();
     uint256 timeLeft = (maturity > block.timestamp) ? maturity - block.timestamp : 0;

--- a/test/oracle/PTLinearDiscountPriceOracle.t.sol
+++ b/test/oracle/PTLinearDiscountPriceOracle.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { PTLinearDiscountPriceOracle, ILinearDiscountOracle } from "../../src/oracle/PTLinearDiscountPriceOracle.sol";
+import { IOracle } from "../../src/moolah/interfaces/IOracle.sol";
+
+interface IPTExpiry {
+  function expiry() external view returns (uint256);
+}
+
+contract PTLinearDiscountOracleTest is Test {
+  PTLinearDiscountPriceOracle ptLinearDiscountOracle;
+
+  address ptClisBNB30OCT2025 = 0xb84cEC1Ab2af11b530ae0d8594B1493556be49Cd;
+  address discountOracle = 0xDF1dED2EA9dEa5456533A0C92f6EF7d6F2ACc1c0;
+  address WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+  address multiOracle = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+
+  address admin = address(0x01);
+  address manager = address(0x02);
+
+  function setUp() public {
+    vm.createSelectFork("https://bsc-dataseed.bnbchain.org");
+
+    PTLinearDiscountPriceOracle impl = new PTLinearDiscountPriceOracle();
+    ERC1967Proxy proxy_ = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(
+        PTLinearDiscountPriceOracle.initialize.selector,
+        admin,
+        manager,
+        ptClisBNB30OCT2025,
+        discountOracle,
+        WBNB,
+        multiOracle
+      )
+    );
+    ptLinearDiscountOracle = PTLinearDiscountPriceOracle(address(proxy_));
+
+    assertEq(ptLinearDiscountOracle.asset(), ptClisBNB30OCT2025);
+    assertEq(ptLinearDiscountOracle.discountOracle(), discountOracle);
+    assertEq(ptLinearDiscountOracle.decimals(), 8);
+    assertEq(ptLinearDiscountOracle.baseToken(), WBNB);
+    assertEq(address(ptLinearDiscountOracle.baseTokenOracle()), multiOracle);
+    assertTrue(ptLinearDiscountOracle.hasRole(ptLinearDiscountOracle.MANAGER(), manager));
+    assertTrue(ptLinearDiscountOracle.hasRole(ptLinearDiscountOracle.DEFAULT_ADMIN_ROLE(), admin));
+  }
+
+  function test_peek() public view {
+    uint256 price = ptLinearDiscountOracle.peek(ptClisBNB30OCT2025);
+
+    uint256 basePrice = IOracle(multiOracle).peek(WBNB);
+
+    uint256 maturity = IPTExpiry(ptClisBNB30OCT2025).expiry();
+    uint256 timeLeft = (maturity > block.timestamp) ? maturity - block.timestamp : 0;
+    uint256 discount = 1e18 - ILinearDiscountOracle(discountOracle).getDiscount(timeLeft);
+
+    assertEq(price, (basePrice * discount) / 1e18); // price equals to discount applied to the base price
+  }
+}


### PR DESCRIPTION
Added PTLinearDiscountPriceOracle to support `PT-clisBNB-30OCT2025`. The price is calculated by applying a discount to the base price.