### PR TITLE
feat: add FixedRateIrm

### DIFF
--- a/script/deploy_fixedRateIrm_impl.sol
+++ b/script/deploy_fixedRateIrm_impl.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.8.28;
+
+import "forge-std/Script.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { FixedRateIrm } from "interest-rate-model/FixedRateIrm.sol";
+import { Moolah } from "moolah/Moolah.sol";
+
+contract FixedRateIrmDeploy is Script {
+  function run() public {
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy InterestRateModel implementation
+    FixedRateIrm impl = new FixedRateIrm();
+    console.log("FixedRateIrm implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/interest-rate-model/FixedRateIrm.sol
+++ b/src/interest-rate-model/FixedRateIrm.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+
+import { IIrm } from "moolah/interfaces/IIrm.sol";
+import { IFixedRateIrm } from "./interfaces/IFixedRateIrm.sol";
+
+import { MarketParamsLib } from "../moolah/libraries/MarketParamsLib.sol";
+import { Id, MarketParams, Market } from "moolah/interfaces/IMoolah.sol";
+import { ErrorsLib } from "./libraries/ErrorsLib.sol";
+
+/* ERRORS */
+
+/// @dev Thrown when the rate is already set for this market.
+string constant RATE_SET = "rate set";
+/// @dev Thrown when the rate is zero or negative.
+string constant RATE_INVALID = "rate zero or negative";
+/// @dev Thrown when trying to set a rate that is too high.
+string constant RATE_TOO_HIGH = "rate too high";
+
+/// @title FixedRateIrm
+/// @author Lista DAO
+contract FixedRateIrm is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IFixedRateIrm {
+  using MarketParamsLib for MarketParams;
+
+  /* CONSTANTS */
+
+  /// @inheritdoc IFixedRateIrm
+  int256 public constant MAX_BORROW_RATE = 8.0 ether / int256(365 days);
+
+  /* STORAGE */
+
+  /// @inheritdoc IFixedRateIrm
+  mapping(Id => int256) public borrowRateStored;
+
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+
+  /* CONSTRUCTOR */
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @notice Constructor.
+  /// @param admin The new admin of the contract.
+  function initialize(address admin, address manager) public initializer {
+    require(admin != address(0), ErrorsLib.ZERO_ADDRESS);
+    require(manager != address(0), ErrorsLib.ZERO_ADDRESS);
+
+    __AccessControl_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+  }
+
+  /* SETTER */
+
+  /// @inheritdoc IFixedRateIrm
+  function setBorrowRate(Id id, int256 newBorrowRate) external onlyRole(MANAGER) {
+    require(newBorrowRate > 0, RATE_INVALID);
+    require(newBorrowRate <= MAX_BORROW_RATE, RATE_TOO_HIGH);
+    require(borrowRateStored[id] != newBorrowRate, RATE_SET);
+
+    borrowRateStored[id] = newBorrowRate;
+
+    emit SetBorrowRate(id, newBorrowRate);
+  }
+
+  /* BORROW RATES */
+
+  /// @inheritdoc IIrm
+  function borrowRateView(MarketParams memory marketParams, Market memory) external view returns (uint256) {
+    int256 borrowRateCached = borrowRateStored[marketParams.id()];
+    require(borrowRateCached > 0, RATE_INVALID);
+    int256 _borrowRate = borrowRateCached > MAX_BORROW_RATE ? MAX_BORROW_RATE : borrowRateCached;
+    return uint256(_borrowRate);
+  }
+
+  /// @inheritdoc IIrm
+  /// @dev Reverts on not set rate, so the rate has to be set before the market creation.
+  function borrowRate(MarketParams memory marketParams, Market memory) external view returns (uint256) {
+    int256 borrowRateCached = borrowRateStored[marketParams.id()];
+    require(borrowRateCached > 0, RATE_INVALID);
+    int256 _borrowRate = borrowRateCached > MAX_BORROW_RATE ? MAX_BORROW_RATE : borrowRateCached;
+    return uint256(_borrowRate);
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/interest-rate-model/FixedRateIrm.sol
+++ b/src/interest-rate-model/FixedRateIrm.sol
@@ -72,7 +72,7 @@ contract FixedRateIrm is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IF
   /* BORROW RATES */
 
   /// @inheritdoc IIrm
-  function borrowRateView(MarketParams memory marketParams, Market memory) external view returns (uint256) {
+  function borrowRateView(MarketParams memory marketParams, Market memory) public view returns (uint256) {
     int256 borrowRateCached = borrowRateStored[marketParams.id()];
     require(borrowRateCached > 0, RATE_INVALID);
     int256 _borrowRate = borrowRateCached > MAX_BORROW_RATE ? MAX_BORROW_RATE : borrowRateCached;
@@ -81,11 +81,8 @@ contract FixedRateIrm is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IF
 
   /// @inheritdoc IIrm
   /// @dev Reverts on not set rate, so the rate has to be set before the market creation.
-  function borrowRate(MarketParams memory marketParams, Market memory) external view returns (uint256) {
-    int256 borrowRateCached = borrowRateStored[marketParams.id()];
-    require(borrowRateCached > 0, RATE_INVALID);
-    int256 _borrowRate = borrowRateCached > MAX_BORROW_RATE ? MAX_BORROW_RATE : borrowRateCached;
-    return uint256(_borrowRate);
+  function borrowRate(MarketParams memory marketParams, Market memory market) external view returns (uint256) {
+    return borrowRateView(marketParams, market);
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/src/interest-rate-model/interfaces/IFixedRateIrm.sol
+++ b/src/interest-rate-model/interfaces/IFixedRateIrm.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IIrm } from "moolah/interfaces/IIrm.sol";
+import { Id } from "moolah/interfaces/IMoolah.sol";
+
+/// @title IFixedRateIrm
+interface IFixedRateIrm is IIrm {
+  /* EVENTS */
+
+  /// @notice Emitted when a borrow rate is set.
+  event SetBorrowRate(Id indexed id, int256 newBorrowRate);
+
+  /* EXTERNAL */
+
+  /// @notice Max settable borrow rate (800%).
+  function MAX_BORROW_RATE() external returns (int256);
+
+  /// @notice Fixed borrow rates.
+  function borrowRateStored(Id id) external returns (int256);
+
+  /// @notice Sets the borrow rate for a market.
+  /// @dev A rate can only be set or updated by manager.
+  /// @dev Reverts on not set rate, so the rate has to be set before the market creation.
+  /// @dev As interest are rounded down in Moolah, for markets with a low total borrow, setting a rate too low could
+  /// prevent interest from accruing if interactions are frequent.
+  function setBorrowRate(Id id, int256 newBorrowRate) external;
+}

--- a/test/interest-rate-model/AlphaIrmTest.sol
+++ b/test/interest-rate-model/AlphaIrmTest.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "forge-std/Test.sol";
+
+import "interest-rate-model/FixedRateIrm.sol";
+
+contract AlpahIrmMainnetTest is Test {
+  using MarketParamsLib for MarketParams;
+
+  address admin = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253; // timelock
+  address manager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+  address alphaIrm = 0x5F9f9173B405C6CEAfa7f98d09e4B8447e9797E6;
+
+  FixedRateIrm fixedRateIrm = FixedRateIrm(alphaIrm);
+
+  bytes32 private constant IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+  function setUp() external {
+    vm.createSelectFork("https://bsc-dataseed.bnbchain.org");
+
+    address impl = address(new FixedRateIrm());
+
+    vm.startPrank(admin);
+    UUPSUpgradeable proxy = UUPSUpgradeable(alphaIrm);
+    proxy.upgradeToAndCall(impl, bytes(""));
+    assertEq(getImplementation(alphaIrm), impl);
+    fixedRateIrm = FixedRateIrm(alphaIrm);
+
+    fixedRateIrm.grantRole(fixedRateIrm.MANAGER(), manager);
+    vm.stopPrank();
+  }
+
+  function test_roleAdmin() public view {
+    assertTrue(fixedRateIrm.hasRole(fixedRateIrm.DEFAULT_ADMIN_ROLE(), admin));
+    assertTrue(fixedRateIrm.hasRole(fixedRateIrm.MANAGER(), manager));
+
+    assertEq(fixedRateIrm.getRoleAdmin(fixedRateIrm.DEFAULT_ADMIN_ROLE()), fixedRateIrm.DEFAULT_ADMIN_ROLE());
+    assertEq(fixedRateIrm.getRoleAdmin(fixedRateIrm.MANAGER()), fixedRateIrm.DEFAULT_ADMIN_ROLE());
+  }
+
+  function test_setBorrowRate() public {
+    Id id = Id.wrap(bytes32(0x00));
+    int256 rate = 0.05 ether / int256(365 days); // 5% annual interest rate
+    vm.expectRevert();
+    fixedRateIrm.setBorrowRate(id, rate);
+    vm.startPrank(manager);
+    fixedRateIrm.setBorrowRate(id, rate);
+
+    assertEq(fixedRateIrm.borrowRateStored(id), rate);
+    vm.stopPrank();
+  }
+
+  function test_borrowRateView() public {
+    int256 rate = 0.05 ether / int256(365 days); // 5% annual interest rate
+
+    MarketParams memory marketParams;
+    Market memory market;
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(marketParams.id(), rate);
+
+    assertEq(fixedRateIrm.borrowRateView(marketParams, market), uint256(rate));
+  }
+
+  function test_borrowRate() public {
+    int256 rate = 0.05 ether / int256(365 days); // 5% annual interest rate
+
+    MarketParams memory marketParams;
+    Market memory market;
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(marketParams.id(), rate);
+
+    assertEq(fixedRateIrm.borrowRate(marketParams, market), uint256(rate));
+  }
+
+  function getImplementation(address _proxyAddress) public view returns (address) {
+    bytes32 implSlot = vm.load(_proxyAddress, IMPLEMENTATION_SLOT);
+    return address(uint160(uint256(implSlot)));
+  }
+}

--- a/test/interest-rate-model/FixedRateIrmTest.sol
+++ b/test/interest-rate-model/FixedRateIrmTest.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "forge-std/Test.sol";
+
+import "interest-rate-model/FixedRateIrm.sol";
+
+contract FixedRateIrmTest is Test {
+  using MarketParamsLib for MarketParams;
+
+  event SetBorrowRate(Id indexed id, int256 newBorrowRate);
+
+  FixedRateIrm public fixedRateIrm;
+
+  address admin = makeAddr("admin");
+  address manager = makeAddr("manager");
+
+  function setUp() external {
+    FixedRateIrm impl = new FixedRateIrm();
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, admin, manager)
+    );
+
+    fixedRateIrm = FixedRateIrm(address(proxy));
+  }
+
+  function testSetBorrowRate(Id id, int256 newBorrowRate) external {
+    newBorrowRate = bound(newBorrowRate, 1, fixedRateIrm.MAX_BORROW_RATE());
+
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(id, newBorrowRate);
+    assertEq(fixedRateIrm.borrowRateStored(id), int256(newBorrowRate));
+  }
+
+  function testSetBorrowRateEvent(Id id, int256 newBorrowRate) external {
+    newBorrowRate = bound(newBorrowRate, 1, fixedRateIrm.MAX_BORROW_RATE());
+
+    vm.expectEmit(true, true, true, true, address(fixedRateIrm));
+    emit SetBorrowRate(id, int256(newBorrowRate));
+    vm.startPrank(manager);
+    fixedRateIrm.setBorrowRate(id, newBorrowRate);
+  }
+
+  function testSetBorrowRateAlreadySet(Id id, int256 newBorrowRate1) external {
+    newBorrowRate1 = fixedRateIrm.MAX_BORROW_RATE() / 2;
+
+    vm.startPrank(manager);
+    fixedRateIrm.setBorrowRate(id, newBorrowRate1);
+    vm.expectRevert(bytes(RATE_SET));
+    fixedRateIrm.setBorrowRate(id, newBorrowRate1);
+  }
+
+  function testSetBorrowRateRateZero(Id id) external {
+    vm.expectRevert(bytes(RATE_INVALID));
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(id, 0);
+  }
+
+  function testSetBorrowRateTooHigh(Id id, int256 newBorrowRate) external {
+    newBorrowRate = bound(newBorrowRate, fixedRateIrm.MAX_BORROW_RATE() + 1, type(int256).max);
+    vm.expectRevert(bytes(RATE_TOO_HIGH));
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(id, newBorrowRate);
+  }
+
+  function testBorrowRate(MarketParams memory marketParams, Market memory market, int256 newBorrowRate) external {
+    newBorrowRate = bound(newBorrowRate, 1, fixedRateIrm.MAX_BORROW_RATE());
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(marketParams.id(), newBorrowRate);
+    assertEq(fixedRateIrm.borrowRate(marketParams, market), uint256(newBorrowRate));
+  }
+
+  function testBorrowRateRateNotSet(MarketParams memory marketParams, Market memory market) external {
+    vm.expectRevert(bytes(RATE_INVALID));
+    fixedRateIrm.borrowRate(marketParams, market);
+  }
+
+  function testBorrowRateView(MarketParams memory marketParams, Market memory market, int256 newBorrowRate) external {
+    newBorrowRate = bound(newBorrowRate, 1, fixedRateIrm.MAX_BORROW_RATE());
+    vm.prank(manager);
+    fixedRateIrm.setBorrowRate(marketParams.id(), newBorrowRate);
+    assertEq(fixedRateIrm.borrowRateView(marketParams, market), uint256(newBorrowRate));
+  }
+
+  function testBorrowRateViewRateNotSet(MarketParams memory marketParams, Market memory market) external {
+    vm.expectRevert(bytes(RATE_INVALID));
+    fixedRateIrm.borrowRateView(marketParams, market);
+  }
+}


### PR DESCRIPTION
Added `FixedRateIrm` to support Lending Alpha Zone.

To be compatible with current adaptive curve IRM, we use `int256` instead of `uint256` to store borrow rate