### PR TITLE
fea: add BatchUtils and add setDefaultMarkeFee for Moolah

### DIFF
--- a/script/deploy_BatchManagementUtils.sol
+++ b/script/deploy_BatchManagementUtils.sol
@@ -1,0 +1,33 @@
+pragma solidity 0.8.28;
+
+import "forge-std/Script.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { BatchManagementUtils } from "src/utils/BatchManagementUtils.sol";
+
+contract BatchManagementUtilsDeploy is Script {
+  function run() public {
+    address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+    address admin = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+    address manager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy Moolah implementation
+    BatchManagementUtils impl = new BatchManagementUtils(moolah);
+    console.log("implementation: ", address(impl));
+
+    // Deploy Moolah proxy
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, admin, manager)
+    );
+    console.log("proxy: ", address(proxy));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/moolah/Moolah.sol
+++ b/src/moolah/Moolah.sol
@@ -76,6 +76,9 @@ contract Moolah is
   /// if whitelist is set, only whitelisted addresses can supply, supply collateral, borrow
   mapping(Id => EnumerableSet.AddressSet) private whiteList;
 
+  /// default market fee rate
+  uint256 public defaultMarketFee;
+
   bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
   bytes32 public constant PAUSER = keccak256("PAUSER"); // pauser role
   bytes32 public constant OPERATOR = keccak256("OPERATOR"); // operator role
@@ -142,6 +145,16 @@ contract Moolah is
     market[id].fee = uint128(newFee);
 
     emit EventsLib.SetFee(id, newFee);
+  }
+
+  /// @inheritdoc IMoolahBase
+  function setDefaultMarketFee(uint256 newFee) external onlyRole(MANAGER) {
+    require(newFee != defaultMarketFee, ErrorsLib.ALREADY_SET);
+    require(newFee <= MAX_FEE, ErrorsLib.MAX_FEE_EXCEEDED);
+
+    defaultMarketFee = newFee;
+
+    emit EventsLib.SetDefaultMarketFee(newFee);
   }
 
   /// @inheritdoc IMoolahBase
@@ -253,7 +266,7 @@ contract Moolah is
 
     // Safe "unchecked" cast.
     market[id].lastUpdate = uint128(block.timestamp);
-    market[id].fee = DEFAULT_FEE;
+    market[id].fee = uint128(defaultMarketFee);
     idToMarketParams[id] = marketParams;
     IOracle(marketParams.oracle).peek(marketParams.loanToken);
     IOracle(marketParams.oracle).peek(marketParams.collateralToken);

--- a/src/moolah/interfaces/IMoolah.sol
+++ b/src/moolah/interfaces/IMoolah.sol
@@ -326,6 +326,12 @@ interface IMoolahBase {
 
   /// @notice Remove `account` from the whitelist of the market `id`.
   function removeWhiteList(Id id, address account) external;
+
+  /// @notice Returns the default market fee.
+  function defaultMarketFee() external view returns (uint256);
+
+  /// @notice Set the default market fee for new markets.
+  function setDefaultMarketFee(uint256 newFee) external;
 }
 
 /// @dev This interface is inherited by Moolah so that function signatures are checked by the compiler.

--- a/src/moolah/libraries/EventsLib.sol
+++ b/src/moolah/libraries/EventsLib.sol
@@ -177,4 +177,8 @@ library EventsLib {
   /// @param token The token that was removed.
   /// @param provider The provider that was removed.
   event RemoveProvider(Id id, address token, address provider);
+
+  /// @notice Emitted when setting the default market fee.
+  /// @param fee The new default market fee.
+  event SetDefaultMarketFee(uint256 fee);
 }

--- a/src/utils/BatchManagementUtils.sol
+++ b/src/utils/BatchManagementUtils.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import { IMoolah, Id, MarketParams } from "moolah/interfaces/IMoolah.sol";
+
+contract BatchManagementUtils is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
+  address public immutable MOOLAH;
+
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+
+  event SetWhitelist(address indexed to, bool status);
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor(address moolah) {
+    require(moolah != address(0), "moolah is zero address");
+    _disableInitializers();
+
+    MOOLAH = moolah;
+  }
+
+  /** @dev Initializer function to set up roles and initial state.
+   * @param admin The address to be granted the DEFAULT_ADMIN_ROLE.
+   * @param manager The address to be granted the MANAGER role.
+   *
+   * Requirements:
+   * - `admin` must not be the zero address.
+   * - `manager` must not be the zero address.
+   */
+  function initialize(address admin, address manager) public initializer {
+    require(admin != address(0), "admin is zero address");
+    require(manager != address(0), "manager is zero address");
+    __AccessControlEnumerable_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+  }
+
+  /**
+   * @dev Set market fee for multiple markets in a single transaction.
+   * @param ids The array of market IDs.
+   * @param fees The array of fees corresponding to each market ID.
+   *
+   * Requirements:
+   * - Caller must have the MANAGER role for the specified `moolah` contract.
+   * - `ids` and `fees` arrays must have the same length and be non-empty.
+   * - Each market ID in `ids` must correspond to an existing market in the `moolah` contract.
+   */
+  function batchSetMarketFee(Id[] calldata ids, uint256[] calldata fees) external {
+    require(IAccessControl(MOOLAH).hasRole(MANAGER, msg.sender), "Not manager of moolah");
+    require(ids.length == fees.length && ids.length > 0, "Array length mismatch");
+
+    for (uint256 i = 0; i < ids.length; i++) {
+      MarketParams memory marketParams = IMoolah(MOOLAH).idToMarketParams(ids[i]);
+      require(marketParams.loanToken != address(0), "Market not created");
+      IMoolah(MOOLAH).setFee(marketParams, fees[i]);
+    }
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/test/audit/MoolahAuditTest.sol
+++ b/test/audit/MoolahAuditTest.sol
@@ -191,7 +191,7 @@ contract MoolahAuditTest is Test {
 
     Id marketId = testMarketParams.id();
     uint128 fee = moolah.market(marketId).fee;
-    assertTrue(fee != 0, "fee should not be 0");
+    assertTrue(fee == 0, "fee should be 0");
   }
 
   function test_supplyLessThanMinLoanValue() public {

--- a/test/moolah/BaseTest.sol
+++ b/test/moolah/BaseTest.sol
@@ -95,6 +95,7 @@ contract BaseTest is Test {
     moolah.enableIrm(address(irm));
     moolah.enableLltv(0);
     moolah.setFeeRecipient(FEE_RECIPIENT);
+    moolah.setDefaultMarketFee(0.05 ether);
     vm.stopPrank();
 
     loanToken.approve(address(moolah), type(uint256).max);

--- a/test/moolah/integration/MarketFeeTest.sol
+++ b/test/moolah/integration/MarketFeeTest.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "../BaseTest.sol";
+import { ErrorsLib } from "moolah/libraries/ErrorsLib.sol";
+import { BatchManagementUtils } from "src/utils/BatchManagementUtils.sol";
+import { Id } from "moolah/interfaces/IMoolah.sol";
+
+contract MarketFeeTest is BaseTest {
+  using MathLib for uint256;
+  using SharesMathLib for uint256;
+  using MarketParamsLib for MarketParams;
+
+  BatchManagementUtils batchUtils;
+
+  function setUp() public override {
+    super.setUp();
+    batchUtils = newBatchUtils();
+
+    vm.startPrank(OWNER);
+    moolah.enableLltv(0.1 ether);
+    moolah.grantRole(MANAGER, address(batchUtils));
+    vm.stopPrank();
+  }
+
+  function test_setDefaultMarketFee() public {
+    vm.startPrank(OWNER);
+    moolah.setDefaultMarketFee(0.1 ether);
+    vm.stopPrank();
+
+    assertEq(moolah.defaultMarketFee(), 0.1 ether, "defaultMarketFee error");
+
+    MarketParams memory marketParams = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(collateralToken),
+      oracle: address(oracle),
+      irm: address(irm),
+      lltv: 0.1 ether
+    });
+    moolah.createMarket(marketParams);
+
+    Market memory market = moolah.market(marketParams.id());
+    assertEq(market.fee, 0.1 ether, "market fee error");
+  }
+
+  function test_setDefaultMarketFeeUpperLimit() public {
+    vm.startPrank(OWNER);
+    vm.expectRevert(bytes(ErrorsLib.MAX_FEE_EXCEEDED));
+    moolah.setDefaultMarketFee(0.26 ether);
+    vm.stopPrank();
+  }
+
+  function test_batchSetMarketFee() public {
+    Id id1 = marketParams.id();
+
+    MarketParams memory marketParams2 = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(collateralToken),
+      oracle: address(oracle),
+      irm: address(irm),
+      lltv: 0.1 ether
+    });
+
+    Id id2 = marketParams2.id();
+
+    Id[] memory ids = new Id[](2);
+    ids[0] = id1;
+    ids[1] = id2;
+
+    uint256[] memory fees = new uint256[](2);
+    fees[0] = 0.1 ether;
+    fees[1] = 0.15 ether;
+
+    vm.expectRevert(bytes("Not manager of moolah"));
+    batchUtils.batchSetMarketFee(ids, fees);
+
+    vm.startPrank(OWNER);
+    vm.expectRevert(bytes("Market not created"));
+    batchUtils.batchSetMarketFee(ids, fees);
+    vm.stopPrank();
+
+    vm.startPrank(OWNER);
+    moolah.createMarket(marketParams2);
+    batchUtils.batchSetMarketFee(ids, fees);
+    vm.stopPrank();
+
+    Market memory market1 = moolah.market(id1);
+    Market memory market2 = moolah.market(id2);
+    assertEq(market1.fee, 0.1 ether, "market1 fee error");
+    assertEq(market2.fee, 0.15 ether, "market2 fee error");
+  }
+
+  function newBatchUtils() internal returns (BatchManagementUtils) {
+    BatchManagementUtils _batchUtils = new BatchManagementUtils(address(moolah));
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(_batchUtils),
+      abi.encodeWithSelector(_batchUtils.initialize.selector, OWNER, OWNER)
+    );
+    return BatchManagementUtils(address(proxy));
+  }
+}

--- a/test/revenue/LendingFeeRecipientTest.sol
+++ b/test/revenue/LendingFeeRecipientTest.sol
@@ -71,6 +71,7 @@ contract LendingFeeRecipientTest is Test {
     moolah.enableLltv(lltv);
     moolah.enableIrm(irm);
     moolah.setFeeRecipient(address(lendingFeeRecipient));
+    moolah.setDefaultMarketFee(0.05 ether);
 
     vault.grantRole(CURATOR_ROLE, OWNER);
     vault.grantRole(ALLOCATOR_ROLE, OWNER);


### PR DESCRIPTION
## 📄 Description
add BatchUtils and add setDefaultMarkeFee for Moolah


## 🧠 Rationale
moolah support to update default market fee when create new markets
manager can batch set market fee by BatchUtils


## 🧪 Example / Testing
forge test --match-contract MarketFeeTest -vvvv

## 🧬 Changes Summary
* add a new contract src/utils/BatchUtils.sol
* add a new method setDefaultMarkeFee for src/moolah/Moolah
