### PR TITLE
feature: add borrow rate floor to adaptive curve irm

### DIFF
--- a/src/interest-rate-model/InterestRateModel.sol
+++ b/src/interest-rate-model/InterestRateModel.sol
@@ -167,7 +167,6 @@ contract InterestRateModel is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
 
     // Adjust rate to make sure the rate >= floor
     uint256 floor = rateFloor[id];
-    require(floor <= _cap, "invalid floor");
     if (avgRate < floor) avgRate = floor;
 
     return (avgRate, endRateAtTarget);
@@ -199,6 +198,8 @@ contract InterestRateModel is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
   function updateRateCap(Id id, uint256 newRateCap) external onlyRole(BOT) {
     uint256 oldCap = rateCap[id];
     require(newRateCap >= minCap && newRateCap != oldCap, "invalid rate cap");
+    require(rateFloor[id] <= newRateCap, "invalid new cap vs floor");
+
     rateCap[id] = newRateCap;
 
     emit BorrowRateCapUpdate(id, oldCap, newRateCap);

--- a/src/interest-rate-model/interfaces/IInterestRateModel.sol
+++ b/src/interest-rate-model/interfaces/IInterestRateModel.sol
@@ -18,6 +18,9 @@ interface IInterestRateModel is IIrm {
   /// @notice Rate cap for the given market.
   function rateCap(Id id) external view returns (uint256);
 
+  /// @notice Minimum borrow rate for the given market.
+  function rateFloor(Id id) external view returns (uint256);
+
   /// @notice Minimum borrow rate cap for all markets.
   function minCap() external view returns (uint256);
 

--- a/test/interest-rate-model/InterestRateModelTest.sol
+++ b/test/interest-rate-model/InterestRateModelTest.sol
@@ -365,12 +365,19 @@ contract InterestRateModelTest is Test {
     assertEq(irm.rateCap(id), newCap);
   }
 
-  function testUpateMinCap(uint256 newMinCap) public {
+  function testUpdateMinCap(uint256 newMinCap) public {
     // minCap = uint256(0.05 ether) / 365 days; // 5%
     newMinCap = bound(newMinCap, 1, uint256(0.05 ether) / 365 days);
     vm.prank(makeAddr("manager"));
     irm.updateMinCap(newMinCap);
     assertEq(irm.minCap(), newMinCap);
+  }
+
+  function testUpdateRateFloor(Id id, uint256 newFloor) public {
+    newFloor = bound(newFloor, 1, uint256(ConstantsLib.INITIAL_RATE_AT_TARGET));
+    vm.prank(makeAddr("bot"));
+    irm.updateRateFloor(id, newFloor);
+    assertEq(irm.rateFloor(id), newFloor);
   }
 
   /* HANDLERS */


### PR DESCRIPTION
## 📄 Description
Support adjust minimum borrow rate for given market


## 🧪 Example / Testing
```
forge test --mc InterestRateModelTest
```


## 🧬 Changes Summary
Notable changes:
* Added mapping `rateFloor`
