### PR TITLE
Feature/batch liquidator whitelist

### DIFF
--- a/src/moolah/Moolah.sol
+++ b/src/moolah/Moolah.sol
@@ -170,11 +170,43 @@ contract Moolah is
   }
 
   /// @inheritdoc IMoolahBase
+  function batchAddLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external onlyRole(MANAGER) {
+    require(ids.length == accounts.length, ErrorsLib.INCONSISTENT_INPUT);
+    // add accounts to liquidation whitelist for each id
+    for (uint256 i = 0; i < ids.length; ++i) {
+      Id id = ids[i];
+      address[] memory accountList = accounts[i];
+      for (uint256 j = 0; j < accountList.length; ++j) {
+        address account = accountList[j];
+        require(!liquidationWhitelist[id].contains(account), ErrorsLib.ALREADY_SET);
+        liquidationWhitelist[id].add(account);
+        emit EventsLib.AddLiquidationWhitelist(id, account);
+      }
+    }
+  }
+
+  /// @inheritdoc IMoolahBase
   function removeLiquidationWhitelist(Id id, address account) external onlyRole(MANAGER) {
     require(liquidationWhitelist[id].contains(account), ErrorsLib.NOT_SET);
     liquidationWhitelist[id].remove(account);
 
     emit EventsLib.RemoveLiquidationWhitelist(id, account);
+  }
+
+  /// @inheritdoc IMoolahBase
+  function batchRemoveLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external onlyRole(MANAGER) {
+    require(ids.length == accounts.length, ErrorsLib.INCONSISTENT_INPUT);
+    // remove accounts from liquidation whitelist for each id
+    for (uint256 i = 0; i < ids.length; ++i) {
+      Id id = ids[i];
+      address[] memory accountList = accounts[i];
+      for (uint256 j = 0; j < accountList.length; ++j) {
+        address account = accountList[j];
+        require(liquidationWhitelist[id].contains(account), ErrorsLib.NOT_SET);
+        liquidationWhitelist[id].remove(account);
+        emit EventsLib.RemoveLiquidationWhitelist(id, account);
+      }
+    }
   }
 
   /// @inheritdoc IMoolahBase

--- a/src/moolah/Moolah.sol
+++ b/src/moolah/Moolah.sol
@@ -184,7 +184,7 @@ contract Moolah is
     bool isAddition
   ) external onlyRole(MANAGER) {
     require(ids.length == accounts.length, ErrorsLib.INCONSISTENT_INPUT);
-    // remove accounts from liquidation whitelist for each id
+    // add/remove accounts from liquidation whitelist for each market
     for (uint256 i = 0; i < ids.length; ++i) {
       Id id = ids[i];
       address[] memory accountList = accounts[i];

--- a/src/moolah/Moolah.sol
+++ b/src/moolah/Moolah.sol
@@ -162,7 +162,7 @@ contract Moolah is
   }
 
   /// @inheritdoc IMoolahBase
-  function addLiquidationWhitelist(Id id, address account) external onlyRole(MANAGER) {
+  function addLiquidationWhitelist(Id id, address account) public onlyRole(MANAGER) {
     require(!liquidationWhitelist[id].contains(account), ErrorsLib.ALREADY_SET);
     liquidationWhitelist[id].add(account);
 
@@ -170,23 +170,7 @@ contract Moolah is
   }
 
   /// @inheritdoc IMoolahBase
-  function batchAddLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external onlyRole(MANAGER) {
-    require(ids.length == accounts.length, ErrorsLib.INCONSISTENT_INPUT);
-    // add accounts to liquidation whitelist for each id
-    for (uint256 i = 0; i < ids.length; ++i) {
-      Id id = ids[i];
-      address[] memory accountList = accounts[i];
-      for (uint256 j = 0; j < accountList.length; ++j) {
-        address account = accountList[j];
-        require(!liquidationWhitelist[id].contains(account), ErrorsLib.ALREADY_SET);
-        liquidationWhitelist[id].add(account);
-        emit EventsLib.AddLiquidationWhitelist(id, account);
-      }
-    }
-  }
-
-  /// @inheritdoc IMoolahBase
-  function removeLiquidationWhitelist(Id id, address account) external onlyRole(MANAGER) {
+  function removeLiquidationWhitelist(Id id, address account) public onlyRole(MANAGER) {
     require(liquidationWhitelist[id].contains(account), ErrorsLib.NOT_SET);
     liquidationWhitelist[id].remove(account);
 
@@ -194,7 +178,11 @@ contract Moolah is
   }
 
   /// @inheritdoc IMoolahBase
-  function batchRemoveLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external onlyRole(MANAGER) {
+  function batchToggleLiquidationWhitelist(
+    Id[] memory ids,
+    address[][] memory accounts,
+    bool isAddition
+  ) external onlyRole(MANAGER) {
     require(ids.length == accounts.length, ErrorsLib.INCONSISTENT_INPUT);
     // remove accounts from liquidation whitelist for each id
     for (uint256 i = 0; i < ids.length; ++i) {
@@ -202,9 +190,13 @@ contract Moolah is
       address[] memory accountList = accounts[i];
       for (uint256 j = 0; j < accountList.length; ++j) {
         address account = accountList[j];
-        require(liquidationWhitelist[id].contains(account), ErrorsLib.NOT_SET);
-        liquidationWhitelist[id].remove(account);
-        emit EventsLib.RemoveLiquidationWhitelist(id, account);
+        // add to whitelist
+        if (isAddition) {
+          addLiquidationWhitelist(id, account);
+        } else {
+          // remove from whitelist
+          removeLiquidationWhitelist(id, account);
+        }
       }
     }
   }

--- a/src/moolah/interfaces/IMoolah.sol
+++ b/src/moolah/interfaces/IMoolah.sol
@@ -292,7 +292,7 @@ interface IMoolahBase {
   /// @notice Removes `account` from the liquidation whitelist of the market `id`.
   function removeLiquidationWhitelist(Id id, address account) external;
 
-  /// @notice Removes `account` from the liquidation whitelist of the market `id`.
+  /// @notice Add/removes `accounts` from the liquidation whitelist of markets `ids`.
   function batchToggleLiquidationWhitelist(Id[] memory ids, address[][] memory accounts, bool isAddition) external;
 
   /// @notice Returns the liquidation whitelist of the market `id`.

--- a/src/moolah/interfaces/IMoolah.sol
+++ b/src/moolah/interfaces/IMoolah.sol
@@ -292,11 +292,8 @@ interface IMoolahBase {
   /// @notice Removes `account` from the liquidation whitelist of the market `id`.
   function removeLiquidationWhitelist(Id id, address account) external;
 
-  /// @notice Batch add `accounts` to the liquidation whitelist of the markets `ids`.
-  function batchAddLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external;
-
   /// @notice Removes `account` from the liquidation whitelist of the market `id`.
-  function batchRemoveLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external;
+  function batchToggleLiquidationWhitelist(Id[] memory ids, address[][] memory accounts, bool isAddition) external;
 
   /// @notice Returns the liquidation whitelist of the market `id`.
   function getLiquidationWhitelist(Id id) external view returns (address[] memory);

--- a/src/moolah/interfaces/IMoolah.sol
+++ b/src/moolah/interfaces/IMoolah.sol
@@ -292,6 +292,12 @@ interface IMoolahBase {
   /// @notice Removes `account` from the liquidation whitelist of the market `id`.
   function removeLiquidationWhitelist(Id id, address account) external;
 
+  /// @notice Batch add `accounts` to the liquidation whitelist of the markets `ids`.
+  function batchAddLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external;
+
+  /// @notice Removes `account` from the liquidation whitelist of the market `id`.
+  function batchRemoveLiquidationWhitelist(Id[] memory ids, address[][] memory accounts) external;
+
   /// @notice Returns the liquidation whitelist of the market `id`.
   function getLiquidationWhitelist(Id id) external view returns (address[] memory);
 

--- a/test/liquidator/PublicLiquidator.t.sol
+++ b/test/liquidator/PublicLiquidator.t.sol
@@ -140,4 +140,44 @@ contract PublicLiquidatorTest is BaseTest {
     publicLiquidator.liquidate(Id.unwrap(marketParams.id()), address(this), collateralAmount, 0);
     vm.stopPrank();
   }
+
+  /// @dev revert when trying to liquidate a market that is not whitelisted
+  function testNonWhitelistLiquidate_batch() public {
+    uint256 loanAmount = 1e19;
+    uint256 collateralAmount = 1e19;
+
+    oracle.setPrice(address(collateralToken), ORACLE_PRICE_SCALE);
+    oracle.setPrice(address(loanToken), ORACLE_PRICE_SCALE);
+
+    loanToken.setBalance(address(this), loanAmount);
+    loanToken.setBalance(address(publicLiquidator), loanAmount);
+    collateralToken.setBalance(address(this), collateralAmount);
+    moolah.supply(marketParams, loanAmount, 0, address(this), "");
+
+    moolah.supplyCollateral(marketParams, collateralAmount, address(this), "");
+
+    moolah.borrow(marketParams, 8e18, 0, address(this), address(this));
+
+    oracle.setPrice(address(collateralToken), ORACLE_PRICE_SCALE / 10);
+
+    Id[] memory ids = new Id[](1);
+    ids[0] = marketParams.id();
+
+    address[][] memory accounts = new address[][](1);
+    accounts[0] = new address[](1);
+    accounts[0][0] = makeAddr("WHITELISTOR");
+
+    // make this market only whitelisted address can liquidate
+    vm.prank(OWNER);
+    moolah.batchAddLiquidationWhitelist(ids, accounts);
+
+    vm.startPrank(USER);
+    // give user some loan token to buy collateral token
+    loanToken.setBalance(USER, 8e18 * 1.1);
+    // approve publicLiquidator to spend USER's loan token
+    loanToken.approve(address(publicLiquidator), 8e18 * 1.1);
+    vm.expectRevert(bytes4(keccak256("NotWhitelisted()")));
+    publicLiquidator.liquidate(Id.unwrap(marketParams.id()), address(this), collateralAmount, 0);
+    vm.stopPrank();
+  }
 }

--- a/test/liquidator/PublicLiquidator.t.sol
+++ b/test/liquidator/PublicLiquidator.t.sol
@@ -169,7 +169,7 @@ contract PublicLiquidatorTest is BaseTest {
 
     // make this market only whitelisted address can liquidate
     vm.prank(OWNER);
-    moolah.batchAddLiquidationWhitelist(ids, accounts);
+    moolah.batchToggleLiquidationWhitelist(ids, accounts, true);
 
     vm.startPrank(USER);
     // give user some loan token to buy collateral token


### PR DESCRIPTION
1. Added new method for manager to batch add/remove liquidators from varies of markets
- ` function batchToggleLiquidationWhitelist(
    Id[] memory ids,
    address[][] memory accounts,
    bool isAddition
  ) external`

`isAddition` indicates whether the it's add or remove accounts from the whitelist