### PR TITLE
Audit/bnb provider

### DIFF
--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -72,6 +72,9 @@ contract MoolahVault is
   /// @inheritdoc IMoolahVaultBase
   uint256 public lastTotalAssets;
 
+  /// @inheritdoc IMoolahVaultBase
+  address public provider;
+
   bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
   bytes32 public constant CURATOR = keccak256("CURATOR"); // curator role
   bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR"); // allocator role
@@ -312,6 +315,15 @@ contract MoolahVault is
     require(_revokeRole(BOT, _address), ErrorsLib.RevokeBotFailed());
   }
 
+  /// @inheritdoc IMoolahVaultBase
+  function initProvider(address _provider) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_provider != address(0), ErrorsLib.ZeroAddress());
+    require(provider == address(0), ErrorsLib.AlreadySet());
+    provider = _provider;
+
+    emit EventsLib.InitProvider(_provider);
+  }
+
   /* EXTERNAL */
 
   /// @inheritdoc IMoolahVaultBase
@@ -409,7 +421,6 @@ contract MoolahVault is
   /// @param owner The address of the owner of the shares; shares are burned from owner.
   /// @param sender The address of the caller who initiated the withdrawal via the provider.
   function withdrawFor(uint256 assets, address owner, address sender) external returns (uint256 shares) {
-    address provider = MOOLAH.providers(asset());
     require(provider != address(0), ErrorsLib.ZeroAddress());
     require(msg.sender == provider, ErrorsLib.NotProvider());
 
@@ -428,7 +439,6 @@ contract MoolahVault is
   /// @param owner The address of the owner of the shares; shares are burned from owner.
   /// @param sender The address of the caller who initiated the redemption via the provider.
   function redeemFor(uint256 shares, address owner, address sender) external returns (uint256 assets) {
-    address provider = MOOLAH.providers(asset());
     require(provider != address(0), ErrorsLib.ZeroAddress());
     require(msg.sender == provider, ErrorsLib.NotProvider());
 

--- a/src/moolah-vault/interfaces/IMoolahVault.sol
+++ b/src/moolah-vault/interfaces/IMoolahVault.sol
@@ -62,6 +62,9 @@ interface IMoolahVaultBase {
   /// triggered (deposit/mint/withdraw/redeem/setFee/setFeeRecipient).
   function lastTotalAssets() external view returns (uint256);
 
+  /// @notice The address of the provider.
+  function provider() external view returns (address);
+
   /// @notice set market removal
   function setMarketRemoval(MarketParams memory) external;
 
@@ -111,6 +114,8 @@ interface IMoolahVaultBase {
   function reallocate(MarketAllocation[] calldata allocations) external;
   function setBotRole(address _address) external;
   function revokeBotRole(address _address) external;
+  /// @notice Sets the address of the provider.
+  function initProvider(address _provider) external;
 }
 
 /// @dev This interface is inherited by MoolahVault so that function signatures are checked by the compiler.

--- a/src/moolah-vault/libraries/EventsLib.sol
+++ b/src/moolah-vault/libraries/EventsLib.sol
@@ -86,6 +86,9 @@ library EventsLib {
   /// @notice Emitted when an `amount` of `token` is transferred to the skim recipient by `caller`.
   event Skim(address indexed caller, address indexed token, uint256 amount);
 
+  /// @notice Emitted when a `provider` is set to Vault.
+  event InitProvider(address indexed provider);
+
   /// @notice Emitted when a new MoolahVault vault is created.
   /// @param moolahVault The address of the MoolahVault vault.
   /// @param caller The caller of the function.

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -178,6 +178,9 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     require(marketParams.loanToken == address(WBNB), "invalid loan token");
     require(msg.value >= assets, "invalid BNB amount");
 
+    // accrue interest on the market and then calculate `wrapAmount`
+    MOOLAH.accrueInterest(marketParams);
+
     uint256 wrapAmount = assets;
     if (wrapAmount == 0) {
       // If assets is 0, we need to wrap the shares amount

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -187,6 +187,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
       require(shares > 0, ErrorsLib.ZERO_ASSETS);
       Market memory market = MOOLAH.market(marketParams.id());
       wrapAmount = shares.toAssetsUp(market.totalBorrowAssets, market.totalBorrowShares);
+      require(msg.value >= wrapAmount, "insufficient funds");
     }
 
     // 1. wrap BNB to WBNB

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -53,6 +53,8 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
     MOOLAH = IMoolah(moolah);
     MOOLAH_VAULT = IMoolahVault(moolahVault);
     TOKEN = wbnb;
+
+    _disableInitializers();
   }
 
   /// @param admin The admin of the contract.

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -157,7 +157,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     WBNB.withdraw(_assets);
 
     // 3. transfer BNB to receiver
-    (bool success, ) = receiver.call{ value: assets }("");
+    (bool success, ) = receiver.call{ value: _assets }("");
     require(success, "transfer failed");
   }
 

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnume
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import { IWBNB } from "./interfaces/IWBNB.sol";
+import { IProvider } from "./interfaces/IProvider.sol";
 
 import { MarketParamsLib } from "../moolah/libraries/MarketParamsLib.sol";
 import { SharesMathLib } from "../moolah/libraries/SharesMathLib.sol";
@@ -19,7 +20,7 @@ import { UtilsLib } from "../moolah/libraries/UtilsLib.sol";
 /// @dev
 /// - Handles interactions with the WBNB vault for deposit, mint, withdraw, and redeem operations.
 /// - Integrates with the Moolah core contract to support borrowing, repayment, and collateral management using BNB.
-contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
+contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IProvider {
   using MarketParamsLib for MarketParams;
   using SharesMathLib for uint256;
 
@@ -27,7 +28,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
 
   IMoolah public immutable MOOLAH;
   IMoolahVault public immutable MOOLAH_VAULT;
-  IWBNB public immutable WBNB;
+  address public immutable TOKEN;
 
   bytes32 public constant MANAGER = keccak256("MANAGER");
 
@@ -51,7 +52,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
 
     MOOLAH = IMoolah(moolah);
     MOOLAH_VAULT = IMoolahVault(moolahVault);
-    WBNB = IWBNB(wbnb);
+    TOKEN = wbnb;
   }
 
   /// @param admin The admin of the contract.
@@ -73,8 +74,8 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     uint256 assets = msg.value;
     require(assets > 0, ErrorsLib.ZERO_ASSETS);
 
-    WBNB.deposit{ value: assets }();
-    require(WBNB.approve(address(MOOLAH_VAULT), assets));
+    IWBNB(TOKEN).deposit{ value: assets }();
+    require(IWBNB(TOKEN).approve(address(MOOLAH_VAULT), assets));
 
     shares = MOOLAH_VAULT.deposit(assets, receiver);
   }
@@ -87,8 +88,8 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     uint256 previewAssets = MOOLAH_VAULT.previewMint(shares); // ceiling rounding
     require(msg.value >= previewAssets, "invalid BNB amount");
 
-    WBNB.deposit{ value: previewAssets }();
-    require(WBNB.approve(address(MOOLAH_VAULT), previewAssets));
+    IWBNB(TOKEN).deposit{ value: previewAssets }();
+    require(IWBNB(TOKEN).approve(address(MOOLAH_VAULT), previewAssets));
     assets = MOOLAH_VAULT.mint(shares, receiver);
 
     if (msg.value > assets) {
@@ -108,7 +109,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     shares = MOOLAH_VAULT.withdrawFor(assets, owner, msg.sender);
 
     // 2. unwrap WBNB
-    WBNB.withdraw(assets);
+    IWBNB(TOKEN).withdraw(assets);
 
     // 3. transfer WBNB to receiver
     (bool success, ) = receiver.call{ value: assets }("");
@@ -126,7 +127,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     assets = MOOLAH_VAULT.redeemFor(shares, owner, msg.sender);
 
     // 2. unwrap WBNB
-    WBNB.withdraw(assets);
+    IWBNB(TOKEN).withdraw(assets);
 
     // 3. transfer BNB to receiver
     (bool success, ) = receiver.call{ value: assets }("");
@@ -147,14 +148,14 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     address payable receiver
   ) external returns (uint256 _assets, uint256 _shares) {
     // No need to verify assets and shares, as they are already verified in the Moolah contract.
-    require(marketParams.loanToken == address(WBNB), "invalid loan token");
+    require(marketParams.loanToken == TOKEN, "invalid loan token");
     require(isSenderAuthorized(msg.sender, onBehalf), ErrorsLib.UNAUTHORIZED);
 
     // 1. borrow WBNB from moolah
     (_assets, _shares) = MOOLAH.borrow(marketParams, assets, shares, onBehalf, address(this));
 
     // 2. unwrap WBNB
-    WBNB.withdraw(_assets);
+    IWBNB(TOKEN).withdraw(_assets);
 
     // 3. transfer BNB to receiver
     (bool success, ) = receiver.call{ value: _assets }("");
@@ -175,7 +176,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     bytes calldata data
   ) external payable returns (uint256 _assets, uint256 _shares) {
     require(UtilsLib.exactlyOneZero(assets, shares), ErrorsLib.INCONSISTENT_INPUT);
-    require(marketParams.loanToken == address(WBNB), "invalid loan token");
+    require(marketParams.loanToken == TOKEN, "invalid loan token");
     require(msg.value >= assets, "invalid BNB amount");
 
     // accrue interest on the market and then calculate `wrapAmount`
@@ -191,9 +192,9 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     }
 
     // 1. wrap BNB to WBNB
-    WBNB.deposit{ value: wrapAmount }();
+    IWBNB(TOKEN).deposit{ value: wrapAmount }();
     // 2. approve moolah to transfer WBNB
-    require(WBNB.approve(address(MOOLAH), wrapAmount));
+    require(IWBNB(TOKEN).approve(address(MOOLAH), wrapAmount));
     // 3. repay WBNB to moolah
     (_assets, _shares) = MOOLAH.repay(marketParams, assets, shares, onBehalf, data);
 
@@ -215,12 +216,12 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
   ) external payable {
     uint256 assets = msg.value;
     require(assets > 0, ErrorsLib.ZERO_ASSETS);
-    require(marketParams.collateralToken == address(WBNB), "invalid collateral token");
+    require(marketParams.collateralToken == TOKEN, "invalid collateral token");
 
     // 1. deposit WBNB
-    WBNB.deposit{ value: assets }();
+    IWBNB(TOKEN).deposit{ value: assets }();
     // 2. approve moolah to transfer WBNB
-    require(WBNB.approve(address(MOOLAH), assets));
+    require(IWBNB(TOKEN).approve(address(MOOLAH), assets));
     // 3. supply collateral to moolah
     MOOLAH.supplyCollateral(marketParams, assets, onBehalf, data);
   }
@@ -236,14 +237,14 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable {
     address onBehalf,
     address payable receiver
   ) external {
-    require(marketParams.collateralToken == address(WBNB), "invalid collateral token");
+    require(marketParams.collateralToken == TOKEN, "invalid collateral token");
     require(isSenderAuthorized(msg.sender, onBehalf), ErrorsLib.UNAUTHORIZED);
 
     // 1. withdraw WBNB from moolah by specifying the amount
     MOOLAH.withdrawCollateral(marketParams, assets, onBehalf, address(this));
 
     // 2. unwrap WBNB
-    WBNB.withdraw(assets);
+    IWBNB(TOKEN).withdraw(assets);
 
     // 3. transfer BNB to receiver
     (bool success, ) = receiver.call{ value: assets }("");

--- a/test/provider/BNBProviderMainnet.t.sol
+++ b/test/provider/BNBProviderMainnet.t.sol
@@ -373,7 +373,7 @@ contract BNBProviderTest is Test {
 
     skip(1 days);
 
-    moolah.accrueInterest(param);
+    //    moolah.accrueInterest(param);
     vm.startPrank(user);
     (uint256 supplySharesBefore, uint128 borrowSharesBefore, uint128 collateralBefore) = moolah.position(
       param.id(),
@@ -382,6 +382,8 @@ contract BNBProviderTest is Test {
     (, , uint128 totalBorrowAssets, uint128 totalBorrowShares, , ) = moolah.market(param.id());
     uint256 assets = uint256(borrowSharesBefore).toAssetsUp(totalBorrowAssets, totalBorrowShares);
     uint256 balanceBefore = user.balance;
+    vm.expectRevert("insufficient funds");
+    bnbProvider.repay{ value: 0 }(param, 0, borrowSharesBefore, user, "");
     bnbProvider.repay{ value: assets + 100 }(param, 0, borrowSharesBefore, user, "");
 
     (uint256 supplyShares, uint128 borrowShares, uint128 collateral) = moolah.position(param.id(), user);

--- a/test/provider/BNBProviderMainnet.t.sol
+++ b/test/provider/BNBProviderMainnet.t.sol
@@ -309,6 +309,33 @@ contract BNBProviderTest is Test {
     return param;
   }
 
+  function test_borrow_with_shares() public returns (MarketParams memory) {
+    MarketParams memory param = test_supplyCollateral_btcb();
+
+    uint256 balanceBefore = user.balance;
+    uint256 assets = 1 ether;
+    (
+      uint128 totalSupplyAssets,
+      uint128 totalSupplyShares,
+      uint128 totalBorrowAssets,
+      uint128 totalBorrowShares,
+      uint128 lastUpdate,
+      uint128 fee
+    ) = moolah.market(param.id());
+    uint256 shares = assets.toSharesUp(totalBorrowAssets, totalBorrowShares);
+
+    vm.startPrank(user);
+    bnbProvider.borrow(param, 0, shares, user, payable(user));
+
+    (uint256 supplyShares, uint128 borrowShares, uint128 collateral) = moolah.position(param.id(), user);
+    assertEq(supplyShares, 0);
+    assertEq(borrowShares, shares);
+    assertEq(collateral, 1 ether);
+    assertEq(user.balance, balanceBefore + assets);
+
+    return param;
+  }
+
   function test_borrow_onBehalf() public returns (MarketParams memory) {
     MarketParams memory param = test_supplyCollateral_btcb();
     vm.stopPrank();


### PR DESCRIPTION
Fixed issues:

* should use `_asset` instead of `asset` in `BNBProvider.borrow`
* add check for `msg.value` and `wrapAmount` when input parameter assets is zero
* should accure interest on repayment before the calculation of `wrapAmount`
* add `provider` variable to `MoolahVault`