### PR TITLE
fix: remove redundant slippage checks

### DIFF
--- a/test/provider/SmartProvider.t.sol
+++ b/test/provider/SmartProvider.t.sol
@@ -231,7 +231,7 @@ contract SmartProviderTest is Test {
       supplyAmount
     );
 
-    vm.expectRevert("slippage too high");
+    vm.expectRevert("Slippage screwed you");
     smartProvider.supplyCollateral{ value: amounts[1] }(
       marketParams,
       user2,


### PR DESCRIPTION
## 📄 Description
Remove redundant estimate checks in SmartProvider codebase.

