### PR TITLE
fix: audit fixes for StableSwapFactory

### DIFF
--- a/script/deploy_stableSwapPool.sol
+++ b/script/deploy_stableSwapPool.sol
@@ -26,7 +26,8 @@ contract StableSwapFactoryDeploy is Script {
     //    address factory = deployFactory(deployer);
     //    (address lpImpl, address poolImpl) = deployImpls();
 
-    factory.setImpls(lpImpl, poolImpl);
+    factory.setLpImpl(lpImpl);
+    factory.setSwapImpl(poolImpl);
 
     console.log("Set impls in Factory");
 

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -183,18 +183,20 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
     addPairInfoInternal(_swapContract, swap.coins(0), swap.coins(1), swap.token());
   }
 
-  function setImpls(address _newLpImpl, address _newSwapImpl) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    require(_newLpImpl != address(0) && _newSwapImpl != address(0), "Zero address");
+  function setLpImpl(address _newLpImpl) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_newLpImpl != address(0), "Zero address");
+    require(_newLpImpl != lpImpl, "Same implementation");
 
-    if (_newLpImpl != lpImpl) {
-      lpImpl = _newLpImpl;
-      emit SetLpImplementation(_newLpImpl);
-    }
+    lpImpl = _newLpImpl;
+    emit SetLpImplementation(_newLpImpl);
+  }
 
-    if (_newSwapImpl != swapImpl) {
-      swapImpl = _newSwapImpl;
-      emit SetSwapImplementation(_newSwapImpl);
-    }
+  function setSwapImpl(address _newSwapImpl) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_newSwapImpl != address(0), "Zero address");
+    require(_newSwapImpl != swapImpl, "Same implementation");
+
+    swapImpl = _newSwapImpl;
+    emit SetSwapImplementation(_newSwapImpl);
   }
 
   function getPairInfo(address _tokenA, address _tokenB) external view returns (StableSwapPairInfo[] memory) {

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -121,8 +121,8 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
 
   /**
    * @notice createSwapPair
-   * @param _tokenA: Addresses of ERC20 conracts .
-   * @param _tokenB: Addresses of ERC20 conracts .
+   * @param _tokenA: Addresses of ERC20 contracts
+   * @param _tokenB: Addresses of ERC20 contracts
    * @param _name: name of LP token
    * @param _symbol: symbol of LP token
    * @param _A: Amplification coefficient multiplied by n * (n - 1)

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -150,6 +150,7 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
   ) external onlyRole(DEPLOYER) returns (address lp, address swapContract) {
     require(swapImpl != address(0) && lpImpl != address(0), "Implementation not set");
     require(_tokenA != address(0) && _tokenB != address(0) && _tokenA != _tokenB, "Illegal token");
+    require(_admin != address(this), "New admin cannot be factory");
     (address t0, address t1) = sortTokens(_tokenA, _tokenB);
 
     // 1. create LP token; tranfer admin role after set minter

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -16,7 +16,7 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
   /// @notice check swap contract before deploy
   address public swapImpl;
 
-  mapping(address => mapping(address => StableSwapPairInfo)) public stableSwapPairInfo;
+  mapping(address => mapping(address => StableSwapPairInfo[])) public stableSwapPairInfo;
   mapping(uint256 => address) public swapPairContract;
   uint256 public pairLength;
 
@@ -166,11 +166,9 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
   }
 
   function addPairInfoInternal(address _swapContract, address _t0, address _t1, address _lp) internal {
-    StableSwapPairInfo storage info = stableSwapPairInfo[_t0][_t1];
-    info.swapContract = _swapContract;
-    info.token0 = _t0;
-    info.token1 = _t1;
-    info.LPContract = _lp;
+    StableSwapPairInfo[] storage info = stableSwapPairInfo[_t0][_t1];
+    info.push(StableSwapPairInfo({ swapContract: _swapContract, token0: _t0, token1: _t1, LPContract: _lp }));
+
     swapPairContract[pairLength] = _swapContract;
     pairLength += 1;
 
@@ -198,13 +196,10 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
     }
   }
 
-  function getPairInfo(address _tokenA, address _tokenB) external view returns (StableSwapPairInfo memory info) {
+  function getPairInfo(address _tokenA, address _tokenB) external view returns (StableSwapPairInfo[] memory) {
     (address t0, address t1) = sortTokens(_tokenA, _tokenB);
-    StableSwapPairInfo memory pairInfo = stableSwapPairInfo[t0][t1];
-    info.swapContract = pairInfo.swapContract;
-    info.token0 = pairInfo.token0;
-    info.token1 = pairInfo.token1;
-    info.LPContract = pairInfo.LPContract;
+    StableSwapPairInfo[] memory pairInfo = stableSwapPairInfo[t0][t1];
+    return pairInfo;
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -159,7 +159,7 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
     // 2. create stable swap pool
     swapContract = _createSwapPair(t0, t1, _A, _fee, _admin_fee, _admin, _manager, _pauser, lp, _oracle);
 
-    // 3. transfer minter to swap contract; TODO tranfer admin role of lp to _admin
+    // 3. transfer minter to swap contract
     IStableSwapLP(lp).setMinter(swapContract);
     IAccessControlEnumerable(lp).grantRole(DEFAULT_ADMIN_ROLE, _admin);
     IAccessControlEnumerable(lp).revokeRole(DEFAULT_ADMIN_ROLE, address(this));

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -55,8 +55,8 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
   }
   /**
    * @dev createSwapLP
-   * @param _tokenA: Addresses of ERC20 conracts
-   * @param _tokenB: Addresses of ERC20 conracts
+   * @param _tokenA: Addresses of ERC20 contracts
+   * @param _tokenB: Addresses of ERC20 contracts
    * @param _name: name of LP token
    * @param _symbol: symbol of LP token
    * @return lpToken: Address of LP tokena
@@ -66,7 +66,7 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
     address _tokenB,
     string memory _name,
     string memory _symbol
-  ) internal onlyRole(DEPLOYER) returns (address) {
+  ) internal returns (address) {
     require(lpImpl != address(0), "LP implementation not set");
 
     // create LP token

--- a/src/dex/StableSwapFactory.sol
+++ b/src/dex/StableSwapFactory.sol
@@ -180,7 +180,11 @@ contract StableSwapFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeabl
     IStableSwap swap = IStableSwap(_swapContract);
     uint256 n_coins = swap.N_COINS();
     require(n_coins == 2, "Only support 2 coins pool");
-    addPairInfoInternal(_swapContract, swap.coins(0), swap.coins(1), swap.token());
+    address coin0 = swap.coins(0);
+    address coin1 = swap.coins(1);
+    (address t0, address t1) = sortTokens(coin0, coin1);
+    require(coin0 == t0 && coin1 == t1, "Unsorted coins");
+    addPairInfoInternal(_swapContract, coin0, coin1, swap.token());
   }
 
   function setLpImpl(address _newLpImpl) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/test/dex/StableSwapFactory.t.sol
+++ b/test/dex/StableSwapFactory.t.sol
@@ -58,6 +58,20 @@ contract StableSwapFactoryTest is Test {
 
     vm.startPrank(deployer1);
     // create 1st pool
+    vm.expectRevert("New admin cannot be factory");
+    factory.createSwapPair(
+      address(token0),
+      token1,
+      "LPToken",
+      "LPT",
+      30,
+      1000000,
+      500000,
+      address(factory),
+      admin,
+      admin,
+      oracle
+    );
     factory.createSwapPair(address(token0), token1, "LPToken", "LPT", 30, 1000000, 500000, admin, admin, admin, oracle);
 
     (address t0, address t1) = factory.sortTokens(address(token0), token1);

--- a/test/dex/StableSwapFactory.t.sol
+++ b/test/dex/StableSwapFactory.t.sol
@@ -53,7 +53,8 @@ contract StableSwapFactoryTest is Test {
     vm.startPrank(admin);
     address lpImpl = address(new StableSwapLP());
     address swapImpl = address(new StableSwapPool(address(factory)));
-    factory.setImpls(lpImpl, swapImpl);
+    factory.setLpImpl(lpImpl);
+    factory.setSwapImpl(swapImpl);
     vm.stopPrank();
 
     vm.startPrank(deployer1);

--- a/test/dex/StableSwapFactory.t.sol
+++ b/test/dex/StableSwapFactory.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { StableSwapPool } from "../../src/dex/StableSwapPool.sol";
+import { StableSwapLP } from "../../src/dex/StableSwapLP.sol";
+import { StableSwapPoolInfo } from "../../src/dex/StableSwapPoolInfo.sol";
+import { ERC20Mock } from "../../src/moolah/mocks/ERC20Mock.sol";
+import { IOracle } from "../../src/moolah/interfaces/IOracle.sol";
+import "../../src/dex/interfaces/IStableSwap.sol";
+
+import { StableSwapFactory } from "../../src/dex/StableSwapFactory.sol";
+
+contract StableSwapFactoryTest is Test {
+  address constant BNB_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+  ERC20Mock token0;
+  address token1 = BNB_ADDRESS;
+  address oracle = makeAddr("oracle");
+  address admin = makeAddr("admin");
+  address deployer1 = makeAddr("deployer1");
+  address deployer2 = makeAddr("deployer2");
+
+  StableSwapFactory factory;
+
+  bytes32 constant DEPLOYER = keccak256("DEPLOYER");
+  bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+
+  function setUp() public {
+    address[] memory deployers = new address[](2);
+    deployers[0] = deployer1;
+    deployers[1] = deployer2;
+    StableSwapFactory factoryImpl = new StableSwapFactory();
+    ERC1967Proxy factoryProxy = new ERC1967Proxy(
+      address(factoryImpl),
+      abi.encodeWithSelector(factoryImpl.initialize.selector, admin, deployers)
+    );
+    factory = StableSwapFactory(address(factoryProxy));
+    token0 = new ERC20Mock();
+
+    assertTrue(factory.hasRole(DEFAULT_ADMIN_ROLE, admin));
+    assertTrue(factory.hasRole(DEPLOYER, deployer1));
+    assertTrue(factory.hasRole(DEPLOYER, deployer2));
+  }
+
+  function test_createSwapPair() public {
+    // mock oracle calls; token0 (slisBnb) price = $846.6; token1 (BNB) price = $830, rate = 1.02
+    vm.mockCall(oracle, abi.encodeWithSelector(IOracle.peek.selector, address(token0)), abi.encode(8466e7));
+    vm.mockCall(oracle, abi.encodeWithSelector(IOracle.peek.selector, token1), abi.encode(830e8));
+
+    vm.startPrank(admin);
+    address lpImpl = address(new StableSwapLP());
+    address swapImpl = address(new StableSwapPool(address(factory)));
+    factory.setImpls(lpImpl, swapImpl);
+    vm.stopPrank();
+
+    vm.startPrank(deployer1);
+    // create 1st pool
+    factory.createSwapPair(address(token0), token1, "LPToken", "LPT", 30, 1000000, 500000, admin, admin, admin, oracle);
+
+    (address t0, address t1) = factory.sortTokens(address(token0), token1);
+    (address swapContract, address tokenA, address tokenB, address lp) = factory.stableSwapPairInfo(t0, t1, 0);
+
+    assertEq(tokenA, t0);
+    assertEq(tokenB, t1);
+    assertEq(swapContract, factory.swapPairContract(0));
+    assertEq(factory.pairLength(), 1);
+
+    StableSwapFactory.StableSwapPairInfo[] memory pairs = factory.getPairInfo(tokenA, tokenB);
+    assertEq(pairs.length, 1);
+    assertEq(pairs[0].swapContract, swapContract);
+    assertEq(pairs[0].token0, tokenA);
+    assertEq(pairs[0].token1, tokenB);
+    assertEq(pairs[0].LPContract, lp);
+
+    // create 2nd pool with same tokens
+    factory.createSwapPair(
+      address(token0),
+      token1,
+      "LPToken2",
+      "LPT2",
+      30,
+      1000000,
+      500000,
+      admin,
+      admin,
+      admin,
+      oracle
+    );
+    (address swapContract2, address tokenA2, address tokenB2, address lp2) = factory.stableSwapPairInfo(t0, t1, 1);
+    assertEq(tokenA2, t0);
+    assertEq(tokenB2, t1);
+    assertEq(swapContract2, factory.swapPairContract(1));
+    assertEq(factory.pairLength(), 2);
+
+    StableSwapFactory.StableSwapPairInfo[] memory pairs2 = factory.getPairInfo(tokenA2, tokenB2);
+    assertEq(pairs2.length, 2);
+    assertEq(pairs2[1].swapContract, swapContract2);
+    assertEq(pairs2[1].token0, tokenA2);
+    assertEq(pairs2[1].token1, tokenB2);
+    assertEq(pairs2[1].LPContract, lp2);
+
+    vm.stopPrank();
+  }
+}

--- a/test/dex/StableSwapPoolBNB.t.sol
+++ b/test/dex/StableSwapPoolBNB.t.sol
@@ -81,8 +81,11 @@ contract StableSwapPoolBNBTest is Test {
 
     address lpImpl = address(new StableSwapLP());
     address poolImpl = address(new StableSwapPool(address(factory)));
-    vm.prank(admin);
-    factory.setImpls(lpImpl, poolImpl);
+    vm.startPrank(admin);
+    factory.setLpImpl(lpImpl);
+    factory.setSwapImpl(poolImpl);
+    vm.stopPrank();
+
     assertEq(factory.lpImpl(), lpImpl);
     assertEq(factory.swapImpl(), poolImpl);
 

--- a/test/dex/StableSwapPoolERC20.t.sol
+++ b/test/dex/StableSwapPoolERC20.t.sol
@@ -76,8 +76,10 @@ contract StableSwapPoolERC20Test is Test {
 
     address lpImpl = address(new StableSwapLP());
     address poolImpl = address(new StableSwapPool(address(factory)));
-    vm.prank(admin);
-    factory.setImpls(lpImpl, poolImpl);
+    vm.startPrank(admin);
+    factory.setLpImpl(lpImpl);
+    factory.setSwapImpl(poolImpl);
+    vm.stopPrank();
     assertEq(factory.lpImpl(), lpImpl);
     assertEq(factory.swapImpl(), poolImpl);
 

--- a/test/provider/SmartProvider.t.sol
+++ b/test/provider/SmartProvider.t.sol
@@ -146,8 +146,10 @@ contract SmartProviderTest is Test {
 
     address lpImpl = address(new StableSwapLP());
     address poolImpl = address(new StableSwapPool(address(factory)));
-    vm.prank(admin);
-    factory.setImpls(lpImpl, poolImpl);
+    vm.startPrank(admin);
+    factory.setLpImpl(lpImpl);
+    factory.setSwapImpl(poolImpl);
+    vm.stopPrank();
     assertEq(factory.lpImpl(), lpImpl);
     assertEq(factory.swapImpl(), poolImpl);
 


### PR DESCRIPTION
## 📄 Description
Update `stableSwapPairInfo` to store array of `StableSwapPairInfo` to support multiple pools for the same token pair.



## 🧪 Example / Testing
```
forge test --mc StableSwapFactoryTest -vv
```

