### PR TITLE
BNBProviders supports multi vaults

### DIFF
--- a/script/deploy_bnbProvider.sol
+++ b/script/deploy_bnbProvider.sol
@@ -21,7 +21,7 @@ contract BNBProviderDeploy is Script {
     vm.startBroadcast(deployerPrivateKey);
 
     // Deploy BNBProvider implementation
-    BNBProvider impl = new BNBProvider(moolah, asset);
+    BNBProvider impl = new BNBProvider(moolah, loopVault, asset);
     console.log("Loop WBNB Vault BNBProvider implementation: ", address(impl));
 
     // Deploy Loop WBNB Vault BNBProvider proxy

--- a/script/deploy_bnbProvider_impl.sol
+++ b/script/deploy_bnbProvider_impl.sol
@@ -8,9 +8,6 @@ import { BNBProvider } from "../src/provider/BNBProvider.sol";
 
 contract BNBProviderDeploy is Script {
   address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
-  address vault = 0x57134a64B7cD9F9eb72F8255A671F5Bf2fe3E2d0; // Lista WBNB Vault
-  address mevVault = 0xd5cfc0f894bA77e95E3325Aa53Eb3e6CBBb5A81E; // MEV WBNB Vault
-  address loopVault = vault; // Loop WBNB Vault
 
   address asset = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c; // WBNB
 
@@ -23,13 +20,6 @@ contract BNBProviderDeploy is Script {
     // Deploy BNBProvider implementation
     BNBProvider impl = new BNBProvider(moolah, asset);
     console.log("Loop WBNB Vault BNBProvider implementation: ", address(impl));
-
-    // Deploy Loop WBNB Vault BNBProvider proxy
-    ERC1967Proxy proxy = new ERC1967Proxy(
-      address(impl),
-      abi.encodeWithSelector(impl.initialize.selector, deployer, deployer)
-    );
-    console.log("Loop WBNB Vault BNBProvider proxy: ", address(proxy));
 
     vm.stopBroadcast();
   }

--- a/script/deploy_bnbProvider_impl.sol
+++ b/script/deploy_bnbProvider_impl.sol
@@ -8,7 +8,7 @@ import { BNBProvider } from "../src/provider/BNBProvider.sol";
 
 contract BNBProviderDeploy is Script {
   address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
-
+  address vault = 0x57134a64B7cD9F9eb72F8255A671F5Bf2fe3E2d0; // Lista WBNB Vault
   address asset = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c; // WBNB
 
   function run() public {
@@ -18,7 +18,7 @@ contract BNBProviderDeploy is Script {
     vm.startBroadcast(deployerPrivateKey);
 
     // Deploy BNBProvider implementation
-    BNBProvider impl = new BNBProvider(moolah, asset);
+    BNBProvider impl = new BNBProvider(moolah, vault, asset);
     console.log("Loop WBNB Vault BNBProvider implementation: ", address(impl));
 
     vm.stopBroadcast();

--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -351,9 +351,9 @@ contract MoolahVault is
   }
 
   /// @inheritdoc IMoolahVaultBase
-  function initProvider(address _provider) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function setProvider(address _provider) external onlyRole(DEFAULT_ADMIN_ROLE) {
     require(_provider != address(0), ErrorsLib.ZeroAddress());
-    require(provider == address(0), ErrorsLib.AlreadySet());
+    require(provider != _provider, ErrorsLib.AlreadySet());
     require(IProvider(_provider).TOKEN() == asset(), ErrorsLib.TokenMismatch());
     provider = _provider;
 

--- a/src/moolah-vault/interfaces/IMoolahVault.sol
+++ b/src/moolah-vault/interfaces/IMoolahVault.sol
@@ -115,7 +115,7 @@ interface IMoolahVaultBase {
   function setBotRole(address _address) external;
   function revokeBotRole(address _address) external;
   /// @notice Sets the address of the provider.
-  function initProvider(address _provider) external;
+  function setProvider(address _provider) external;
 
   /// @notice Add account to whitelist
   function addWhiteList(address account) external;

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -75,31 +75,14 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   /// @param receiver The address to receive the shares.
   /// @return shares The number of shares received.
   function deposit(address receiver) external payable returns (uint256 shares) {
-    uint256 assets = msg.value;
-    require(assets > 0, ErrorsLib.ZERO_ASSETS);
-
-    IWBNB(TOKEN).deposit{ value: assets }();
-    require(IWBNB(TOKEN).approve(address(MOOLAH_VAULT), assets));
-
-    shares = MOOLAH_VAULT.deposit(assets, receiver);
+    return deposit(address(MOOLAH_VAULT), receiver);
   }
 
   /// @dev Deposit BNB and receive shares by specifying the amount of shares.
   /// @param shares The amount of shares to mint.
   /// @param receiver The address to receive the shares.
   function mint(uint256 shares, address receiver) external payable returns (uint256 assets) {
-    require(shares > 0, ErrorsLib.ZERO_ASSETS);
-    uint256 previewAssets = MOOLAH_VAULT.previewMint(shares); // ceiling rounding
-    require(msg.value >= previewAssets, "invalid BNB amount");
-
-    IWBNB(TOKEN).deposit{ value: previewAssets }();
-    require(IWBNB(TOKEN).approve(address(MOOLAH_VAULT), previewAssets));
-    assets = MOOLAH_VAULT.mint(shares, receiver);
-
-    if (msg.value > assets) {
-      (bool success, ) = msg.sender.call{ value: msg.value - assets }("");
-      require(success, "transfer failed");
-    }
+    return mint(address(MOOLAH_VAULT), shares, receiver);
   }
 
   /// @dev Withdraw shares from owner and send BNB to receiver by specifying the amount of assets.
@@ -107,18 +90,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   /// @param receiver The address to receive the assets.
   /// @param owner The address of the owner of the shares.
   function withdraw(uint256 assets, address payable receiver, address owner) external returns (uint256 shares) {
-    require(assets > 0, ErrorsLib.ZERO_ASSETS);
-    require(receiver != address(0), ErrorsLib.ZERO_ADDRESS);
-
-    // 1. withdraw WBNB from moolah vault
-    shares = MOOLAH_VAULT.withdrawFor(assets, owner, msg.sender);
-
-    // 2. unwrap WBNB
-    IWBNB(TOKEN).withdraw(assets);
-
-    // 3. transfer WBNB to receiver
-    (bool success, ) = receiver.call{ value: assets }("");
-    require(success, "transfer failed");
+    return withdraw(address(MOOLAH_VAULT), assets, receiver, owner);
   }
 
   /// @dev Withdraw shares from owner and send BNB to receiver by specifying the amount of shares.
@@ -126,24 +98,13 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   /// @param receiver The address to receive the assets.
   /// @param owner The address of the owner of the shares.
   function redeem(uint256 shares, address payable receiver, address owner) external returns (uint256 assets) {
-    require(shares > 0, ErrorsLib.ZERO_ASSETS);
-    require(receiver != address(0), ErrorsLib.ZERO_ADDRESS);
-
-    // 1. redeem WBNB from moolah vault
-    assets = MOOLAH_VAULT.redeemFor(shares, owner, msg.sender);
-
-    // 2. unwrap WBNB
-    IWBNB(TOKEN).withdraw(assets);
-
-    // 3. transfer BNB to receiver
-    (bool success, ) = receiver.call{ value: assets }("");
-    require(success, "transfer failed");
+    return redeem(address(MOOLAH_VAULT), shares, receiver, owner);
   }
 
   /// @dev Deposit BNB and receive shares.
   /// @param receiver The address to receive the shares.
   /// @return shares The number of shares received.
-  function deposit(address vault, address receiver) external payable returns (uint256 shares) {
+  function deposit(address vault, address receiver) public payable returns (uint256 shares) {
     require(vaults[vault], "vault not added");
     uint256 assets = msg.value;
     require(assets > 0, ErrorsLib.ZERO_ASSETS);
@@ -158,7 +119,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   /// @param vault The address of the Moolah vault to deposit into.
   /// @param shares The amount of shares to mint.
   /// @param receiver The address to receive the shares.
-  function mint(address vault, uint256 shares, address receiver) external payable returns (uint256 assets) {
+  function mint(address vault, uint256 shares, address receiver) public payable returns (uint256 assets) {
     require(vaults[vault], "vault not added");
     require(shares > 0, ErrorsLib.ZERO_ASSETS);
     uint256 previewAssets = IMoolahVault(vault).previewMint(shares); // ceiling rounding
@@ -184,7 +145,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
     uint256 assets,
     address payable receiver,
     address owner
-  ) external returns (uint256 shares) {
+  ) public returns (uint256 shares) {
     require(vaults[vault], "vault not added");
     require(assets > 0, ErrorsLib.ZERO_ASSETS);
     require(receiver != address(0), ErrorsLib.ZERO_ADDRESS);
@@ -210,7 +171,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
     uint256 shares,
     address payable receiver,
     address owner
-  ) external returns (uint256 assets) {
+  ) public returns (uint256 assets) {
     require(vaults[vault], "vault not added");
     require(shares > 0, ErrorsLib.ZERO_ASSETS);
     require(receiver != address(0), ErrorsLib.ZERO_ADDRESS);
@@ -350,7 +311,8 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   function liquidate(Id id, address borrower) external onlyMoolah {}
 
   /// @dev Add a Moolah vault to the provider.
-  function addVault(address vault) external onlyRole(MANAGER) {
+  function addVault(address vault) external {
+    require(hasRole(MANAGER, msg.sender) || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), ErrorsLib.UNAUTHORIZED);
     require(vault != address(0), ErrorsLib.ZERO_ADDRESS);
     require(!vaults[vault], "vault already added");
     require(address(IMoolahVault(vault).MOOLAH()) == address(MOOLAH), "invalid moolah vault");
@@ -359,7 +321,8 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   }
 
   /// @dev Remove a Moolah vault from the provider.
-  function removeVault(address vault) external onlyRole(MANAGER) {
+  function removeVault(address vault) external {
+    require(hasRole(MANAGER, msg.sender) || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), ErrorsLib.UNAUTHORIZED);
     require(vaults[vault], "vault not added");
     delete vaults[vault];
   }

--- a/src/provider/BNBProvider.sol
+++ b/src/provider/BNBProvider.sol
@@ -102,6 +102,7 @@ contract BNBProvider is UUPSUpgradeable, AccessControlEnumerableUpgradeable, IPr
   }
 
   /// @dev Deposit BNB and receive shares.
+  /// @param vault The address of the Moolah vault to deposit into.
   /// @param receiver The address to receive the shares.
   /// @return shares The number of shares received.
   function deposit(address vault, address receiver) public payable returns (uint256 shares) {

--- a/test/provider/BNBProviderMainnet.t.sol
+++ b/test/provider/BNBProviderMainnet.t.sol
@@ -69,6 +69,7 @@ contract BNBProviderTest is Test {
     UUPSUpgradeable proxy1 = UUPSUpgradeable(address(bnbProvider));
     proxy1.upgradeToAndCall(newImlp, bytes(""));
     assertEq(getImplementation(address(bnbProvider)), newImlp);
+    bnbProvider.addVault(moolahVaultProxy);
     vm.stopPrank();
 
     MarketParams memory param1 = MarketParams({
@@ -399,9 +400,6 @@ contract BNBProviderTest is Test {
 
   function test_removeVault() public {
     vm.startPrank(manager);
-    bnbProvider.addVault(moolahVaultProxy);
-    assertEq(bnbProvider.vaults(moolahVaultProxy), true, "add vault failed");
-
     bnbProvider.removeVault(moolahVaultProxy);
     vm.stopPrank();
 
@@ -410,6 +408,10 @@ contract BNBProviderTest is Test {
 
   function test_depositNotInVaults() public {
     deal(user, 100 ether);
+
+    vm.startPrank(manager);
+    bnbProvider.removeVault(moolahVaultProxy);
+    vm.stopPrank();
 
     vm.startPrank(user);
     vm.expectRevert(bytes("vault not added"));
@@ -422,9 +424,6 @@ contract BNBProviderTest is Test {
 
   function test_withdrawNotInVaults() public {
     test_deposit();
-    vm.startPrank(manager);
-    bnbProvider.addVault(moolahVaultProxy);
-    vm.stopPrank();
 
     bnbProvider.deposit{ value: 1 ether }(moolahVaultProxy, user);
 
@@ -445,10 +444,6 @@ contract BNBProviderTest is Test {
   function test_depositInVaults() public {
     deal(user, 100 ether);
 
-    vm.startPrank(manager);
-    bnbProvider.addVault(moolahVaultProxy);
-    vm.stopPrank();
-
     uint256 bnbBalanceBefore = user.balance;
     uint256 wbnbBalanceBefore = IERC20(WBNB).balanceOf(moolahProxy);
     vm.startPrank(user);
@@ -465,10 +460,6 @@ contract BNBProviderTest is Test {
 
   function test_mintInVaults() public {
     deal(user, 100 ether);
-
-    vm.startPrank(manager);
-    bnbProvider.addVault(moolahVaultProxy);
-    vm.stopPrank();
 
     uint256 bnbBalanceBefore = user.balance;
     uint256 wbnbBalanceBefore = IERC20(WBNB).balanceOf(moolahProxy);


### PR DESCRIPTION
1. maintenance a vault map in BNBProvider, which indicates which vaults are supported. 
2. Add four methods with vault parameters, namely deposit, mint, withdraw, and redeem, to support vault as a parameter.