### PR TITLE
feat: add MANAGER and TRANSFERER roles to StableSwapLPCollateral

### DIFF
--- a/script/smartCollateral/deploy_lp_collateral_impl.sol
+++ b/script/smartCollateral/deploy_lp_collateral_impl.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+import { StableSwapLPCollateral } from "../../src/dex/StableSwapLPCollateral.sol";
+
+contract DeployStableSwapLPCollateralImpl is DeployBase {
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // moolah address is the same for all StableSwapLPCollateral proxies
+    address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+    StableSwapLPCollateral impl = new StableSwapLPCollateral(moolah);
+    console.log("StableSwapLPCollateral implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/dex/StableSwapLPCollateral.sol
+++ b/src/dex/StableSwapLPCollateral.sol
@@ -6,6 +6,9 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgrade
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 
 contract StableSwapLPCollateral is ERC20Upgradeable, UUPSUpgradeable, AccessControlEnumerableUpgradeable {
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant TRANSFERER = keccak256("TRANSFERER");
+
   address public immutable MOOLAH;
 
   /// @notice The address of the minter. Should be the smart provider contract.
@@ -17,13 +20,13 @@ contract StableSwapLPCollateral is ERC20Upgradeable, UUPSUpgradeable, AccessCont
     _;
   }
 
-  /// @notice Checks if the msg.sender is the moolah address.
-  modifier onlyMoolah() {
-    require(msg.sender == MOOLAH, "Not moolah");
+  modifier onlyMoolahOrTransferer() {
+    require(msg.sender == MOOLAH || hasRole(TRANSFERER, msg.sender), "Not moolah or transferer");
     _;
   }
 
   event SetMinter(address newMinter);
+  event SetTransferer(address indexed account, bool enabled);
 
   constructor(address _moolah) {
     require(_moolah != address(0), "Zero address");
@@ -57,6 +60,17 @@ contract StableSwapLPCollateral is ERC20Upgradeable, UUPSUpgradeable, AccessCont
     emit SetMinter(_newMinter);
   }
 
+  function setTransferer(address _account, bool _enabled) external onlyRole(MANAGER) {
+    require(_account != address(0), "Zero address");
+
+    if (_enabled) {
+      _grantRole(TRANSFERER, _account);
+    } else {
+      _revokeRole(TRANSFERER, _account);
+    }
+    emit SetTransferer(_account, _enabled);
+  }
+
   function mint(address _to, uint256 _amount) external onlyMinter {
     _mint(_to, _amount);
   }
@@ -65,18 +79,18 @@ contract StableSwapLPCollateral is ERC20Upgradeable, UUPSUpgradeable, AccessCont
     _burn(_from, _amount);
   }
 
-  /// @dev only Moolah can transfer
+  /// @dev only Moolah or TRANSFERER can transfer
   /// @param to The address of the recipient.
   /// @param value The amount to be transferred.
   /// @return bool Returns true on success, false otherwise.
-  function transfer(address to, uint256 value) public override onlyMoolah returns (bool) {
+  function transfer(address to, uint256 value) public override onlyMoolahOrTransferer returns (bool) {
     address owner = _msgSender();
     _transfer(owner, to, value);
     return true;
   }
 
-  /// @dev only Moolah can call transferFrom
-  function transferFrom(address from, address to, uint256 value) public override onlyMoolah returns (bool) {
+  /// @dev only Moolah or TRANSFERER can call transferFrom
+  function transferFrom(address from, address to, uint256 value) public override onlyMoolahOrTransferer returns (bool) {
     address spender = _msgSender();
     _spendAllowance(from, spender, value);
     _transfer(from, to, value);

--- a/test/dex/StableSwapLPCollateral.t.sol
+++ b/test/dex/StableSwapLPCollateral.t.sol
@@ -6,12 +6,15 @@ import { ERC20Mock } from "../../src/moolah/mocks/ERC20Mock.sol";
 import "../../src/dex/interfaces/IStableSwap.sol";
 
 import { StableSwapLPCollateral } from "../../src/dex/StableSwapLPCollateral.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 contract StableSwapLPCollateralTest is Test {
   address moolah = address(0x100);
   address public admin = address(0x1);
   address public minter = address(0x2);
   address public user1 = address(0x3);
+  address public manager = address(0x4);
+  address public transferer = address(0x5);
 
   ERC20Mock lp = new ERC20Mock();
   StableSwapLPCollateral lpCollateral; // ss-lp collateral
@@ -23,6 +26,11 @@ contract StableSwapLPCollateralTest is Test {
       abi.encodeWithSelector(lpCollateral.initialize.selector, admin, address(this), lp.name(), lp.symbol())
     );
     lpCollateral = StableSwapLPCollateral(address(lpCollateralProxy));
+
+    // Grant MANAGER role
+    vm.startPrank(admin);
+    lpCollateral.grantRole(lpCollateral.MANAGER(), manager);
+    vm.stopPrank();
   }
 
   function test_transfer() public {
@@ -36,7 +44,7 @@ contract StableSwapLPCollateralTest is Test {
 
     assertEq(lpCollateral.balanceOf(user1), 1000e18);
 
-    vm.expectRevert("Not moolah");
+    vm.expectRevert("Not moolah or transferer");
     vm.prank(user1);
     lpCollateral.transfer(user1, 500e18);
 
@@ -58,7 +66,7 @@ contract StableSwapLPCollateralTest is Test {
 
     vm.startPrank(user1);
     lpCollateral.approve(moolah, 500e18);
-    vm.expectRevert("Not moolah");
+    vm.expectRevert("Not moolah or transferer");
     lpCollateral.transferFrom(user1, moolah, 500e18);
     vm.stopPrank();
 
@@ -67,5 +75,136 @@ contract StableSwapLPCollateralTest is Test {
     lpCollateral.approve(moolah, 500e18);
     lpCollateral.transferFrom(user1, moolah, 500e18);
     vm.stopPrank();
+  }
+
+  // --- setTransferer tests ---
+
+  function test_setTransferer_byManager() public {
+    vm.prank(manager);
+    lpCollateral.setTransferer(transferer, true);
+
+    assertTrue(lpCollateral.hasRole(lpCollateral.TRANSFERER(), transferer));
+  }
+
+  function test_setTransferer_revoke() public {
+    vm.startPrank(manager);
+    lpCollateral.setTransferer(transferer, true);
+    lpCollateral.setTransferer(transferer, false);
+    vm.stopPrank();
+
+    assertFalse(lpCollateral.hasRole(lpCollateral.TRANSFERER(), transferer));
+  }
+
+  function test_setTransferer_revertIfNotManager() public {
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user1, lpCollateral.MANAGER())
+    );
+    vm.prank(user1);
+    lpCollateral.setTransferer(transferer, true);
+  }
+
+  function test_setTransferer_revertIfZeroAddress() public {
+    vm.expectRevert("Zero address");
+    vm.prank(manager);
+    lpCollateral.setTransferer(address(0), true);
+  }
+
+  // --- TRANSFERER role transfer/transferFrom tests ---
+
+  function test_transfererCanTransfer() public {
+    vm.prank(manager);
+    lpCollateral.setTransferer(transferer, true);
+
+    vm.startPrank(admin);
+    lpCollateral.setMinter(minter);
+    vm.stopPrank();
+
+    vm.prank(minter);
+    lpCollateral.mint(transferer, 1000e18);
+
+    vm.prank(transferer);
+    lpCollateral.transfer(user1, 500e18);
+
+    assertEq(lpCollateral.balanceOf(user1), 500e18);
+    assertEq(lpCollateral.balanceOf(transferer), 500e18);
+  }
+
+  function test_transfererCanTransferFrom() public {
+    vm.prank(manager);
+    lpCollateral.setTransferer(transferer, true);
+
+    vm.startPrank(admin);
+    lpCollateral.setMinter(minter);
+    vm.stopPrank();
+
+    vm.prank(minter);
+    lpCollateral.mint(user1, 1000e18);
+
+    vm.prank(user1);
+    lpCollateral.approve(transferer, 500e18);
+
+    vm.prank(transferer);
+    lpCollateral.transferFrom(user1, transferer, 500e18);
+
+    assertEq(lpCollateral.balanceOf(transferer), 500e18);
+    assertEq(lpCollateral.balanceOf(user1), 500e18);
+  }
+
+  function test_revokedTransfererCannotTransfer() public {
+    vm.startPrank(manager);
+    lpCollateral.setTransferer(transferer, true);
+    lpCollateral.setTransferer(transferer, false);
+    vm.stopPrank();
+
+    vm.startPrank(admin);
+    lpCollateral.setMinter(minter);
+    vm.stopPrank();
+
+    vm.prank(minter);
+    lpCollateral.mint(transferer, 1000e18);
+
+    vm.expectRevert("Not moolah or transferer");
+    vm.prank(transferer);
+    lpCollateral.transfer(user1, 500e18);
+  }
+
+  // --- MANAGER role grant/revoke tests ---
+
+  function test_grantManagerRole() public {
+    address newManager = address(0x6);
+    vm.startPrank(admin);
+    lpCollateral.grantRole(lpCollateral.MANAGER(), newManager);
+    vm.stopPrank();
+
+    assertTrue(lpCollateral.hasRole(lpCollateral.MANAGER(), newManager));
+  }
+
+  function test_revokeManagerRole() public {
+    vm.startPrank(admin);
+    lpCollateral.revokeRole(lpCollateral.MANAGER(), manager);
+    vm.stopPrank();
+
+    assertFalse(lpCollateral.hasRole(lpCollateral.MANAGER(), manager));
+  }
+
+  function test_grantManagerRole_revertIfNotAdmin() public {
+    bytes32 managerRole = lpCollateral.MANAGER();
+    bytes32 adminRole = lpCollateral.DEFAULT_ADMIN_ROLE();
+    vm.startPrank(user1);
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user1, adminRole));
+    lpCollateral.grantRole(managerRole, user1);
+    vm.stopPrank();
+  }
+
+  function test_revokedManagerCannotSetTransferer() public {
+    vm.startPrank(admin);
+    lpCollateral.revokeRole(lpCollateral.MANAGER(), manager);
+    vm.stopPrank();
+
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, manager, lpCollateral.MANAGER())
+    );
+    vm.prank(manager);
+    lpCollateral.setTransferer(transferer, true);
   }
 }


### PR DESCRIPTION
## Summary
- Add `MANAGER` and `TRANSFERER` roles to `StableSwapLPCollateral`
- `MANAGER` role (granted via `grantRole` by `DEFAULT_ADMIN_ROLE`) can grant/revoke `TRANSFERER` via `setTransferer`
- `transfer` and `transferFrom` now allow both Moolah address and `TRANSFERER` role holders (`onlyMoolahOrTransferer` modifier)
- `DEFAULT_ADMIN_ROLE` is only used for contract upgrades

## Test plan
- [x] Updated existing transfer/transferFrom tests to cover new role-based access
- [x] All tests pass (`forge test --mc StableSwapLPCollateral`)