### PR TITLE
feat: fork V3 contracts with UUPS upgradeability

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -10,5 +10,17 @@
       "name": "v0.1.0",
       "rev": "5feccd1253d7da820f7cccccdedf64471025455d"
     }
+  },
+  "lib/v3-core": {
+    "tag": {
+      "name": "v1.0.0",
+      "rev": "e3589b192d0be27e100cd0daaf6c97204fdb1899"
+    }
+  },
+  "lib/v3-periphery": {
+    "tag": {
+      "name": "v1.3.0",
+      "rev": "80f26c86c57b8a5e4b913f42844d4c8bd274d058"
+    }
   }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,9 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+remappings = [
+  "@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/",
+]
 solc = "0.8.34"
 optimizer = true
 optimizer_runs = 20

--- a/src/dex/v3/NOTICE
+++ b/src/dex/v3/NOTICE
@@ -1,0 +1,12 @@
+This code is derived from Uniswap V3 (https://github.com/Uniswap/v3-core,
+https://github.com/Uniswap/v3-periphery), originally licensed under
+Business Source License 1.1, which transitioned to GPL-2.0-or-later
+on 2023-04-01.
+
+Portions of src/dex/v3/core/libraries/ (FullMath, UnsafeMath) are derived
+from work by Remco Bloemen, licensed under MIT.
+
+Modifications by Lista DAO to the original Uniswap V3 code are licensed
+under GPL-2.0-or-later, consistent with the original license terms.
+
+Original files authored by Lista DAO are licensed under MIT.

--- a/src/dex/v3/core/ListaV3Factory.sol
+++ b/src/dex/v3/core/ListaV3Factory.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { IListaV3Factory } from "./interfaces/IListaV3Factory.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import { ListaV3PoolDeployer } from "./ListaV3PoolDeployer.sol";
+
+import { ListaV3Pool } from "./ListaV3Pool.sol";
+
+/// @title Canonical Lista V3 factory (UUPS upgradeable)
+/// @notice Deploys Lista V3 pools and manages ownership and control over pool protocol fees
+contract ListaV3Factory is IListaV3Factory, ListaV3PoolDeployer, Initializable, UUPSUpgradeable {
+  /// @inheritdoc IListaV3Factory
+  address public override owner;
+
+  /// @inheritdoc IListaV3Factory
+  mapping(uint24 => int24) public override feeAmountTickSpacing;
+  /// @inheritdoc IListaV3Factory
+  mapping(address => mapping(address => mapping(uint24 => address))) public override getPool;
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  function initialize(address _owner) external initializer {
+    require(_owner != address(0), "zero address");
+    owner = _owner;
+    emit OwnerChanged(address(0), _owner);
+
+    feeAmountTickSpacing[500] = 10;
+    emit FeeAmountEnabled(500, 10);
+    feeAmountTickSpacing[3000] = 60;
+    emit FeeAmountEnabled(3000, 60);
+    feeAmountTickSpacing[10000] = 200;
+    emit FeeAmountEnabled(10000, 200);
+  }
+
+  /// @inheritdoc IListaV3Factory
+  function createPool(address tokenA, address tokenB, uint24 fee) external override returns (address pool) {
+    require(tokenA != tokenB);
+    (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    require(token0 != address(0));
+    int24 tickSpacing = feeAmountTickSpacing[fee];
+    require(tickSpacing != 0);
+    require(getPool[token0][token1][fee] == address(0));
+    pool = deploy(address(this), token0, token1, fee, tickSpacing);
+    getPool[token0][token1][fee] = pool;
+    getPool[token1][token0][fee] = pool;
+    emit PoolCreated(token0, token1, fee, tickSpacing, pool);
+  }
+
+  /// @inheritdoc IListaV3Factory
+  function setOwner(address _owner) external override {
+    require(msg.sender == owner);
+    emit OwnerChanged(owner, _owner);
+    owner = _owner;
+  }
+
+  /// @inheritdoc IListaV3Factory
+  function enableFeeAmount(uint24 fee, int24 tickSpacing) public override {
+    require(msg.sender == owner);
+    require(fee < 1000000);
+    require(tickSpacing > 0 && tickSpacing < 16384);
+    require(feeAmountTickSpacing[fee] == 0);
+
+    feeAmountTickSpacing[fee] = tickSpacing;
+    emit FeeAmountEnabled(fee, tickSpacing);
+  }
+
+  /// @notice Returns the init code hash for pool deployment.
+  ///         Used by periphery contracts (PoolAddress.computeAddress) to deterministically
+  ///         derive pool addresses from (factory, token0, token1, fee).
+  function poolInitCodeHash() external pure returns (bytes32) {
+    return keccak256(type(ListaV3Pool).creationCode);
+  }
+
+  function _authorizeUpgrade(address) internal override {
+    require(msg.sender == owner);
+  }
+}

--- a/src/dex/v3/core/ListaV3Pool.sol
+++ b/src/dex/v3/core/ListaV3Pool.sol
@@ -1,0 +1,876 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { IListaV3PoolImmutables, IListaV3PoolState, IListaV3PoolActions, IListaV3PoolDerivedState, IListaV3PoolOwnerActions, IListaV3Pool } from "./interfaces/IListaV3Pool.sol";
+
+import { SafeCast } from "./libraries/SafeCast.sol";
+import { Tick } from "./libraries/Tick.sol";
+import { TickBitmap } from "./libraries/TickBitmap.sol";
+import { Position } from "./libraries/Position.sol";
+import { Oracle } from "./libraries/Oracle.sol";
+
+import { FullMath } from "./libraries/FullMath.sol";
+import { FixedPoint128 } from "./libraries/FixedPoint128.sol";
+import { TransferHelper } from "./libraries/TransferHelper.sol";
+import { TickMath } from "./libraries/TickMath.sol";
+import { SqrtPriceMath } from "./libraries/SqrtPriceMath.sol";
+import { SwapMath } from "./libraries/SwapMath.sol";
+
+import { IListaV3PoolDeployer } from "./interfaces/IListaV3PoolDeployer.sol";
+import { IListaV3Factory } from "./interfaces/IListaV3Factory.sol";
+import { IERC20Minimal } from "./interfaces/IERC20Minimal.sol";
+import { IListaV3MintCallback } from "./interfaces/callback/IListaV3MintCallback.sol";
+import { IListaV3SwapCallback } from "./interfaces/callback/IListaV3SwapCallback.sol";
+import { IListaV3FlashCallback } from "./interfaces/callback/IListaV3FlashCallback.sol";
+
+contract ListaV3Pool is IListaV3Pool {
+  using SafeCast for uint256;
+  using SafeCast for int256;
+  using Tick for mapping(int24 => Tick.Info);
+  using TickBitmap for mapping(int16 => uint256);
+  using Position for mapping(bytes32 => Position.Info);
+  using Position for Position.Info;
+  using Oracle for Oracle.Observation[65535];
+
+  /// @inheritdoc IListaV3PoolImmutables
+  address public immutable override factory;
+  /// @inheritdoc IListaV3PoolImmutables
+  address public immutable override token0;
+  /// @inheritdoc IListaV3PoolImmutables
+  address public immutable override token1;
+  /// @inheritdoc IListaV3PoolImmutables
+  uint24 public immutable override fee;
+
+  /// @inheritdoc IListaV3PoolImmutables
+  int24 public immutable override tickSpacing;
+
+  /// @inheritdoc IListaV3PoolImmutables
+  uint128 public immutable override maxLiquidityPerTick;
+
+  struct Slot0 {
+    // the current price
+    uint160 sqrtPriceX96;
+    // the current tick
+    int24 tick;
+    // the most-recently updated index of the observations array
+    uint16 observationIndex;
+    // the current maximum number of observations that are being stored
+    uint16 observationCardinality;
+    // the next maximum number of observations to store, triggered in observations.write
+    uint16 observationCardinalityNext;
+    // the current protocol fee as a percentage of the swap fee taken on withdrawal
+    // represented as an integer denominator (1/x)%
+    uint8 feeProtocol;
+    // whether the pool is locked
+    bool unlocked;
+  }
+  /// @inheritdoc IListaV3PoolState
+  Slot0 public override slot0;
+
+  /// @inheritdoc IListaV3PoolState
+  uint256 public override feeGrowthGlobal0X128;
+  /// @inheritdoc IListaV3PoolState
+  uint256 public override feeGrowthGlobal1X128;
+
+  // accumulated protocol fees in token0/token1 units
+  struct ProtocolFees {
+    uint128 token0;
+    uint128 token1;
+  }
+  /// @inheritdoc IListaV3PoolState
+  ProtocolFees public override protocolFees;
+
+  /// @inheritdoc IListaV3PoolState
+  uint128 public override liquidity;
+
+  /// @inheritdoc IListaV3PoolState
+  mapping(int24 => Tick.Info) public override ticks;
+  /// @inheritdoc IListaV3PoolState
+  mapping(int16 => uint256) public override tickBitmap;
+  /// @inheritdoc IListaV3PoolState
+  mapping(bytes32 => Position.Info) public override positions;
+  /// @inheritdoc IListaV3PoolState
+  Oracle.Observation[65535] public override observations;
+
+  /// @dev Mutually exclusive reentrancy protection into the pool to/from a method. This method also prevents entrance
+  /// to a function before the pool is initialized. The reentrancy guard is required throughout the contract because
+  /// we use balance checks to determine the payment status of interactions such as mint, swap and flash.
+  modifier lock() {
+    if (!slot0.unlocked) revert LOK();
+    slot0.unlocked = false;
+    _;
+    slot0.unlocked = true;
+  }
+
+  /// @dev Prevents calling a function from anyone except the address returned by IListaV3Factory#owner()
+  modifier onlyFactoryOwner() {
+    require(msg.sender == IListaV3Factory(factory).owner());
+    _;
+  }
+
+  constructor() {
+    int24 _tickSpacing;
+    (factory, token0, token1, fee, _tickSpacing) = IListaV3PoolDeployer(msg.sender).parameters();
+    tickSpacing = _tickSpacing;
+
+    maxLiquidityPerTick = Tick.tickSpacingToMaxLiquidityPerTick(_tickSpacing);
+  }
+
+  /// @dev Common checks for valid tick inputs.
+  function checkTicks(int24 tickLower, int24 tickUpper) private pure {
+    if (tickLower >= tickUpper) revert TLU();
+    if (tickLower < TickMath.MIN_TICK) revert TLM();
+    if (tickUpper > TickMath.MAX_TICK) revert TUM();
+  }
+
+  /// @dev Returns the block timestamp truncated to 32 bits, i.e. mod 2**32. This method is overridden in tests.
+  function _blockTimestamp() internal view virtual returns (uint32) {
+    return uint32(block.timestamp); // truncation is desired
+  }
+
+  /// @dev Get the pool's balance of token0
+  /// @dev This function is gas optimized to avoid a redundant extcodesize check in addition to the returndatasize
+  /// check
+  function balance0() private view returns (uint256) {
+    (bool success, bytes memory data) = token0.staticcall(
+      abi.encodeWithSelector(IERC20Minimal.balanceOf.selector, address(this))
+    );
+    require(success && data.length >= 32);
+    return abi.decode(data, (uint256));
+  }
+
+  /// @dev Get the pool's balance of token1
+  /// @dev This function is gas optimized to avoid a redundant extcodesize check in addition to the returndatasize
+  /// check
+  function balance1() private view returns (uint256) {
+    (bool success, bytes memory data) = token1.staticcall(
+      abi.encodeWithSelector(IERC20Minimal.balanceOf.selector, address(this))
+    );
+    require(success && data.length >= 32);
+    return abi.decode(data, (uint256));
+  }
+
+  /// @inheritdoc IListaV3PoolDerivedState
+  function snapshotCumulativesInside(
+    int24 tickLower,
+    int24 tickUpper
+  )
+    external
+    view
+    override
+    returns (int56 tickCumulativeInside, uint160 secondsPerLiquidityInsideX128, uint32 secondsInside)
+  {
+    checkTicks(tickLower, tickUpper);
+
+    int56 tickCumulativeLower;
+    int56 tickCumulativeUpper;
+    uint160 secondsPerLiquidityOutsideLowerX128;
+    uint160 secondsPerLiquidityOutsideUpperX128;
+    uint32 secondsOutsideLower;
+    uint32 secondsOutsideUpper;
+
+    {
+      Tick.Info storage lower = ticks[tickLower];
+      Tick.Info storage upper = ticks[tickUpper];
+      bool initializedLower;
+      (tickCumulativeLower, secondsPerLiquidityOutsideLowerX128, secondsOutsideLower, initializedLower) = (
+        lower.tickCumulativeOutside,
+        lower.secondsPerLiquidityOutsideX128,
+        lower.secondsOutside,
+        lower.initialized
+      );
+      require(initializedLower);
+
+      bool initializedUpper;
+      (tickCumulativeUpper, secondsPerLiquidityOutsideUpperX128, secondsOutsideUpper, initializedUpper) = (
+        upper.tickCumulativeOutside,
+        upper.secondsPerLiquidityOutsideX128,
+        upper.secondsOutside,
+        upper.initialized
+      );
+      require(initializedUpper);
+    }
+
+    Slot0 memory _slot0 = slot0;
+
+    unchecked {
+      if (_slot0.tick < tickLower) {
+        return (
+          tickCumulativeLower - tickCumulativeUpper,
+          secondsPerLiquidityOutsideLowerX128 - secondsPerLiquidityOutsideUpperX128,
+          secondsOutsideLower - secondsOutsideUpper
+        );
+      } else if (_slot0.tick < tickUpper) {
+        uint32 time = _blockTimestamp();
+        (int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128) = observations.observeSingle(
+          time,
+          0,
+          _slot0.tick,
+          _slot0.observationIndex,
+          liquidity,
+          _slot0.observationCardinality
+        );
+        return (
+          tickCumulative - tickCumulativeLower - tickCumulativeUpper,
+          secondsPerLiquidityCumulativeX128 - secondsPerLiquidityOutsideLowerX128 - secondsPerLiquidityOutsideUpperX128,
+          time - secondsOutsideLower - secondsOutsideUpper
+        );
+      } else {
+        return (
+          tickCumulativeUpper - tickCumulativeLower,
+          secondsPerLiquidityOutsideUpperX128 - secondsPerLiquidityOutsideLowerX128,
+          secondsOutsideUpper - secondsOutsideLower
+        );
+      }
+    }
+  }
+
+  /// @inheritdoc IListaV3PoolDerivedState
+  function observe(
+    uint32[] calldata secondsAgos
+  )
+    external
+    view
+    override
+    returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s)
+  {
+    return
+      observations.observe(
+        _blockTimestamp(),
+        secondsAgos,
+        slot0.tick,
+        slot0.observationIndex,
+        liquidity,
+        slot0.observationCardinality
+      );
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external override lock {
+    uint16 observationCardinalityNextOld = slot0.observationCardinalityNext; // for the event
+    uint16 observationCardinalityNextNew = observations.grow(observationCardinalityNextOld, observationCardinalityNext);
+    slot0.observationCardinalityNext = observationCardinalityNextNew;
+    if (observationCardinalityNextOld != observationCardinalityNextNew)
+      emit IncreaseObservationCardinalityNext(observationCardinalityNextOld, observationCardinalityNextNew);
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  /// @dev not locked because it initializes unlocked
+  function initialize(uint160 sqrtPriceX96) external override {
+    if (slot0.sqrtPriceX96 != 0) revert AI();
+
+    int24 tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
+
+    (uint16 cardinality, uint16 cardinalityNext) = observations.initialize(_blockTimestamp());
+
+    slot0 = Slot0({
+      sqrtPriceX96: sqrtPriceX96,
+      tick: tick,
+      observationIndex: 0,
+      observationCardinality: cardinality,
+      observationCardinalityNext: cardinalityNext,
+      feeProtocol: 0,
+      unlocked: true
+    });
+
+    emit Initialize(sqrtPriceX96, tick);
+  }
+
+  struct ModifyPositionParams {
+    // the address that owns the position
+    address owner;
+    // the lower and upper tick of the position
+    int24 tickLower;
+    int24 tickUpper;
+    // any change in liquidity
+    int128 liquidityDelta;
+  }
+
+  /// @dev Effect some changes to a position
+  /// @param params the position details and the change to the position's liquidity to effect
+  /// @return position a storage pointer referencing the position with the given owner and tick range
+  /// @return amount0 the amount of token0 owed to the pool, negative if the pool should pay the recipient
+  /// @return amount1 the amount of token1 owed to the pool, negative if the pool should pay the recipient
+  function _modifyPosition(
+    ModifyPositionParams memory params
+  ) private returns (Position.Info storage position, int256 amount0, int256 amount1) {
+    checkTicks(params.tickLower, params.tickUpper);
+
+    Slot0 memory _slot0 = slot0; // SLOAD for gas optimization
+
+    position = _updatePosition(params.owner, params.tickLower, params.tickUpper, params.liquidityDelta, _slot0.tick);
+
+    if (params.liquidityDelta != 0) {
+      if (_slot0.tick < params.tickLower) {
+        // current tick is below the passed range; liquidity can only become in range by crossing from left to
+        // right, when we'll need _more_ token0 (it's becoming more valuable) so user must provide it
+        amount0 = SqrtPriceMath.getAmount0Delta(
+          TickMath.getSqrtRatioAtTick(params.tickLower),
+          TickMath.getSqrtRatioAtTick(params.tickUpper),
+          params.liquidityDelta
+        );
+      } else if (_slot0.tick < params.tickUpper) {
+        // current tick is inside the passed range
+        uint128 liquidityBefore = liquidity; // SLOAD for gas optimization
+
+        // write an oracle entry
+        (slot0.observationIndex, slot0.observationCardinality) = observations.write(
+          _slot0.observationIndex,
+          _blockTimestamp(),
+          _slot0.tick,
+          liquidityBefore,
+          _slot0.observationCardinality,
+          _slot0.observationCardinalityNext
+        );
+
+        amount0 = SqrtPriceMath.getAmount0Delta(
+          _slot0.sqrtPriceX96,
+          TickMath.getSqrtRatioAtTick(params.tickUpper),
+          params.liquidityDelta
+        );
+        amount1 = SqrtPriceMath.getAmount1Delta(
+          TickMath.getSqrtRatioAtTick(params.tickLower),
+          _slot0.sqrtPriceX96,
+          params.liquidityDelta
+        );
+
+        liquidity = params.liquidityDelta < 0
+          ? liquidityBefore - uint128(-params.liquidityDelta)
+          : liquidityBefore + uint128(params.liquidityDelta);
+      } else {
+        // current tick is above the passed range; liquidity can only become in range by crossing from right to
+        // left, when we'll need _more_ token1 (it's becoming more valuable) so user must provide it
+        amount1 = SqrtPriceMath.getAmount1Delta(
+          TickMath.getSqrtRatioAtTick(params.tickLower),
+          TickMath.getSqrtRatioAtTick(params.tickUpper),
+          params.liquidityDelta
+        );
+      }
+    }
+  }
+
+  /// @dev Gets and updates a position with the given liquidity delta
+  /// @param owner the owner of the position
+  /// @param tickLower the lower tick of the position's tick range
+  /// @param tickUpper the upper tick of the position's tick range
+  /// @param tick the current tick, passed to avoid sloads
+  function _updatePosition(
+    address owner,
+    int24 tickLower,
+    int24 tickUpper,
+    int128 liquidityDelta,
+    int24 tick
+  ) private returns (Position.Info storage position) {
+    position = positions.get(owner, tickLower, tickUpper);
+
+    uint256 _feeGrowthGlobal0X128 = feeGrowthGlobal0X128; // SLOAD for gas optimization
+    uint256 _feeGrowthGlobal1X128 = feeGrowthGlobal1X128; // SLOAD for gas optimization
+
+    // if we need to update the ticks, do it
+    bool flippedLower;
+    bool flippedUpper;
+    if (liquidityDelta != 0) {
+      uint32 time = _blockTimestamp();
+      (int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128) = observations.observeSingle(
+        time,
+        0,
+        slot0.tick,
+        slot0.observationIndex,
+        liquidity,
+        slot0.observationCardinality
+      );
+
+      flippedLower = ticks.update(
+        tickLower,
+        tick,
+        liquidityDelta,
+        _feeGrowthGlobal0X128,
+        _feeGrowthGlobal1X128,
+        secondsPerLiquidityCumulativeX128,
+        tickCumulative,
+        time,
+        false,
+        maxLiquidityPerTick
+      );
+      flippedUpper = ticks.update(
+        tickUpper,
+        tick,
+        liquidityDelta,
+        _feeGrowthGlobal0X128,
+        _feeGrowthGlobal1X128,
+        secondsPerLiquidityCumulativeX128,
+        tickCumulative,
+        time,
+        true,
+        maxLiquidityPerTick
+      );
+
+      if (flippedLower) {
+        tickBitmap.flipTick(tickLower, tickSpacing);
+      }
+      if (flippedUpper) {
+        tickBitmap.flipTick(tickUpper, tickSpacing);
+      }
+    }
+
+    (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) = ticks.getFeeGrowthInside(
+      tickLower,
+      tickUpper,
+      tick,
+      _feeGrowthGlobal0X128,
+      _feeGrowthGlobal1X128
+    );
+
+    position.update(liquidityDelta, feeGrowthInside0X128, feeGrowthInside1X128);
+
+    // clear any tick data that is no longer needed
+    if (liquidityDelta < 0) {
+      if (flippedLower) {
+        ticks.clear(tickLower);
+      }
+      if (flippedUpper) {
+        ticks.clear(tickUpper);
+      }
+    }
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  /// @dev  is applied indirectly via _modifyPosition
+  function mint(
+    address recipient,
+    int24 tickLower,
+    int24 tickUpper,
+    uint128 amount,
+    bytes calldata data
+  ) external override lock returns (uint256 amount0, uint256 amount1) {
+    require(amount > 0);
+    (, int256 amount0Int, int256 amount1Int) = _modifyPosition(
+      ModifyPositionParams({
+        owner: recipient,
+        tickLower: tickLower,
+        tickUpper: tickUpper,
+        liquidityDelta: int256(uint256(amount)).toInt128()
+      })
+    );
+
+    amount0 = uint256(amount0Int);
+    amount1 = uint256(amount1Int);
+
+    uint256 balance0Before;
+    uint256 balance1Before;
+    if (amount0 > 0) balance0Before = balance0();
+    if (amount1 > 0) balance1Before = balance1();
+    IListaV3MintCallback(msg.sender).listaV3MintCallback(amount0, amount1, data);
+    if (amount0 > 0 && balance0Before + amount0 > balance0()) revert M0();
+    if (amount1 > 0 && balance1Before + amount1 > balance1()) revert M1();
+
+    emit Mint(msg.sender, recipient, tickLower, tickUpper, amount, amount0, amount1);
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  function collect(
+    address recipient,
+    int24 tickLower,
+    int24 tickUpper,
+    uint128 amount0Requested,
+    uint128 amount1Requested
+  ) external override lock returns (uint128 amount0, uint128 amount1) {
+    // we don't need to checkTicks here, because invalid positions will never have non-zero tokensOwed{0,1}
+    Position.Info storage position = positions.get(msg.sender, tickLower, tickUpper);
+
+    amount0 = amount0Requested > position.tokensOwed0 ? position.tokensOwed0 : amount0Requested;
+    amount1 = amount1Requested > position.tokensOwed1 ? position.tokensOwed1 : amount1Requested;
+
+    unchecked {
+      if (amount0 > 0) {
+        position.tokensOwed0 -= amount0;
+        TransferHelper.safeTransfer(token0, recipient, amount0);
+      }
+      if (amount1 > 0) {
+        position.tokensOwed1 -= amount1;
+        TransferHelper.safeTransfer(token1, recipient, amount1);
+      }
+    }
+
+    emit Collect(msg.sender, recipient, tickLower, tickUpper, amount0, amount1);
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  /// @dev  is applied indirectly via _modifyPosition
+  function burn(
+    int24 tickLower,
+    int24 tickUpper,
+    uint128 amount
+  ) external override lock returns (uint256 amount0, uint256 amount1) {
+    unchecked {
+      (Position.Info storage position, int256 amount0Int, int256 amount1Int) = _modifyPosition(
+        ModifyPositionParams({
+          owner: msg.sender,
+          tickLower: tickLower,
+          tickUpper: tickUpper,
+          liquidityDelta: -int256(uint256(amount)).toInt128()
+        })
+      );
+
+      amount0 = uint256(-amount0Int);
+      amount1 = uint256(-amount1Int);
+
+      if (amount0 > 0 || amount1 > 0) {
+        (position.tokensOwed0, position.tokensOwed1) = (
+          position.tokensOwed0 + uint128(amount0),
+          position.tokensOwed1 + uint128(amount1)
+        );
+      }
+
+      emit Burn(msg.sender, tickLower, tickUpper, amount, amount0, amount1);
+    }
+  }
+
+  struct SwapCache {
+    // the protocol fee for the input token
+    uint8 feeProtocol;
+    // liquidity at the beginning of the swap
+    uint128 liquidityStart;
+    // the timestamp of the current block
+    uint32 blockTimestamp;
+    // the current value of the tick accumulator, computed only if we cross an initialized tick
+    int56 tickCumulative;
+    // the current value of seconds per liquidity accumulator, computed only if we cross an initialized tick
+    uint160 secondsPerLiquidityCumulativeX128;
+    // whether we've computed and cached the above two accumulators
+    bool computedLatestObservation;
+  }
+
+  // the top level state of the swap, the results of which are recorded in storage at the end
+  struct SwapState {
+    // the amount remaining to be swapped in/out of the input/output asset
+    int256 amountSpecifiedRemaining;
+    // the amount already swapped out/in of the output/input asset
+    int256 amountCalculated;
+    // current sqrt(price)
+    uint160 sqrtPriceX96;
+    // the tick associated with the current price
+    int24 tick;
+    // the global fee growth of the input token
+    uint256 feeGrowthGlobalX128;
+    // amount of input token paid as protocol fee
+    uint128 protocolFee;
+    // the current liquidity in range
+    uint128 liquidity;
+  }
+
+  struct StepComputations {
+    // the price at the beginning of the step
+    uint160 sqrtPriceStartX96;
+    // the next tick to swap to from the current tick in the swap direction
+    int24 tickNext;
+    // whether tickNext is initialized or not
+    bool initialized;
+    // sqrt(price) for the next tick (1/0)
+    uint160 sqrtPriceNextX96;
+    // how much is being swapped in in this step
+    uint256 amountIn;
+    // how much is being swapped out
+    uint256 amountOut;
+    // how much fee is being paid in
+    uint256 feeAmount;
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  function swap(
+    address recipient,
+    bool zeroForOne,
+    int256 amountSpecified,
+    uint160 sqrtPriceLimitX96,
+    bytes calldata data
+  ) external override returns (int256 amount0, int256 amount1) {
+    if (amountSpecified == 0) revert AS();
+
+    Slot0 memory slot0Start = slot0;
+
+    if (!slot0Start.unlocked) revert LOK();
+    require(
+      zeroForOne
+        ? sqrtPriceLimitX96 < slot0Start.sqrtPriceX96 && sqrtPriceLimitX96 > TickMath.MIN_SQRT_RATIO
+        : sqrtPriceLimitX96 > slot0Start.sqrtPriceX96 && sqrtPriceLimitX96 < TickMath.MAX_SQRT_RATIO,
+      "SPL"
+    );
+
+    slot0.unlocked = false;
+
+    SwapCache memory cache = SwapCache({
+      liquidityStart: liquidity,
+      blockTimestamp: _blockTimestamp(),
+      feeProtocol: zeroForOne ? (slot0Start.feeProtocol % 16) : (slot0Start.feeProtocol >> 4),
+      secondsPerLiquidityCumulativeX128: 0,
+      tickCumulative: 0,
+      computedLatestObservation: false
+    });
+
+    bool exactInput = amountSpecified > 0;
+
+    SwapState memory state = SwapState({
+      amountSpecifiedRemaining: amountSpecified,
+      amountCalculated: 0,
+      sqrtPriceX96: slot0Start.sqrtPriceX96,
+      tick: slot0Start.tick,
+      feeGrowthGlobalX128: zeroForOne ? feeGrowthGlobal0X128 : feeGrowthGlobal1X128,
+      protocolFee: 0,
+      liquidity: cache.liquidityStart
+    });
+
+    // continue swapping as long as we haven't used the entire input/output and haven't reached the price limit
+    while (state.amountSpecifiedRemaining != 0 && state.sqrtPriceX96 != sqrtPriceLimitX96) {
+      StepComputations memory step;
+
+      step.sqrtPriceStartX96 = state.sqrtPriceX96;
+
+      (step.tickNext, step.initialized) = tickBitmap.nextInitializedTickWithinOneWord(
+        state.tick,
+        tickSpacing,
+        zeroForOne
+      );
+
+      // ensure that we do not overshoot the min/max tick, as the tick bitmap is not aware of these bounds
+      if (step.tickNext < TickMath.MIN_TICK) {
+        step.tickNext = TickMath.MIN_TICK;
+      } else if (step.tickNext > TickMath.MAX_TICK) {
+        step.tickNext = TickMath.MAX_TICK;
+      }
+
+      // get the price for the next tick
+      step.sqrtPriceNextX96 = TickMath.getSqrtRatioAtTick(step.tickNext);
+
+      // compute values to swap to the target tick, price limit, or point where input/output amount is exhausted
+      (state.sqrtPriceX96, step.amountIn, step.amountOut, step.feeAmount) = SwapMath.computeSwapStep(
+        state.sqrtPriceX96,
+        (zeroForOne ? step.sqrtPriceNextX96 < sqrtPriceLimitX96 : step.sqrtPriceNextX96 > sqrtPriceLimitX96)
+          ? sqrtPriceLimitX96
+          : step.sqrtPriceNextX96,
+        state.liquidity,
+        state.amountSpecifiedRemaining,
+        fee
+      );
+
+      if (exactInput) {
+        // safe because we test that amountSpecified > amountIn + feeAmount in SwapMath
+        unchecked {
+          state.amountSpecifiedRemaining -= (step.amountIn + step.feeAmount).toInt256();
+        }
+        state.amountCalculated -= step.amountOut.toInt256();
+      } else {
+        unchecked {
+          state.amountSpecifiedRemaining += step.amountOut.toInt256();
+        }
+        state.amountCalculated += (step.amountIn + step.feeAmount).toInt256();
+      }
+
+      // if the protocol fee is on, calculate how much is owed, decrement feeAmount, and increment protocolFee
+      if (cache.feeProtocol > 0) {
+        unchecked {
+          uint256 delta = step.feeAmount / cache.feeProtocol;
+          step.feeAmount -= delta;
+          state.protocolFee += uint128(delta);
+        }
+      }
+
+      // update global fee tracker
+      if (state.liquidity > 0) {
+        unchecked {
+          state.feeGrowthGlobalX128 += FullMath.mulDiv(step.feeAmount, FixedPoint128.Q128, state.liquidity);
+        }
+      }
+
+      // shift tick if we reached the next price
+      if (state.sqrtPriceX96 == step.sqrtPriceNextX96) {
+        // if the tick is initialized, run the tick transition
+        if (step.initialized) {
+          // check for the placeholder value, which we replace with the actual value the first time the swap
+          // crosses an initialized tick
+          if (!cache.computedLatestObservation) {
+            (cache.tickCumulative, cache.secondsPerLiquidityCumulativeX128) = observations.observeSingle(
+              cache.blockTimestamp,
+              0,
+              slot0Start.tick,
+              slot0Start.observationIndex,
+              cache.liquidityStart,
+              slot0Start.observationCardinality
+            );
+            cache.computedLatestObservation = true;
+          }
+          int128 liquidityNet = ticks.cross(
+            step.tickNext,
+            (zeroForOne ? state.feeGrowthGlobalX128 : feeGrowthGlobal0X128),
+            (zeroForOne ? feeGrowthGlobal1X128 : state.feeGrowthGlobalX128),
+            cache.secondsPerLiquidityCumulativeX128,
+            cache.tickCumulative,
+            cache.blockTimestamp
+          );
+          // if we're moving leftward, we interpret liquidityNet as the opposite sign
+          // safe because liquidityNet cannot be type(int128).min
+          unchecked {
+            if (zeroForOne) liquidityNet = -liquidityNet;
+          }
+
+          state.liquidity = liquidityNet < 0
+            ? state.liquidity - uint128(-liquidityNet)
+            : state.liquidity + uint128(liquidityNet);
+        }
+
+        unchecked {
+          state.tick = zeroForOne ? step.tickNext - 1 : step.tickNext;
+        }
+      } else if (state.sqrtPriceX96 != step.sqrtPriceStartX96) {
+        // recompute unless we're on a lower tick boundary (i.e. already transitioned ticks), and haven't moved
+        state.tick = TickMath.getTickAtSqrtRatio(state.sqrtPriceX96);
+      }
+    }
+
+    // update tick and write an oracle entry if the tick change
+    if (state.tick != slot0Start.tick) {
+      (uint16 observationIndex, uint16 observationCardinality) = observations.write(
+        slot0Start.observationIndex,
+        cache.blockTimestamp,
+        slot0Start.tick,
+        cache.liquidityStart,
+        slot0Start.observationCardinality,
+        slot0Start.observationCardinalityNext
+      );
+      (slot0.sqrtPriceX96, slot0.tick, slot0.observationIndex, slot0.observationCardinality) = (
+        state.sqrtPriceX96,
+        state.tick,
+        observationIndex,
+        observationCardinality
+      );
+    } else {
+      // otherwise just update the price
+      slot0.sqrtPriceX96 = state.sqrtPriceX96;
+    }
+
+    // update liquidity if it changed
+    if (cache.liquidityStart != state.liquidity) liquidity = state.liquidity;
+
+    // update fee growth global and, if necessary, protocol fees
+    // overflow is acceptable, protocol has to withdraw before it hits type(uint128).max fees
+    if (zeroForOne) {
+      feeGrowthGlobal0X128 = state.feeGrowthGlobalX128;
+      unchecked {
+        if (state.protocolFee > 0) protocolFees.token0 += state.protocolFee;
+      }
+    } else {
+      feeGrowthGlobal1X128 = state.feeGrowthGlobalX128;
+      unchecked {
+        if (state.protocolFee > 0) protocolFees.token1 += state.protocolFee;
+      }
+    }
+
+    unchecked {
+      (amount0, amount1) = zeroForOne == exactInput
+        ? (amountSpecified - state.amountSpecifiedRemaining, state.amountCalculated)
+        : (state.amountCalculated, amountSpecified - state.amountSpecifiedRemaining);
+    }
+
+    // do the transfers and collect payment
+    if (zeroForOne) {
+      unchecked {
+        if (amount1 < 0) TransferHelper.safeTransfer(token1, recipient, uint256(-amount1));
+      }
+
+      uint256 balance0Before = balance0();
+      IListaV3SwapCallback(msg.sender).listaV3SwapCallback(amount0, amount1, data);
+      if (balance0Before + uint256(amount0) > balance0()) revert IIA();
+    } else {
+      unchecked {
+        if (amount0 < 0) TransferHelper.safeTransfer(token0, recipient, uint256(-amount0));
+      }
+
+      uint256 balance1Before = balance1();
+      IListaV3SwapCallback(msg.sender).listaV3SwapCallback(amount0, amount1, data);
+      if (balance1Before + uint256(amount1) > balance1()) revert IIA();
+    }
+
+    emit Swap(msg.sender, recipient, amount0, amount1, state.sqrtPriceX96, state.liquidity, state.tick);
+    slot0.unlocked = true;
+  }
+
+  /// @inheritdoc IListaV3PoolActions
+  function flash(address recipient, uint256 amount0, uint256 amount1, bytes calldata data) external override lock {
+    uint128 _liquidity = liquidity;
+    if (_liquidity <= 0) revert L();
+
+    uint256 fee0 = FullMath.mulDivRoundingUp(amount0, fee, 1e6);
+    uint256 fee1 = FullMath.mulDivRoundingUp(amount1, fee, 1e6);
+    uint256 balance0Before = balance0();
+    uint256 balance1Before = balance1();
+
+    if (amount0 > 0) TransferHelper.safeTransfer(token0, recipient, amount0);
+    if (amount1 > 0) TransferHelper.safeTransfer(token1, recipient, amount1);
+
+    IListaV3FlashCallback(msg.sender).listaV3FlashCallback(fee0, fee1, data);
+
+    uint256 balance0After = balance0();
+    uint256 balance1After = balance1();
+
+    if (balance0Before + fee0 > balance0After) revert F0();
+    if (balance1Before + fee1 > balance1After) revert F1();
+
+    unchecked {
+      // sub is safe because we know balanceAfter is gt balanceBefore by at least fee
+      uint256 paid0 = balance0After - balance0Before;
+      uint256 paid1 = balance1After - balance1Before;
+
+      if (paid0 > 0) {
+        uint8 feeProtocol0 = slot0.feeProtocol % 16;
+        uint256 pFees0 = feeProtocol0 == 0 ? 0 : paid0 / feeProtocol0;
+        if (uint128(pFees0) > 0) protocolFees.token0 += uint128(pFees0);
+        feeGrowthGlobal0X128 += FullMath.mulDiv(paid0 - pFees0, FixedPoint128.Q128, _liquidity);
+      }
+      if (paid1 > 0) {
+        uint8 feeProtocol1 = slot0.feeProtocol >> 4;
+        uint256 pFees1 = feeProtocol1 == 0 ? 0 : paid1 / feeProtocol1;
+        if (uint128(pFees1) > 0) protocolFees.token1 += uint128(pFees1);
+        feeGrowthGlobal1X128 += FullMath.mulDiv(paid1 - pFees1, FixedPoint128.Q128, _liquidity);
+      }
+
+      emit Flash(msg.sender, recipient, amount0, amount1, paid0, paid1);
+    }
+  }
+
+  /// @inheritdoc IListaV3PoolOwnerActions
+  function setFeeProtocol(uint8 feeProtocol0, uint8 feeProtocol1) external override lock onlyFactoryOwner {
+    unchecked {
+      require(
+        (feeProtocol0 == 0 || (feeProtocol0 >= 4 && feeProtocol0 <= 10)) &&
+          (feeProtocol1 == 0 || (feeProtocol1 >= 4 && feeProtocol1 <= 10))
+      );
+      uint8 feeProtocolOld = slot0.feeProtocol;
+      slot0.feeProtocol = feeProtocol0 + (feeProtocol1 << 4);
+      emit SetFeeProtocol(feeProtocolOld % 16, feeProtocolOld >> 4, feeProtocol0, feeProtocol1);
+    }
+  }
+
+  /// @inheritdoc IListaV3PoolOwnerActions
+  function collectProtocol(
+    address recipient,
+    uint128 amount0Requested,
+    uint128 amount1Requested
+  ) external override lock onlyFactoryOwner returns (uint128 amount0, uint128 amount1) {
+    amount0 = amount0Requested > protocolFees.token0 ? protocolFees.token0 : amount0Requested;
+    amount1 = amount1Requested > protocolFees.token1 ? protocolFees.token1 : amount1Requested;
+
+    unchecked {
+      if (amount0 > 0) {
+        if (amount0 == protocolFees.token0) amount0--; // ensure that the slot is not cleared, for gas savings
+        protocolFees.token0 -= amount0;
+        TransferHelper.safeTransfer(token0, recipient, amount0);
+      }
+      if (amount1 > 0) {
+        if (amount1 == protocolFees.token1) amount1--; // ensure that the slot is not cleared, for gas savings
+        protocolFees.token1 -= amount1;
+        TransferHelper.safeTransfer(token1, recipient, amount1);
+      }
+    }
+
+    emit CollectProtocol(msg.sender, recipient, amount0, amount1);
+  }
+}

--- a/src/dex/v3/core/ListaV3PoolDeployer.sol
+++ b/src/dex/v3/core/ListaV3PoolDeployer.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { IListaV3PoolDeployer } from "./interfaces/IListaV3PoolDeployer.sol";
+
+import { ListaV3Pool } from "./ListaV3Pool.sol";
+
+contract ListaV3PoolDeployer is IListaV3PoolDeployer {
+  struct Parameters {
+    address factory;
+    address token0;
+    address token1;
+    uint24 fee;
+    int24 tickSpacing;
+  }
+
+  /// @inheritdoc IListaV3PoolDeployer
+  Parameters public override parameters;
+
+  /// @dev Deploys a pool with the given parameters by transiently setting the parameters storage slot and then
+  /// clearing it after deploying the pool.
+  function deploy(
+    address factory,
+    address token0,
+    address token1,
+    uint24 fee,
+    int24 tickSpacing
+  ) internal returns (address pool) {
+    parameters = Parameters({ factory: factory, token0: token0, token1: token1, fee: fee, tickSpacing: tickSpacing });
+    pool = address(new ListaV3Pool{ salt: keccak256(abi.encode(token0, token1, fee)) }());
+    delete parameters;
+  }
+}

--- a/src/dex/v3/core/NoDelegateCall.sol
+++ b/src/dex/v3/core/NoDelegateCall.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+/// @title Prevents delegatecall to a contract
+/// @notice Base contract that provides a modifier for preventing delegatecall to methods in a child contract
+abstract contract NoDelegateCall {
+  /// @dev The original address of this contract
+  address private immutable original;
+
+  constructor() {
+    // Immutables are computed in the init code of the contract, and then inlined into the deployed bytecode.
+    // In other words, this variable won't change when it's checked at runtime.
+    original = address(this);
+  }
+
+  /// @dev Private method is used instead of inlining into modifier because modifiers are copied into each method,
+  ///     and the use of immutable means the address bytes are copied in every place the modifier is used.
+  function checkNotDelegateCall() private view {
+    require(address(this) == original);
+  }
+
+  /// @notice Prevents delegatecall into the modified method
+  modifier noDelegateCall() {
+    checkNotDelegateCall();
+    _;
+  }
+}

--- a/src/dex/v3/core/interfaces/IERC20Minimal.sol
+++ b/src/dex/v3/core/interfaces/IERC20Minimal.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Minimal ERC20 interface for Lista
+/// @notice Contains a subset of the full ERC20 interface that is used in Lista V3
+interface IERC20Minimal {
+  /// @notice Returns the balance of a token
+  /// @param account The account for which to look up the number of tokens it has, i.e. its balance
+  /// @return The number of tokens held by the account
+  function balanceOf(address account) external view returns (uint256);
+
+  /// @notice Transfers the amount of token from the `msg.sender` to the recipient
+  /// @param recipient The account that will receive the amount transferred
+  /// @param amount The number of tokens to send from the sender to the recipient
+  /// @return Returns true for a successful transfer, false for an unsuccessful transfer
+  function transfer(address recipient, uint256 amount) external returns (bool);
+
+  /// @notice Returns the current allowance given to a spender by an owner
+  /// @param owner The account of the token owner
+  /// @param spender The account of the token spender
+  /// @return The current allowance granted by `owner` to `spender`
+  function allowance(address owner, address spender) external view returns (uint256);
+
+  /// @notice Sets the allowance of a spender from the `msg.sender` to the value `amount`
+  /// @param spender The account which will be allowed to spend a given amount of the owners tokens
+  /// @param amount The amount of tokens allowed to be used by `spender`
+  /// @return Returns true for a successful approval, false for unsuccessful
+  function approve(address spender, uint256 amount) external returns (bool);
+
+  /// @notice Transfers `amount` tokens from `sender` to `recipient` up to the allowance given to the `msg.sender`
+  /// @param sender The account from which the transfer will be initiated
+  /// @param recipient The recipient of the transfer
+  /// @param amount The amount of the transfer
+  /// @return Returns true for a successful transfer, false for unsuccessful
+  function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+  /// @notice Event emitted when tokens are transferred from one address to another, either via `#transfer` or `#transferFrom`.
+  /// @param from The account from which the tokens were sent, i.e. the balance decreased
+  /// @param to The account to which the tokens were sent, i.e. the balance increased
+  /// @param value The amount of tokens that were transferred
+  event Transfer(address indexed from, address indexed to, uint256 value);
+
+  /// @notice Event emitted when the approval amount for the spender of a given owner's tokens changes.
+  /// @param owner The account that approved spending of its tokens
+  /// @param spender The account for which the spending allowance was modified
+  /// @param value The new allowance from the owner to the spender
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/src/dex/v3/core/interfaces/IListaV3Factory.sol
+++ b/src/dex/v3/core/interfaces/IListaV3Factory.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title The interface for the Lista V3 Factory
+/// @notice The Lista V3 Factory facilitates creation of Lista V3 pools and control over the protocol fees
+interface IListaV3Factory {
+  /// @notice Emitted when the owner of the factory is changed
+  /// @param oldOwner The owner before the owner was changed
+  /// @param newOwner The owner after the owner was changed
+  event OwnerChanged(address indexed oldOwner, address indexed newOwner);
+
+  /// @notice Emitted when a pool is created
+  /// @param token0 The first token of the pool by address sort order
+  /// @param token1 The second token of the pool by address sort order
+  /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+  /// @param tickSpacing The minimum number of ticks between initialized ticks
+  /// @param pool The address of the created pool
+  event PoolCreated(
+    address indexed token0,
+    address indexed token1,
+    uint24 indexed fee,
+    int24 tickSpacing,
+    address pool
+  );
+
+  /// @notice Emitted when a new fee amount is enabled for pool creation via the factory
+  /// @param fee The enabled fee, denominated in hundredths of a bip
+  /// @param tickSpacing The minimum number of ticks between initialized ticks for pools created with the given fee
+  event FeeAmountEnabled(uint24 indexed fee, int24 indexed tickSpacing);
+
+  /// @notice Returns the current owner of the factory
+  /// @dev Can be changed by the current owner via setOwner
+  /// @return The address of the factory owner
+  function owner() external view returns (address);
+
+  /// @notice Returns the tick spacing for a given fee amount, if enabled, or 0 if not enabled
+  /// @dev A fee amount can never be removed, so this value should be hard coded or cached in the calling context
+  /// @param fee The enabled fee, denominated in hundredths of a bip. Returns 0 in case of unenabled fee
+  /// @return The tick spacing
+  function feeAmountTickSpacing(uint24 fee) external view returns (int24);
+
+  /// @notice Returns the pool address for a given pair of tokens and a fee, or address 0 if it does not exist
+  /// @dev tokenA and tokenB may be passed in either token0/token1 or token1/token0 order
+  /// @param tokenA The contract address of either token0 or token1
+  /// @param tokenB The contract address of the other token
+  /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+  /// @return pool The pool address
+  function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool);
+
+  /// @notice Creates a pool for the given two tokens and fee
+  /// @param tokenA One of the two tokens in the desired pool
+  /// @param tokenB The other of the two tokens in the desired pool
+  /// @param fee The desired fee for the pool
+  /// @dev tokenA and tokenB may be passed in either order: token0/token1 or token1/token0. tickSpacing is retrieved
+  /// from the fee. The call will revert if the pool already exists, the fee is invalid, or the token arguments
+  /// are invalid.
+  /// @return pool The address of the newly created pool
+  function createPool(address tokenA, address tokenB, uint24 fee) external returns (address pool);
+
+  /// @notice Updates the owner of the factory
+  /// @dev Must be called by the current owner
+  /// @param _owner The new owner of the factory
+  function setOwner(address _owner) external;
+
+  /// @notice Enables a fee amount with the given tickSpacing
+  /// @dev Fee amounts may never be removed once enabled
+  /// @param fee The fee amount to enable, denominated in hundredths of a bip (i.e. 1e-6)
+  /// @param tickSpacing The spacing between ticks to be enforced for all pools created with the given fee amount
+  function enableFeeAmount(uint24 fee, int24 tickSpacing) external;
+}

--- a/src/dex/v3/core/interfaces/IListaV3Pool.sol
+++ b/src/dex/v3/core/interfaces/IListaV3Pool.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import { IListaV3PoolImmutables } from "./pool/IListaV3PoolImmutables.sol";
+import { IListaV3PoolState } from "./pool/IListaV3PoolState.sol";
+import { IListaV3PoolDerivedState } from "./pool/IListaV3PoolDerivedState.sol";
+import { IListaV3PoolActions } from "./pool/IListaV3PoolActions.sol";
+import { IListaV3PoolOwnerActions } from "./pool/IListaV3PoolOwnerActions.sol";
+import { IListaV3PoolErrors } from "./pool/IListaV3PoolErrors.sol";
+import { IListaV3PoolEvents } from "./pool/IListaV3PoolEvents.sol";
+
+/// @title The interface for a Lista V3 Pool
+/// @notice A Lista pool facilitates swapping and automated market making between any two assets that strictly conform
+/// to the ERC20 specification
+/// @dev The pool interface is broken up into many smaller pieces
+interface IListaV3Pool is
+  IListaV3PoolImmutables,
+  IListaV3PoolState,
+  IListaV3PoolDerivedState,
+  IListaV3PoolActions,
+  IListaV3PoolOwnerActions,
+  IListaV3PoolErrors,
+  IListaV3PoolEvents
+{}

--- a/src/dex/v3/core/interfaces/IListaV3PoolDeployer.sol
+++ b/src/dex/v3/core/interfaces/IListaV3PoolDeployer.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title An interface for a contract that is capable of deploying Lista V3 Pools
+/// @notice A contract that constructs a pool must implement this to pass arguments to the pool
+/// @dev This is used to avoid having constructor arguments in the pool contract, which results in the init code hash
+/// of the pool being constant allowing the CREATE2 address of the pool to be cheaply computed on-chain
+interface IListaV3PoolDeployer {
+  /// @notice Get the parameters to be used in constructing the pool, set transiently during pool creation.
+  /// @dev Called by the pool constructor to fetch the parameters of the pool
+  /// Returns factory The factory address
+  /// Returns token0 The first token of the pool by address sort order
+  /// Returns token1 The second token of the pool by address sort order
+  /// Returns fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+  /// Returns tickSpacing The minimum number of ticks between initialized ticks
+  function parameters()
+    external
+    view
+    returns (address factory, address token0, address token1, uint24 fee, int24 tickSpacing);
+}

--- a/src/dex/v3/core/interfaces/callback/IListaV3FlashCallback.sol
+++ b/src/dex/v3/core/interfaces/callback/IListaV3FlashCallback.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Callback for IListaV3PoolActions#flash
+/// @notice Any contract that calls IListaV3PoolActions#flash must implement this interface
+interface IListaV3FlashCallback {
+  /// @notice Called to `msg.sender` after transferring to the recipient from IListaV3Pool#flash.
+  /// @dev In the implementation you must repay the pool the tokens sent by flash plus the computed fee amounts.
+  /// The caller of this method must be checked to be a ListaV3Pool deployed by the canonical ListaV3Factory.
+  /// @param fee0 The fee amount in token0 due to the pool by the end of the flash
+  /// @param fee1 The fee amount in token1 due to the pool by the end of the flash
+  /// @param data Any data passed through by the caller via the IListaV3PoolActions#flash call
+  function listaV3FlashCallback(uint256 fee0, uint256 fee1, bytes calldata data) external;
+}

--- a/src/dex/v3/core/interfaces/callback/IListaV3MintCallback.sol
+++ b/src/dex/v3/core/interfaces/callback/IListaV3MintCallback.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Callback for IListaV3PoolActions#mint
+/// @notice Any contract that calls IListaV3PoolActions#mint must implement this interface
+interface IListaV3MintCallback {
+  /// @notice Called to `msg.sender` after minting liquidity to a position from IListaV3Pool#mint.
+  /// @dev In the implementation you must pay the pool tokens owed for the minted liquidity.
+  /// The caller of this method must be checked to be a ListaV3Pool deployed by the canonical ListaV3Factory.
+  /// @param amount0Owed The amount of token0 due to the pool for the minted liquidity
+  /// @param amount1Owed The amount of token1 due to the pool for the minted liquidity
+  /// @param data Any data passed through by the caller via the IListaV3PoolActions#mint call
+  function listaV3MintCallback(uint256 amount0Owed, uint256 amount1Owed, bytes calldata data) external;
+}

--- a/src/dex/v3/core/interfaces/callback/IListaV3SwapCallback.sol
+++ b/src/dex/v3/core/interfaces/callback/IListaV3SwapCallback.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Callback for IListaV3PoolActions#swap
+/// @notice Any contract that calls IListaV3PoolActions#swap must implement this interface
+interface IListaV3SwapCallback {
+  /// @notice Called to `msg.sender` after executing a swap via IListaV3Pool#swap.
+  /// @dev In the implementation you must pay the pool tokens owed for the swap.
+  /// The caller of this method must be checked to be a ListaV3Pool deployed by the canonical ListaV3Factory.
+  /// amount0Delta and amount1Delta can both be 0 if no tokens were swapped.
+  /// @param amount0Delta The amount of token0 that was sent (negative) or must be received (positive) by the pool by
+  /// the end of the swap. If positive, the callback must send that amount of token0 to the pool.
+  /// @param amount1Delta The amount of token1 that was sent (negative) or must be received (positive) by the pool by
+  /// the end of the swap. If positive, the callback must send that amount of token1 to the pool.
+  /// @param data Any data passed through by the caller via the IListaV3PoolActions#swap call
+  function listaV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external;
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolActions.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolActions.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Permissionless pool actions
+/// @notice Contains pool methods that can be called by anyone
+interface IListaV3PoolActions {
+  /// @notice Sets the initial price for the pool
+  /// @dev Price is represented as a sqrt(amountToken1/amountToken0) Q64.96 value
+  /// @param sqrtPriceX96 the initial sqrt price of the pool as a Q64.96
+  function initialize(uint160 sqrtPriceX96) external;
+
+  /// @notice Adds liquidity for the given recipient/tickLower/tickUpper position
+  /// @dev The caller of this method receives a callback in the form of IListaV3MintCallback#listaV3MintCallback
+  /// in which they must pay any token0 or token1 owed for the liquidity. The amount of token0/token1 due depends
+  /// on tickLower, tickUpper, the amount of liquidity, and the current price.
+  /// @param recipient The address for which the liquidity will be created
+  /// @param tickLower The lower tick of the position in which to add liquidity
+  /// @param tickUpper The upper tick of the position in which to add liquidity
+  /// @param amount The amount of liquidity to mint
+  /// @param data Any data that should be passed through to the callback
+  /// @return amount0 The amount of token0 that was paid to mint the given amount of liquidity. Matches the value in the callback
+  /// @return amount1 The amount of token1 that was paid to mint the given amount of liquidity. Matches the value in the callback
+  function mint(
+    address recipient,
+    int24 tickLower,
+    int24 tickUpper,
+    uint128 amount,
+    bytes calldata data
+  ) external returns (uint256 amount0, uint256 amount1);
+
+  /// @notice Collects tokens owed to a position
+  /// @dev Does not recompute fees earned, which must be done either via mint or burn of any amount of liquidity.
+  /// Collect must be called by the position owner. To withdraw only token0 or only token1, amount0Requested or
+  /// amount1Requested may be set to zero. To withdraw all tokens owed, caller may pass any value greater than the
+  /// actual tokens owed, e.g. type(uint128).max. Tokens owed may be from accumulated swap fees or burned liquidity.
+  /// @param recipient The address which should receive the fees collected
+  /// @param tickLower The lower tick of the position for which to collect fees
+  /// @param tickUpper The upper tick of the position for which to collect fees
+  /// @param amount0Requested How much token0 should be withdrawn from the fees owed
+  /// @param amount1Requested How much token1 should be withdrawn from the fees owed
+  /// @return amount0 The amount of fees collected in token0
+  /// @return amount1 The amount of fees collected in token1
+  function collect(
+    address recipient,
+    int24 tickLower,
+    int24 tickUpper,
+    uint128 amount0Requested,
+    uint128 amount1Requested
+  ) external returns (uint128 amount0, uint128 amount1);
+
+  /// @notice Burn liquidity from the sender and account tokens owed for the liquidity to the position
+  /// @dev Can be used to trigger a recalculation of fees owed to a position by calling with an amount of 0
+  /// @dev Fees must be collected separately via a call to #collect
+  /// @param tickLower The lower tick of the position for which to burn liquidity
+  /// @param tickUpper The upper tick of the position for which to burn liquidity
+  /// @param amount How much liquidity to burn
+  /// @return amount0 The amount of token0 sent to the recipient
+  /// @return amount1 The amount of token1 sent to the recipient
+  function burn(int24 tickLower, int24 tickUpper, uint128 amount) external returns (uint256 amount0, uint256 amount1);
+
+  /// @notice Swap token0 for token1, or token1 for token0
+  /// @dev The caller of this method receives a callback in the form of IListaV3SwapCallback#listaV3SwapCallback
+  /// @param recipient The address to receive the output of the swap
+  /// @param zeroForOne The direction of the swap, true for token0 to token1, false for token1 to token0
+  /// @param amountSpecified The amount of the swap, which implicitly configures the swap as exact input (positive), or exact output (negative)
+  /// @param sqrtPriceLimitX96 The Q64.96 sqrt price limit. If zero for one, the price cannot be less than this
+  /// value after the swap. If one for zero, the price cannot be greater than this value after the swap
+  /// @param data Any data to be passed through to the callback
+  /// @return amount0 The delta of the balance of token0 of the pool, exact when negative, minimum when positive
+  /// @return amount1 The delta of the balance of token1 of the pool, exact when negative, minimum when positive
+  function swap(
+    address recipient,
+    bool zeroForOne,
+    int256 amountSpecified,
+    uint160 sqrtPriceLimitX96,
+    bytes calldata data
+  ) external returns (int256 amount0, int256 amount1);
+
+  /// @notice Receive token0 and/or token1 and pay it back, plus a fee, in the callback
+  /// @dev The caller of this method receives a callback in the form of IListaV3FlashCallback#listaV3FlashCallback
+  /// @dev Can be used to donate underlying tokens pro-rata to currently in-range liquidity providers by calling
+  /// with 0 amount{0,1} and sending the donation amount(s) from the callback
+  /// @param recipient The address which will receive the token0 and token1 amounts
+  /// @param amount0 The amount of token0 to send
+  /// @param amount1 The amount of token1 to send
+  /// @param data Any data to be passed through to the callback
+  function flash(address recipient, uint256 amount0, uint256 amount1, bytes calldata data) external;
+
+  /// @notice Increase the maximum number of price and liquidity observations that this pool will store
+  /// @dev This method is no-op if the pool already has an observationCardinalityNext greater than or equal to
+  /// the input observationCardinalityNext.
+  /// @param observationCardinalityNext The desired minimum number of observations for the pool to store
+  function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external;
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolDerivedState.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolDerivedState.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Pool state that is not stored
+/// @notice Contains view functions to provide information about the pool that is computed rather than stored on the
+/// blockchain. The functions here may have variable gas costs.
+interface IListaV3PoolDerivedState {
+  /// @notice Returns the cumulative tick and liquidity as of each timestamp `secondsAgo` from the current block timestamp
+  /// @dev To get a time weighted average tick or liquidity-in-range, you must call this with two values, one representing
+  /// the beginning of the period and another for the end of the period. E.g., to get the last hour time-weighted average tick,
+  /// you must call it with secondsAgos = [3600, 0].
+  /// @dev The time weighted average tick represents the geometric time weighted average price of the pool, in
+  /// log base sqrt(1.0001) of token1 / token0. The TickMath library can be used to go from a tick value to a ratio.
+  /// @param secondsAgos From how long ago each cumulative tick and liquidity value should be returned
+  /// @return tickCumulatives Cumulative tick values as of each `secondsAgos` from the current block timestamp
+  /// @return secondsPerLiquidityCumulativeX128s Cumulative seconds per liquidity-in-range value as of each `secondsAgos` from the current block
+  /// timestamp
+  function observe(
+    uint32[] calldata secondsAgos
+  ) external view returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s);
+
+  /// @notice Returns a snapshot of the tick cumulative, seconds per liquidity and seconds inside a tick range
+  /// @dev Snapshots must only be compared to other snapshots, taken over a period for which a position existed.
+  /// I.e., snapshots cannot be compared if a position is not held for the entire period between when the first
+  /// snapshot is taken and the second snapshot is taken.
+  /// @param tickLower The lower tick of the range
+  /// @param tickUpper The upper tick of the range
+  /// @return tickCumulativeInside The snapshot of the tick accumulator for the range
+  /// @return secondsPerLiquidityInsideX128 The snapshot of seconds per liquidity for the range
+  /// @return secondsInside The snapshot of seconds per liquidity for the range
+  function snapshotCumulativesInside(
+    int24 tickLower,
+    int24 tickUpper
+  ) external view returns (int56 tickCumulativeInside, uint160 secondsPerLiquidityInsideX128, uint32 secondsInside);
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolErrors.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolErrors.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Errors emitted by a pool
+/// @notice Contains all events emitted by the pool
+interface IListaV3PoolErrors {
+  error LOK();
+  error TLU();
+  error TLM();
+  error TUM();
+  error AI();
+  error M0();
+  error M1();
+  error AS();
+  error IIA();
+  error L();
+  error F0();
+  error F1();
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolEvents.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolEvents.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Events emitted by a pool
+/// @notice Contains all events emitted by the pool
+interface IListaV3PoolEvents {
+  /// @notice Emitted exactly once by a pool when #initialize is first called on the pool
+  /// @dev Mint/Burn/Swap cannot be emitted by the pool before Initialize
+  /// @param sqrtPriceX96 The initial sqrt price of the pool, as a Q64.96
+  /// @param tick The initial tick of the pool, i.e. log base 1.0001 of the starting price of the pool
+  event Initialize(uint160 sqrtPriceX96, int24 tick);
+
+  /// @notice Emitted when liquidity is minted for a given position
+  /// @param sender The address that minted the liquidity
+  /// @param owner The owner of the position and recipient of any minted liquidity
+  /// @param tickLower The lower tick of the position
+  /// @param tickUpper The upper tick of the position
+  /// @param amount The amount of liquidity minted to the position range
+  /// @param amount0 How much token0 was required for the minted liquidity
+  /// @param amount1 How much token1 was required for the minted liquidity
+  event Mint(
+    address sender,
+    address indexed owner,
+    int24 indexed tickLower,
+    int24 indexed tickUpper,
+    uint128 amount,
+    uint256 amount0,
+    uint256 amount1
+  );
+
+  /// @notice Emitted when fees are collected by the owner of a position
+  /// @dev Collect events may be emitted with zero amount0 and amount1 when the caller chooses not to collect fees
+  /// @param owner The owner of the position for which fees are collected
+  /// @param tickLower The lower tick of the position
+  /// @param tickUpper The upper tick of the position
+  /// @param amount0 The amount of token0 fees collected
+  /// @param amount1 The amount of token1 fees collected
+  event Collect(
+    address indexed owner,
+    address recipient,
+    int24 indexed tickLower,
+    int24 indexed tickUpper,
+    uint128 amount0,
+    uint128 amount1
+  );
+
+  /// @notice Emitted when a position's liquidity is removed
+  /// @dev Does not withdraw any fees earned by the liquidity position, which must be withdrawn via #collect
+  /// @param owner The owner of the position for which liquidity is removed
+  /// @param tickLower The lower tick of the position
+  /// @param tickUpper The upper tick of the position
+  /// @param amount The amount of liquidity to remove
+  /// @param amount0 The amount of token0 withdrawn
+  /// @param amount1 The amount of token1 withdrawn
+  event Burn(
+    address indexed owner,
+    int24 indexed tickLower,
+    int24 indexed tickUpper,
+    uint128 amount,
+    uint256 amount0,
+    uint256 amount1
+  );
+
+  /// @notice Emitted by the pool for any swaps between token0 and token1
+  /// @param sender The address that initiated the swap call, and that received the callback
+  /// @param recipient The address that received the output of the swap
+  /// @param amount0 The delta of the token0 balance of the pool
+  /// @param amount1 The delta of the token1 balance of the pool
+  /// @param sqrtPriceX96 The sqrt(price) of the pool after the swap, as a Q64.96
+  /// @param liquidity The liquidity of the pool after the swap
+  /// @param tick The log base 1.0001 of price of the pool after the swap
+  event Swap(
+    address indexed sender,
+    address indexed recipient,
+    int256 amount0,
+    int256 amount1,
+    uint160 sqrtPriceX96,
+    uint128 liquidity,
+    int24 tick
+  );
+
+  /// @notice Emitted by the pool for any flashes of token0/token1
+  /// @param sender The address that initiated the swap call, and that received the callback
+  /// @param recipient The address that received the tokens from flash
+  /// @param amount0 The amount of token0 that was flashed
+  /// @param amount1 The amount of token1 that was flashed
+  /// @param paid0 The amount of token0 paid for the flash, which can exceed the amount0 plus the fee
+  /// @param paid1 The amount of token1 paid for the flash, which can exceed the amount1 plus the fee
+  event Flash(
+    address indexed sender,
+    address indexed recipient,
+    uint256 amount0,
+    uint256 amount1,
+    uint256 paid0,
+    uint256 paid1
+  );
+
+  /// @notice Emitted by the pool for increases to the number of observations that can be stored
+  /// @dev observationCardinalityNext is not the observation cardinality until an observation is written at the index
+  /// just before a mint/swap/burn.
+  /// @param observationCardinalityNextOld The previous value of the next observation cardinality
+  /// @param observationCardinalityNextNew The updated value of the next observation cardinality
+  event IncreaseObservationCardinalityNext(uint16 observationCardinalityNextOld, uint16 observationCardinalityNextNew);
+
+  /// @notice Emitted when the protocol fee is changed by the pool
+  /// @param feeProtocol0Old The previous value of the token0 protocol fee
+  /// @param feeProtocol1Old The previous value of the token1 protocol fee
+  /// @param feeProtocol0New The updated value of the token0 protocol fee
+  /// @param feeProtocol1New The updated value of the token1 protocol fee
+  event SetFeeProtocol(uint8 feeProtocol0Old, uint8 feeProtocol1Old, uint8 feeProtocol0New, uint8 feeProtocol1New);
+
+  /// @notice Emitted when the collected protocol fees are withdrawn by the factory owner
+  /// @param sender The address that collects the protocol fees
+  /// @param recipient The address that receives the collected protocol fees
+  /// @param amount0 The amount of token0 protocol fees that is withdrawn
+  /// @param amount0 The amount of token1 protocol fees that is withdrawn
+  event CollectProtocol(address indexed sender, address indexed recipient, uint128 amount0, uint128 amount1);
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolImmutables.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolImmutables.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Pool state that never changes
+/// @notice These parameters are fixed for a pool forever, i.e., the methods will always return the same values
+interface IListaV3PoolImmutables {
+  /// @notice The contract that deployed the pool, which must adhere to the IListaV3Factory interface
+  /// @return The contract address
+  function factory() external view returns (address);
+
+  /// @notice The first of the two tokens of the pool, sorted by address
+  /// @return The token contract address
+  function token0() external view returns (address);
+
+  /// @notice The second of the two tokens of the pool, sorted by address
+  /// @return The token contract address
+  function token1() external view returns (address);
+
+  /// @notice The pool's fee in hundredths of a bip, i.e. 1e-6
+  /// @return The fee
+  function fee() external view returns (uint24);
+
+  /// @notice The pool tick spacing
+  /// @dev Ticks can only be used at multiples of this value, minimum of 1 and always positive
+  /// e.g.: a tickSpacing of 3 means ticks can be initialized every 3rd tick, i.e., ..., -6, -3, 0, 3, 6, ...
+  /// This value is an int24 to avoid casting even though it is always positive.
+  /// @return The tick spacing
+  function tickSpacing() external view returns (int24);
+
+  /// @notice The maximum amount of position liquidity that can use any tick in the range
+  /// @dev This parameter is enforced per tick to prevent liquidity from overflowing a uint128 at any point, and
+  /// also prevents out-of-range liquidity from being used to prevent adding in-range liquidity to a pool
+  /// @return The max amount of liquidity per tick
+  function maxLiquidityPerTick() external view returns (uint128);
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolOwnerActions.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolOwnerActions.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Permissioned pool actions
+/// @notice Contains pool methods that may only be called by the factory owner
+interface IListaV3PoolOwnerActions {
+  /// @notice Set the denominator of the protocol's % share of the fees
+  /// @param feeProtocol0 new protocol fee for token0 of the pool
+  /// @param feeProtocol1 new protocol fee for token1 of the pool
+  function setFeeProtocol(uint8 feeProtocol0, uint8 feeProtocol1) external;
+
+  /// @notice Collect the protocol fee accrued to the pool
+  /// @param recipient The address to which collected protocol fees should be sent
+  /// @param amount0Requested The maximum amount of token0 to send, can be 0 to collect fees in only token1
+  /// @param amount1Requested The maximum amount of token1 to send, can be 0 to collect fees in only token0
+  /// @return amount0 The protocol fee collected in token0
+  /// @return amount1 The protocol fee collected in token1
+  function collectProtocol(
+    address recipient,
+    uint128 amount0Requested,
+    uint128 amount1Requested
+  ) external returns (uint128 amount0, uint128 amount1);
+}

--- a/src/dex/v3/core/interfaces/pool/IListaV3PoolState.sol
+++ b/src/dex/v3/core/interfaces/pool/IListaV3PoolState.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Pool state that can change
+/// @notice These methods compose the pool's state, and can change with any frequency including multiple times
+/// per transaction
+interface IListaV3PoolState {
+  /// @notice The 0th storage slot in the pool stores many values, and is exposed as a single method to save gas
+  /// when accessed externally.
+  /// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
+  /// @return tick The current tick of the pool, i.e. according to the last tick transition that was run.
+  /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
+  /// boundary.
+  /// @return observationIndex The index of the last oracle observation that was written,
+  /// @return observationCardinality The current maximum number of observations stored in the pool,
+  /// @return observationCardinalityNext The next maximum number of observations, to be updated when the observation.
+  /// @return feeProtocol The protocol fee for both tokens of the pool.
+  /// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
+  /// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.
+  /// unlocked Whether the pool is currently locked to reentrancy
+  function slot0()
+    external
+    view
+    returns (
+      uint160 sqrtPriceX96,
+      int24 tick,
+      uint16 observationIndex,
+      uint16 observationCardinality,
+      uint16 observationCardinalityNext,
+      uint8 feeProtocol,
+      bool unlocked
+    );
+
+  /// @notice The fee growth as a Q128.128 fees of token0 collected per unit of liquidity for the entire life of the pool
+  /// @dev This value can overflow the uint256
+  function feeGrowthGlobal0X128() external view returns (uint256);
+
+  /// @notice The fee growth as a Q128.128 fees of token1 collected per unit of liquidity for the entire life of the pool
+  /// @dev This value can overflow the uint256
+  function feeGrowthGlobal1X128() external view returns (uint256);
+
+  /// @notice The amounts of token0 and token1 that are owed to the protocol
+  /// @dev Protocol fees will never exceed uint128 max in either token
+  function protocolFees() external view returns (uint128 token0, uint128 token1);
+
+  /// @notice The currently in range liquidity available to the pool
+  /// @dev This value has no relationship to the total liquidity across all ticks
+  /// @return The liquidity at the current price of the pool
+  function liquidity() external view returns (uint128);
+
+  /// @notice Look up information about a specific tick in the pool
+  /// @param tick The tick to look up
+  /// @return liquidityGross the total amount of position liquidity that uses the pool either as tick lower or
+  /// tick upper
+  /// @return liquidityNet how much liquidity changes when the pool price crosses the tick,
+  /// @return feeGrowthOutside0X128 the fee growth on the other side of the tick from the current tick in token0,
+  /// @return feeGrowthOutside1X128 the fee growth on the other side of the tick from the current tick in token1,
+  /// @return tickCumulativeOutside the cumulative tick value on the other side of the tick from the current tick
+  /// @return secondsPerLiquidityOutsideX128 the seconds spent per liquidity on the other side of the tick from the current tick,
+  /// @return secondsOutside the seconds spent on the other side of the tick from the current tick,
+  /// @return initialized Set to true if the tick is initialized, i.e. liquidityGross is greater than 0, otherwise equal to false.
+  /// Outside values can only be used if the tick is initialized, i.e. if liquidityGross is greater than 0.
+  /// In addition, these values are only relative and must be used only in comparison to previous snapshots for
+  /// a specific position.
+  function ticks(
+    int24 tick
+  )
+    external
+    view
+    returns (
+      uint128 liquidityGross,
+      int128 liquidityNet,
+      uint256 feeGrowthOutside0X128,
+      uint256 feeGrowthOutside1X128,
+      int56 tickCumulativeOutside,
+      uint160 secondsPerLiquidityOutsideX128,
+      uint32 secondsOutside,
+      bool initialized
+    );
+
+  /// @notice Returns 256 packed tick initialized boolean values. See TickBitmap for more information
+  function tickBitmap(int16 wordPosition) external view returns (uint256);
+
+  /// @notice Returns the information about a position by the position's key
+  /// @param key The position's key is a hash of a preimage composed by the owner, tickLower and tickUpper
+  /// @return liquidity The amount of liquidity in the position,
+  /// @return feeGrowthInside0LastX128 fee growth of token0 inside the tick range as of the last mint/burn/poke,
+  /// @return feeGrowthInside1LastX128 fee growth of token1 inside the tick range as of the last mint/burn/poke,
+  /// @return tokensOwed0 the computed amount of token0 owed to the position as of the last mint/burn/poke,
+  /// @return tokensOwed1 the computed amount of token1 owed to the position as of the last mint/burn/poke
+  function positions(
+    bytes32 key
+  )
+    external
+    view
+    returns (
+      uint128 liquidity,
+      uint256 feeGrowthInside0LastX128,
+      uint256 feeGrowthInside1LastX128,
+      uint128 tokensOwed0,
+      uint128 tokensOwed1
+    );
+
+  /// @notice Returns data about a specific observation index
+  /// @param index The element of the observations array to fetch
+  /// @dev You most likely want to use #observe() instead of this method to get an observation as of some amount of time
+  /// ago, rather than at a specific index in the array.
+  /// @return blockTimestamp The timestamp of the observation,
+  /// @return tickCumulative the tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp,
+  /// @return secondsPerLiquidityCumulativeX128 the seconds per in range liquidity for the life of the pool as of the observation timestamp,
+  /// @return initialized whether the observation has been initialized and the values are safe to use
+  function observations(
+    uint256 index
+  )
+    external
+    view
+    returns (uint32 blockTimestamp, int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128, bool initialized);
+}

--- a/src/dex/v3/core/libraries/BitMath.sol
+++ b/src/dex/v3/core/libraries/BitMath.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+/// @title BitMath
+/// @dev This library provides functionality for computing bit properties of an unsigned integer
+library BitMath {
+  /// @notice Returns the index of the most significant bit of the number,
+  ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+  /// @dev The function satisfies the property:
+  ///     x >= 2**mostSignificantBit(x) and x < 2**(mostSignificantBit(x)+1)
+  /// @param x the value for which to compute the most significant bit, must be greater than 0
+  /// @return r the index of the most significant bit
+  function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
+    require(x > 0);
+
+    unchecked {
+      if (x >= 0x100000000000000000000000000000000) {
+        x >>= 128;
+        r += 128;
+      }
+      if (x >= 0x10000000000000000) {
+        x >>= 64;
+        r += 64;
+      }
+      if (x >= 0x100000000) {
+        x >>= 32;
+        r += 32;
+      }
+      if (x >= 0x10000) {
+        x >>= 16;
+        r += 16;
+      }
+      if (x >= 0x100) {
+        x >>= 8;
+        r += 8;
+      }
+      if (x >= 0x10) {
+        x >>= 4;
+        r += 4;
+      }
+      if (x >= 0x4) {
+        x >>= 2;
+        r += 2;
+      }
+      if (x >= 0x2) r += 1;
+    }
+  }
+
+  /// @notice Returns the index of the least significant bit of the number,
+  ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+  /// @dev The function satisfies the property:
+  ///     (x & 2**leastSignificantBit(x)) != 0 and (x & (2**(leastSignificantBit(x)) - 1)) == 0)
+  /// @param x the value for which to compute the least significant bit, must be greater than 0
+  /// @return r the index of the least significant bit
+  function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
+    require(x > 0);
+
+    unchecked {
+      r = 255;
+      if (x & type(uint128).max > 0) {
+        r -= 128;
+      } else {
+        x >>= 128;
+      }
+      if (x & type(uint64).max > 0) {
+        r -= 64;
+      } else {
+        x >>= 64;
+      }
+      if (x & type(uint32).max > 0) {
+        r -= 32;
+      } else {
+        x >>= 32;
+      }
+      if (x & type(uint16).max > 0) {
+        r -= 16;
+      } else {
+        x >>= 16;
+      }
+      if (x & type(uint8).max > 0) {
+        r -= 8;
+      } else {
+        x >>= 8;
+      }
+      if (x & 0xf > 0) {
+        r -= 4;
+      } else {
+        x >>= 4;
+      }
+      if (x & 0x3 > 0) {
+        r -= 2;
+      } else {
+        x >>= 2;
+      }
+      if (x & 0x1 > 0) r -= 1;
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/FixedPoint128.sol
+++ b/src/dex/v3/core/libraries/FixedPoint128.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.4.0;
+
+/// @title FixedPoint128
+/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
+library FixedPoint128 {
+  uint256 internal constant Q128 = 0x100000000000000000000000000000000;
+}

--- a/src/dex/v3/core/libraries/FixedPoint96.sol
+++ b/src/dex/v3/core/libraries/FixedPoint96.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.4.0;
+
+/// @title FixedPoint96
+/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
+/// @dev Used in SqrtPriceMath.sol
+library FixedPoint96 {
+  uint8 internal constant RESOLUTION = 96;
+  uint256 internal constant Q96 = 0x1000000000000000000000000;
+}

--- a/src/dex/v3/core/libraries/FullMath.sol
+++ b/src/dex/v3/core/libraries/FullMath.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+/// @title Contains 512-bit math functions
+/// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
+/// @dev Handles "phantom overflow" i.e., allows multiplication and division where an intermediate value overflows 256 bits
+library FullMath {
+  /// @notice Calculates floor(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+  /// @param a The multiplicand
+  /// @param b The multiplier
+  /// @param denominator The divisor
+  /// @return result The 256-bit result
+  /// @dev Credit to Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv
+  function mulDiv(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
+    unchecked {
+      // 512-bit multiply [prod1 prod0] = a * b
+      // Compute the product mod 2**256 and mod 2**256 - 1
+      // then use the Chinese Remainder Theorem to reconstruct
+      // the 512 bit result. The result is stored in two 256
+      // variables such that product = prod1 * 2**256 + prod0
+      uint256 prod0; // Least significant 256 bits of the product
+      uint256 prod1; // Most significant 256 bits of the product
+      assembly {
+        let mm := mulmod(a, b, not(0))
+        prod0 := mul(a, b)
+        prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+      }
+
+      // Handle non-overflow cases, 256 by 256 division
+      if (prod1 == 0) {
+        require(denominator > 0);
+        assembly {
+          result := div(prod0, denominator)
+        }
+        return result;
+      }
+
+      // Make sure the result is less than 2**256.
+      // Also prevents denominator == 0
+      require(denominator > prod1);
+
+      ///////////////////////////////////////////////
+      // 512 by 256 division.
+      ///////////////////////////////////////////////
+
+      // Make division exact by subtracting the remainder from [prod1 prod0]
+      // Compute remainder using mulmod
+      uint256 remainder;
+      assembly {
+        remainder := mulmod(a, b, denominator)
+      }
+      // Subtract 256 bit number from 512 bit number
+      assembly {
+        prod1 := sub(prod1, gt(remainder, prod0))
+        prod0 := sub(prod0, remainder)
+      }
+
+      // Factor powers of two out of denominator
+      // Compute largest power of two divisor of denominator.
+      // Always >= 1.
+      uint256 twos = (0 - denominator) & denominator;
+      // Divide denominator by power of two
+      assembly {
+        denominator := div(denominator, twos)
+      }
+
+      // Divide [prod1 prod0] by the factors of two
+      assembly {
+        prod0 := div(prod0, twos)
+      }
+      // Shift in bits from prod1 into prod0. For this we need
+      // to flip `twos` such that it is 2**256 / twos.
+      // If twos is zero, then it becomes one
+      assembly {
+        twos := add(div(sub(0, twos), twos), 1)
+      }
+      prod0 |= prod1 * twos;
+
+      // Invert denominator mod 2**256
+      // Now that denominator is an odd number, it has an inverse
+      // modulo 2**256 such that denominator * inv = 1 mod 2**256.
+      // Compute the inverse by starting with a seed that is correct
+      // correct for four bits. That is, denominator * inv = 1 mod 2**4
+      uint256 inv = (3 * denominator) ^ 2;
+      // Now use Newton-Raphson iteration to improve the precision.
+      // Thanks to Hensel's lifting lemma, this also works in modular
+      // arithmetic, doubling the correct bits in each step.
+      inv *= 2 - denominator * inv; // inverse mod 2**8
+      inv *= 2 - denominator * inv; // inverse mod 2**16
+      inv *= 2 - denominator * inv; // inverse mod 2**32
+      inv *= 2 - denominator * inv; // inverse mod 2**64
+      inv *= 2 - denominator * inv; // inverse mod 2**128
+      inv *= 2 - denominator * inv; // inverse mod 2**256
+
+      // Because the division is now exact we can divide by multiplying
+      // with the modular inverse of denominator. This will give us the
+      // correct result modulo 2**256. Since the precoditions guarantee
+      // that the outcome is less than 2**256, this is the final result.
+      // We don't need to compute the high bits of the result and prod1
+      // is no longer required.
+      result = prod0 * inv;
+      return result;
+    }
+  }
+
+  /// @notice Calculates ceil(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+  /// @param a The multiplicand
+  /// @param b The multiplier
+  /// @param denominator The divisor
+  /// @return result The 256-bit result
+  function mulDivRoundingUp(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
+    unchecked {
+      result = mulDiv(a, b, denominator);
+      if (mulmod(a, b, denominator) > 0) {
+        require(result < type(uint256).max);
+        result++;
+      }
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/Oracle.sol
+++ b/src/dex/v3/core/libraries/Oracle.sol
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+/// @title Oracle
+/// @notice Provides price and liquidity data useful for a wide variety of system designs
+/// @dev Instances of stored oracle data, "observations", are collected in the oracle array
+/// Every pool is initialized with an oracle array length of 1. Anyone can pay the SSTOREs to increase the
+/// maximum length of the oracle array. New slots will be added when the array is fully populated.
+/// Observations are overwritten when the full length of the oracle array is populated.
+/// The most recent observation is available, independent of the length of the oracle array, by passing 0 to observe()
+library Oracle {
+  error I();
+  error OLD();
+
+  struct Observation {
+    // the block timestamp of the observation
+    uint32 blockTimestamp;
+    // the tick accumulator, i.e. tick * time elapsed since the pool was first initialized
+    int56 tickCumulative;
+    // the seconds per liquidity, i.e. seconds elapsed / max(1, liquidity) since the pool was first initialized
+    uint160 secondsPerLiquidityCumulativeX128;
+    // whether or not the observation is initialized
+    bool initialized;
+  }
+
+  /// @notice Transforms a previous observation into a new observation, given the passage of time and the current tick and liquidity values
+  /// @dev blockTimestamp _must_ be chronologically equal to or greater than last.blockTimestamp, safe for 0 or 1 overflows
+  /// @param last The specified observation to be transformed
+  /// @param blockTimestamp The timestamp of the new observation
+  /// @param tick The active tick at the time of the new observation
+  /// @param liquidity The total in-range liquidity at the time of the new observation
+  /// @return Observation The newly populated observation
+  function transform(
+    Observation memory last,
+    uint32 blockTimestamp,
+    int24 tick,
+    uint128 liquidity
+  ) private pure returns (Observation memory) {
+    unchecked {
+      uint32 delta = blockTimestamp - last.blockTimestamp;
+      return
+        Observation({
+          blockTimestamp: blockTimestamp,
+          tickCumulative: last.tickCumulative + int56(tick) * int56(uint56(delta)),
+          secondsPerLiquidityCumulativeX128: last.secondsPerLiquidityCumulativeX128 +
+            ((uint160(delta) << 128) / (liquidity > 0 ? liquidity : 1)),
+          initialized: true
+        });
+    }
+  }
+
+  /// @notice Initialize the oracle array by writing the first slot. Called once for the lifecycle of the observations array
+  /// @param self The stored oracle array
+  /// @param time The time of the oracle initialization, via block.timestamp truncated to uint32
+  /// @return cardinality The number of populated elements in the oracle array
+  /// @return cardinalityNext The new length of the oracle array, independent of population
+  function initialize(
+    Observation[65535] storage self,
+    uint32 time
+  ) internal returns (uint16 cardinality, uint16 cardinalityNext) {
+    self[0] = Observation({
+      blockTimestamp: time,
+      tickCumulative: 0,
+      secondsPerLiquidityCumulativeX128: 0,
+      initialized: true
+    });
+    return (1, 1);
+  }
+
+  /// @notice Writes an oracle observation to the array
+  /// @dev Writable at most once per block. Index represents the most recently written element. cardinality and index must be tracked externally.
+  /// If the index is at the end of the allowable array length (according to cardinality), and the next cardinality
+  /// is greater than the current one, cardinality may be increased. This restriction is created to preserve ordering.
+  /// @param self The stored oracle array
+  /// @param index The index of the observation that was most recently written to the observations array
+  /// @param blockTimestamp The timestamp of the new observation
+  /// @param tick The active tick at the time of the new observation
+  /// @param liquidity The total in-range liquidity at the time of the new observation
+  /// @param cardinality The number of populated elements in the oracle array
+  /// @param cardinalityNext The new length of the oracle array, independent of population
+  /// @return indexUpdated The new index of the most recently written element in the oracle array
+  /// @return cardinalityUpdated The new cardinality of the oracle array
+  function write(
+    Observation[65535] storage self,
+    uint16 index,
+    uint32 blockTimestamp,
+    int24 tick,
+    uint128 liquidity,
+    uint16 cardinality,
+    uint16 cardinalityNext
+  ) internal returns (uint16 indexUpdated, uint16 cardinalityUpdated) {
+    unchecked {
+      Observation memory last = self[index];
+
+      // early return if we've already written an observation this block
+      if (last.blockTimestamp == blockTimestamp) return (index, cardinality);
+
+      // if the conditions are right, we can bump the cardinality
+      if (cardinalityNext > cardinality && index == (cardinality - 1)) {
+        cardinalityUpdated = cardinalityNext;
+      } else {
+        cardinalityUpdated = cardinality;
+      }
+
+      indexUpdated = (index + 1) % cardinalityUpdated;
+      self[indexUpdated] = transform(last, blockTimestamp, tick, liquidity);
+    }
+  }
+
+  /// @notice Prepares the oracle array to store up to `next` observations
+  /// @param self The stored oracle array
+  /// @param current The current next cardinality of the oracle array
+  /// @param next The proposed next cardinality which will be populated in the oracle array
+  /// @return next The next cardinality which will be populated in the oracle array
+  function grow(Observation[65535] storage self, uint16 current, uint16 next) internal returns (uint16) {
+    unchecked {
+      if (current <= 0) revert I();
+      // no-op if the passed next value isn't greater than the current next value
+      if (next <= current) return current;
+      // store in each slot to prevent fresh SSTOREs in swaps
+      // this data will not be used because the initialized boolean is still false
+      for (uint16 i = current; i < next; i++) self[i].blockTimestamp = 1;
+      return next;
+    }
+  }
+
+  /// @notice comparator for 32-bit timestamps
+  /// @dev safe for 0 or 1 overflows, a and b _must_ be chronologically before or equal to time
+  /// @param time A timestamp truncated to 32 bits
+  /// @param a A comparison timestamp from which to determine the relative position of `time`
+  /// @param b From which to determine the relative position of `time`
+  /// @return Whether `a` is chronologically <= `b`
+  function lte(uint32 time, uint32 a, uint32 b) private pure returns (bool) {
+    unchecked {
+      // if there hasn't been overflow, no need to adjust
+      if (a <= time && b <= time) return a <= b;
+
+      uint256 aAdjusted = a > time ? a : a + 2 ** 32;
+      uint256 bAdjusted = b > time ? b : b + 2 ** 32;
+
+      return aAdjusted <= bAdjusted;
+    }
+  }
+
+  /// @notice Fetches the observations beforeOrAt and atOrAfter a target, i.e. where [beforeOrAt, atOrAfter] is satisfied.
+  /// The result may be the same observation, or adjacent observations.
+  /// @dev The answer must be contained in the array, used when the target is located within the stored observation
+  /// boundaries: older than the most recent observation and younger, or the same age as, the oldest observation
+  /// @param self The stored oracle array
+  /// @param time The current block.timestamp
+  /// @param target The timestamp at which the reserved observation should be for
+  /// @param index The index of the observation that was most recently written to the observations array
+  /// @param cardinality The number of populated elements in the oracle array
+  /// @return beforeOrAt The observation recorded before, or at, the target
+  /// @return atOrAfter The observation recorded at, or after, the target
+  function binarySearch(
+    Observation[65535] storage self,
+    uint32 time,
+    uint32 target,
+    uint16 index,
+    uint16 cardinality
+  ) private view returns (Observation memory beforeOrAt, Observation memory atOrAfter) {
+    unchecked {
+      uint256 l = (index + 1) % cardinality; // oldest observation
+      uint256 r = l + cardinality - 1; // newest observation
+      uint256 i;
+      while (true) {
+        i = (l + r) / 2;
+
+        beforeOrAt = self[i % cardinality];
+
+        // we've landed on an uninitialized tick, keep searching higher (more recently)
+        if (!beforeOrAt.initialized) {
+          l = i + 1;
+          continue;
+        }
+
+        atOrAfter = self[(i + 1) % cardinality];
+
+        bool targetAtOrAfter = lte(time, beforeOrAt.blockTimestamp, target);
+
+        // check if we've found the answer!
+        if (targetAtOrAfter && lte(time, target, atOrAfter.blockTimestamp)) break;
+
+        if (!targetAtOrAfter) r = i - 1;
+        else l = i + 1;
+      }
+    }
+  }
+
+  /// @notice Fetches the observations beforeOrAt and atOrAfter a given target, i.e. where [beforeOrAt, atOrAfter] is satisfied
+  /// @dev Assumes there is at least 1 initialized observation.
+  /// Used by observeSingle() to compute the counterfactual accumulator values as of a given block timestamp.
+  /// @param self The stored oracle array
+  /// @param time The current block.timestamp
+  /// @param target The timestamp at which the reserved observation should be for
+  /// @param tick The active tick at the time of the returned or simulated observation
+  /// @param index The index of the observation that was most recently written to the observations array
+  /// @param liquidity The total pool liquidity at the time of the call
+  /// @param cardinality The number of populated elements in the oracle array
+  /// @return beforeOrAt The observation which occurred at, or before, the given timestamp
+  /// @return atOrAfter The observation which occurred at, or after, the given timestamp
+  function getSurroundingObservations(
+    Observation[65535] storage self,
+    uint32 time,
+    uint32 target,
+    int24 tick,
+    uint16 index,
+    uint128 liquidity,
+    uint16 cardinality
+  ) private view returns (Observation memory beforeOrAt, Observation memory atOrAfter) {
+    unchecked {
+      // optimistically set before to the newest observation
+      beforeOrAt = self[index];
+
+      // if the target is chronologically at or after the newest observation, we can early return
+      if (lte(time, beforeOrAt.blockTimestamp, target)) {
+        if (beforeOrAt.blockTimestamp == target) {
+          // if newest observation equals target, we're in the same block, so we can ignore atOrAfter
+          return (beforeOrAt, atOrAfter);
+        } else {
+          // otherwise, we need to transform
+          return (beforeOrAt, transform(beforeOrAt, target, tick, liquidity));
+        }
+      }
+
+      // now, set before to the oldest observation
+      beforeOrAt = self[(index + 1) % cardinality];
+      if (!beforeOrAt.initialized) beforeOrAt = self[0];
+
+      // ensure that the target is chronologically at or after the oldest observation
+      if (!lte(time, beforeOrAt.blockTimestamp, target)) revert OLD();
+
+      // if we've reached this point, we have to binary search
+      return binarySearch(self, time, target, index, cardinality);
+    }
+  }
+
+  /// @dev Reverts if an observation at or before the desired observation timestamp does not exist.
+  /// 0 may be passed as `secondsAgo' to return the current cumulative values.
+  /// If called with a timestamp falling between two observations, returns the counterfactual accumulator values
+  /// at exactly the timestamp between the two observations.
+  /// @param self The stored oracle array
+  /// @param time The current block timestamp
+  /// @param secondsAgo The amount of time to look back, in seconds, at which point to return an observation
+  /// @param tick The current tick
+  /// @param index The index of the observation that was most recently written to the observations array
+  /// @param liquidity The current in-range pool liquidity
+  /// @param cardinality The number of populated elements in the oracle array
+  /// @return tickCumulative The tick * time elapsed since the pool was first initialized, as of `secondsAgo`
+  /// @return secondsPerLiquidityCumulativeX128 The time elapsed / max(1, liquidity) since the pool was first initialized, as of `secondsAgo`
+  function observeSingle(
+    Observation[65535] storage self,
+    uint32 time,
+    uint32 secondsAgo,
+    int24 tick,
+    uint16 index,
+    uint128 liquidity,
+    uint16 cardinality
+  ) internal view returns (int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128) {
+    unchecked {
+      if (secondsAgo == 0) {
+        Observation memory last = self[index];
+        if (last.blockTimestamp != time) last = transform(last, time, tick, liquidity);
+        return (last.tickCumulative, last.secondsPerLiquidityCumulativeX128);
+      }
+
+      uint32 target = time - secondsAgo;
+
+      (Observation memory beforeOrAt, Observation memory atOrAfter) = getSurroundingObservations(
+        self,
+        time,
+        target,
+        tick,
+        index,
+        liquidity,
+        cardinality
+      );
+
+      if (target == beforeOrAt.blockTimestamp) {
+        // we're at the left boundary
+        return (beforeOrAt.tickCumulative, beforeOrAt.secondsPerLiquidityCumulativeX128);
+      } else if (target == atOrAfter.blockTimestamp) {
+        // we're at the right boundary
+        return (atOrAfter.tickCumulative, atOrAfter.secondsPerLiquidityCumulativeX128);
+      } else {
+        // we're in the middle
+        uint32 observationTimeDelta = atOrAfter.blockTimestamp - beforeOrAt.blockTimestamp;
+        uint32 targetDelta = target - beforeOrAt.blockTimestamp;
+        return (
+          beforeOrAt.tickCumulative +
+            ((atOrAfter.tickCumulative - beforeOrAt.tickCumulative) / int56(uint56(observationTimeDelta))) *
+            int56(uint56(targetDelta)),
+          beforeOrAt.secondsPerLiquidityCumulativeX128 +
+            uint160(
+              (uint256(atOrAfter.secondsPerLiquidityCumulativeX128 - beforeOrAt.secondsPerLiquidityCumulativeX128) *
+                targetDelta) / observationTimeDelta
+            )
+        );
+      }
+    }
+  }
+
+  /// @notice Returns the accumulator values as of each time seconds ago from the given time in the array of `secondsAgos`
+  /// @dev Reverts if `secondsAgos` > oldest observation
+  /// @param self The stored oracle array
+  /// @param time The current block.timestamp
+  /// @param secondsAgos Each amount of time to look back, in seconds, at which point to return an observation
+  /// @param tick The current tick
+  /// @param index The index of the observation that was most recently written to the observations array
+  /// @param liquidity The current in-range pool liquidity
+  /// @param cardinality The number of populated elements in the oracle array
+  /// @return tickCumulatives The tick * time elapsed since the pool was first initialized, as of each `secondsAgo`
+  /// @return secondsPerLiquidityCumulativeX128s The cumulative seconds / max(1, liquidity) since the pool was first initialized, as of each `secondsAgo`
+  function observe(
+    Observation[65535] storage self,
+    uint32 time,
+    uint32[] memory secondsAgos,
+    int24 tick,
+    uint16 index,
+    uint128 liquidity,
+    uint16 cardinality
+  ) internal view returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) {
+    unchecked {
+      if (cardinality <= 0) revert I();
+
+      tickCumulatives = new int56[](secondsAgos.length);
+      secondsPerLiquidityCumulativeX128s = new uint160[](secondsAgos.length);
+      for (uint256 i = 0; i < secondsAgos.length; i++) {
+        (tickCumulatives[i], secondsPerLiquidityCumulativeX128s[i]) = observeSingle(
+          self,
+          time,
+          secondsAgos[i],
+          tick,
+          index,
+          liquidity,
+          cardinality
+        );
+      }
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/Position.sol
+++ b/src/dex/v3/core/libraries/Position.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { FullMath } from "./FullMath.sol";
+import { FixedPoint128 } from "./FixedPoint128.sol";
+
+/// @title Position
+/// @notice Positions represent an owner address' liquidity between a lower and upper tick boundary
+/// @dev Positions store additional state for tracking fees owed to the position
+library Position {
+  error NP();
+
+  // info stored for each user's position
+  struct Info {
+    // the amount of liquidity owned by this position
+    uint128 liquidity;
+    // fee growth per unit of liquidity as of the last update to liquidity or fees owed
+    uint256 feeGrowthInside0LastX128;
+    uint256 feeGrowthInside1LastX128;
+    // the fees owed to the position owner in token0/token1
+    uint128 tokensOwed0;
+    uint128 tokensOwed1;
+  }
+
+  /// @notice Returns the Info struct of a position, given an owner and position boundaries
+  /// @param self The mapping containing all user positions
+  /// @param owner The address of the position owner
+  /// @param tickLower The lower tick boundary of the position
+  /// @param tickUpper The upper tick boundary of the position
+  /// @return position The position info struct of the given owners' position
+  function get(
+    mapping(bytes32 => Info) storage self,
+    address owner,
+    int24 tickLower,
+    int24 tickUpper
+  ) internal view returns (Position.Info storage position) {
+    position = self[keccak256(abi.encodePacked(owner, tickLower, tickUpper))];
+  }
+
+  /// @notice Credits accumulated fees to a user's position
+  /// @param self The individual position to update
+  /// @param liquidityDelta The change in pool liquidity as a result of the position update
+  /// @param feeGrowthInside0X128 The all-time fee growth in token0, per unit of liquidity, inside the position's tick boundaries
+  /// @param feeGrowthInside1X128 The all-time fee growth in token1, per unit of liquidity, inside the position's tick boundaries
+  function update(
+    Info storage self,
+    int128 liquidityDelta,
+    uint256 feeGrowthInside0X128,
+    uint256 feeGrowthInside1X128
+  ) internal {
+    Info memory _self = self;
+
+    uint128 liquidityNext;
+    if (liquidityDelta == 0) {
+      if (_self.liquidity <= 0) revert NP(); // disallow pokes for 0 liquidity positions
+      liquidityNext = _self.liquidity;
+    } else {
+      liquidityNext = liquidityDelta < 0
+        ? _self.liquidity - uint128(-liquidityDelta)
+        : _self.liquidity + uint128(liquidityDelta);
+    }
+
+    // calculate accumulated fees. overflow in the subtraction of fee growth is expected
+    uint128 tokensOwed0;
+    uint128 tokensOwed1;
+    unchecked {
+      tokensOwed0 = uint128(
+        FullMath.mulDiv(feeGrowthInside0X128 - _self.feeGrowthInside0LastX128, _self.liquidity, FixedPoint128.Q128)
+      );
+      tokensOwed1 = uint128(
+        FullMath.mulDiv(feeGrowthInside1X128 - _self.feeGrowthInside1LastX128, _self.liquidity, FixedPoint128.Q128)
+      );
+
+      // update the position
+      if (liquidityDelta != 0) self.liquidity = liquidityNext;
+      self.feeGrowthInside0LastX128 = feeGrowthInside0X128;
+      self.feeGrowthInside1LastX128 = feeGrowthInside1X128;
+      if (tokensOwed0 > 0 || tokensOwed1 > 0) {
+        // overflow is acceptable, user must withdraw before they hit type(uint128).max fees
+        self.tokensOwed0 += tokensOwed0;
+        self.tokensOwed1 += tokensOwed1;
+      }
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/SafeCast.sol
+++ b/src/dex/v3/core/libraries/SafeCast.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Safe casting methods
+/// @notice Contains methods for safely casting between types
+library SafeCast {
+  /// @notice Cast a uint256 to a uint160, revert on overflow
+  /// @param y The uint256 to be downcasted
+  /// @return z The downcasted integer, now type uint160
+  function toUint160(uint256 y) internal pure returns (uint160 z) {
+    require((z = uint160(y)) == y);
+  }
+
+  /// @notice Cast a int256 to a int128, revert on overflow or underflow
+  /// @param y The int256 to be downcasted
+  /// @return z The downcasted integer, now type int128
+  function toInt128(int256 y) internal pure returns (int128 z) {
+    require((z = int128(y)) == y);
+  }
+
+  /// @notice Cast a uint256 to a int256, revert on overflow
+  /// @param y The uint256 to be casted
+  /// @return z The casted integer, now type int256
+  function toInt256(uint256 y) internal pure returns (int256 z) {
+    require(y < 2 ** 255);
+    z = int256(y);
+  }
+}

--- a/src/dex/v3/core/libraries/SqrtPriceMath.sol
+++ b/src/dex/v3/core/libraries/SqrtPriceMath.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { SafeCast } from "./SafeCast.sol";
+
+import { FullMath } from "./FullMath.sol";
+import { UnsafeMath } from "./UnsafeMath.sol";
+import { FixedPoint96 } from "./FixedPoint96.sol";
+
+/// @title Functions based on Q64.96 sqrt price and liquidity
+/// @notice Contains the math that uses square root of price as a Q64.96 and liquidity to compute deltas
+library SqrtPriceMath {
+  using SafeCast for uint256;
+
+  /// @notice Gets the next sqrt price given a delta of token0
+  /// @dev Always rounds up, because in the exact output case (increasing price) we need to move the price at least
+  /// far enough to get the desired output amount, and in the exact input case (decreasing price) we need to move the
+  /// price less in order to not send too much output.
+  /// The most precise formula for this is liquidity * sqrtPX96 / (liquidity +- amount * sqrtPX96),
+  /// if this is impossible because of overflow, we calculate liquidity / (liquidity / sqrtPX96 +- amount).
+  /// @param sqrtPX96 The starting price, i.e. before accounting for the token0 delta
+  /// @param liquidity The amount of usable liquidity
+  /// @param amount How much of token0 to add or remove from virtual reserves
+  /// @param add Whether to add or remove the amount of token0
+  /// @return The price after adding or removing amount, depending on add
+  function getNextSqrtPriceFromAmount0RoundingUp(
+    uint160 sqrtPX96,
+    uint128 liquidity,
+    uint256 amount,
+    bool add
+  ) internal pure returns (uint160) {
+    // we short circuit amount == 0 because the result is otherwise not guaranteed to equal the input price
+    if (amount == 0) return sqrtPX96;
+    uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+
+    if (add) {
+      unchecked {
+        uint256 product;
+        if ((product = amount * sqrtPX96) / amount == sqrtPX96) {
+          uint256 denominator = numerator1 + product;
+          if (denominator >= numerator1)
+            // always fits in 160 bits
+            return uint160(FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator));
+        }
+      }
+      // denominator is checked for overflow
+      return uint160(UnsafeMath.divRoundingUp(numerator1, (numerator1 / sqrtPX96) + amount));
+    } else {
+      unchecked {
+        uint256 product;
+        // if the product overflows, we know the denominator underflows
+        // in addition, we must check that the denominator does not underflow
+        require((product = amount * sqrtPX96) / amount == sqrtPX96 && numerator1 > product);
+        uint256 denominator = numerator1 - product;
+        return FullMath.mulDivRoundingUp(numerator1, sqrtPX96, denominator).toUint160();
+      }
+    }
+  }
+
+  /// @notice Gets the next sqrt price given a delta of token1
+  /// @dev Always rounds down, because in the exact output case (decreasing price) we need to move the price at least
+  /// far enough to get the desired output amount, and in the exact input case (increasing price) we need to move the
+  /// price less in order to not send too much output.
+  /// The formula we compute is within <1 wei of the lossless version: sqrtPX96 +- amount / liquidity
+  /// @param sqrtPX96 The starting price, i.e., before accounting for the token1 delta
+  /// @param liquidity The amount of usable liquidity
+  /// @param amount How much of token1 to add, or remove, from virtual reserves
+  /// @param add Whether to add, or remove, the amount of token1
+  /// @return The price after adding or removing `amount`
+  function getNextSqrtPriceFromAmount1RoundingDown(
+    uint160 sqrtPX96,
+    uint128 liquidity,
+    uint256 amount,
+    bool add
+  ) internal pure returns (uint160) {
+    // if we're adding (subtracting), rounding down requires rounding the quotient down (up)
+    // in both cases, avoid a mulDiv for most inputs
+    if (add) {
+      uint256 quotient = (
+        amount <= type(uint160).max
+          ? (amount << FixedPoint96.RESOLUTION) / liquidity
+          : FullMath.mulDiv(amount, FixedPoint96.Q96, liquidity)
+      );
+
+      return (uint256(sqrtPX96) + quotient).toUint160();
+    } else {
+      uint256 quotient = (
+        amount <= type(uint160).max
+          ? UnsafeMath.divRoundingUp(amount << FixedPoint96.RESOLUTION, liquidity)
+          : FullMath.mulDivRoundingUp(amount, FixedPoint96.Q96, liquidity)
+      );
+
+      require(sqrtPX96 > quotient);
+      // always fits 160 bits
+      unchecked {
+        return uint160(sqrtPX96 - quotient);
+      }
+    }
+  }
+
+  /// @notice Gets the next sqrt price given an input amount of token0 or token1
+  /// @dev Throws if price or liquidity are 0, or if the next price is out of bounds
+  /// @param sqrtPX96 The starting price, i.e., before accounting for the input amount
+  /// @param liquidity The amount of usable liquidity
+  /// @param amountIn How much of token0, or token1, is being swapped in
+  /// @param zeroForOne Whether the amount in is token0 or token1
+  /// @return sqrtQX96 The price after adding the input amount to token0 or token1
+  function getNextSqrtPriceFromInput(
+    uint160 sqrtPX96,
+    uint128 liquidity,
+    uint256 amountIn,
+    bool zeroForOne
+  ) internal pure returns (uint160 sqrtQX96) {
+    require(sqrtPX96 > 0);
+    require(liquidity > 0);
+
+    // round to make sure that we don't pass the target price
+    return
+      zeroForOne
+        ? getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true)
+        : getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true);
+  }
+
+  /// @notice Gets the next sqrt price given an output amount of token0 or token1
+  /// @dev Throws if price or liquidity are 0 or the next price is out of bounds
+  /// @param sqrtPX96 The starting price before accounting for the output amount
+  /// @param liquidity The amount of usable liquidity
+  /// @param amountOut How much of token0, or token1, is being swapped out
+  /// @param zeroForOne Whether the amount out is token0 or token1
+  /// @return sqrtQX96 The price after removing the output amount of token0 or token1
+  function getNextSqrtPriceFromOutput(
+    uint160 sqrtPX96,
+    uint128 liquidity,
+    uint256 amountOut,
+    bool zeroForOne
+  ) internal pure returns (uint160 sqrtQX96) {
+    require(sqrtPX96 > 0);
+    require(liquidity > 0);
+
+    // round to make sure that we pass the target price
+    return
+      zeroForOne
+        ? getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false)
+        : getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false);
+  }
+
+  /// @notice Gets the amount0 delta between two prices
+  /// @dev Calculates liquidity / sqrt(lower) - liquidity / sqrt(upper),
+  /// i.e. liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+  /// @param sqrtRatioAX96 A sqrt price
+  /// @param sqrtRatioBX96 Another sqrt price
+  /// @param liquidity The amount of usable liquidity
+  /// @param roundUp Whether to round the amount up or down
+  /// @return amount0 Amount of token0 required to cover a position of size liquidity between the two passed prices
+  function getAmount0Delta(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity,
+    bool roundUp
+  ) internal pure returns (uint256 amount0) {
+    unchecked {
+      if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+      uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+      uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+
+      require(sqrtRatioAX96 > 0);
+
+      return
+        roundUp
+          ? UnsafeMath.divRoundingUp(FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96), sqrtRatioAX96)
+          : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
+    }
+  }
+
+  /// @notice Gets the amount1 delta between two prices
+  /// @dev Calculates liquidity * (sqrt(upper) - sqrt(lower))
+  /// @param sqrtRatioAX96 A sqrt price
+  /// @param sqrtRatioBX96 Another sqrt price
+  /// @param liquidity The amount of usable liquidity
+  /// @param roundUp Whether to round the amount up, or down
+  /// @return amount1 Amount of token1 required to cover a position of size liquidity between the two passed prices
+  function getAmount1Delta(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity,
+    bool roundUp
+  ) internal pure returns (uint256 amount1) {
+    unchecked {
+      if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+      return
+        roundUp
+          ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
+          : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+    }
+  }
+
+  /// @notice Helper that gets signed token0 delta
+  /// @param sqrtRatioAX96 A sqrt price
+  /// @param sqrtRatioBX96 Another sqrt price
+  /// @param liquidity The change in liquidity for which to compute the amount0 delta
+  /// @return amount0 Amount of token0 corresponding to the passed liquidityDelta between the two prices
+  function getAmount0Delta(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    int128 liquidity
+  ) internal pure returns (int256 amount0) {
+    unchecked {
+      return
+        liquidity < 0
+          ? -getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+          : getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+    }
+  }
+
+  /// @notice Helper that gets signed token1 delta
+  /// @param sqrtRatioAX96 A sqrt price
+  /// @param sqrtRatioBX96 Another sqrt price
+  /// @param liquidity The change in liquidity for which to compute the amount1 delta
+  /// @return amount1 Amount of token1 corresponding to the passed liquidityDelta between the two prices
+  function getAmount1Delta(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    int128 liquidity
+  ) internal pure returns (int256 amount1) {
+    unchecked {
+      return
+        liquidity < 0
+          ? -getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(-liquidity), false).toInt256()
+          : getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, uint128(liquidity), true).toInt256();
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/SwapMath.sol
+++ b/src/dex/v3/core/libraries/SwapMath.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { FullMath } from "./FullMath.sol";
+import { SqrtPriceMath } from "./SqrtPriceMath.sol";
+
+/// @title Computes the result of a swap within ticks
+/// @notice Contains methods for computing the result of a swap within a single tick price range, i.e., a single tick.
+library SwapMath {
+  /// @notice Computes the result of swapping some amount in, or amount out, given the parameters of the swap
+  /// @dev The fee, plus the amount in, will never exceed the amount remaining if the swap's `amountSpecified` is positive
+  /// @param sqrtRatioCurrentX96 The current sqrt price of the pool
+  /// @param sqrtRatioTargetX96 The price that cannot be exceeded, from which the direction of the swap is inferred
+  /// @param liquidity The usable liquidity
+  /// @param amountRemaining How much input or output amount is remaining to be swapped in/out
+  /// @param feePips The fee taken from the input amount, expressed in hundredths of a bip
+  /// @return sqrtRatioNextX96 The price after swapping the amount in/out, not to exceed the price target
+  /// @return amountIn The amount to be swapped in, of either token0 or token1, based on the direction of the swap
+  /// @return amountOut The amount to be received, of either token0 or token1, based on the direction of the swap
+  /// @return feeAmount The amount of input that will be taken as a fee
+  function computeSwapStep(
+    uint160 sqrtRatioCurrentX96,
+    uint160 sqrtRatioTargetX96,
+    uint128 liquidity,
+    int256 amountRemaining,
+    uint24 feePips
+  ) internal pure returns (uint160 sqrtRatioNextX96, uint256 amountIn, uint256 amountOut, uint256 feeAmount) {
+    unchecked {
+      bool zeroForOne = sqrtRatioCurrentX96 >= sqrtRatioTargetX96;
+      bool exactIn = amountRemaining >= 0;
+
+      if (exactIn) {
+        uint256 amountRemainingLessFee = FullMath.mulDiv(uint256(amountRemaining), 1e6 - feePips, 1e6);
+        amountIn = zeroForOne
+          ? SqrtPriceMath.getAmount0Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true)
+          : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true);
+        if (amountRemainingLessFee >= amountIn) sqrtRatioNextX96 = sqrtRatioTargetX96;
+        else
+          sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromInput(
+            sqrtRatioCurrentX96,
+            liquidity,
+            amountRemainingLessFee,
+            zeroForOne
+          );
+      } else {
+        amountOut = zeroForOne
+          ? SqrtPriceMath.getAmount1Delta(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false)
+          : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false);
+        if (uint256(-amountRemaining) >= amountOut) sqrtRatioNextX96 = sqrtRatioTargetX96;
+        else
+          sqrtRatioNextX96 = SqrtPriceMath.getNextSqrtPriceFromOutput(
+            sqrtRatioCurrentX96,
+            liquidity,
+            uint256(-amountRemaining),
+            zeroForOne
+          );
+      }
+
+      bool max = sqrtRatioTargetX96 == sqrtRatioNextX96;
+
+      // get the input/output amounts
+      if (zeroForOne) {
+        amountIn = max && exactIn
+          ? amountIn
+          : SqrtPriceMath.getAmount0Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true);
+        amountOut = max && !exactIn
+          ? amountOut
+          : SqrtPriceMath.getAmount1Delta(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false);
+      } else {
+        amountIn = max && exactIn
+          ? amountIn
+          : SqrtPriceMath.getAmount1Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true);
+        amountOut = max && !exactIn
+          ? amountOut
+          : SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false);
+      }
+
+      // cap the output amount to not exceed the remaining output amount
+      if (!exactIn && amountOut > uint256(-amountRemaining)) {
+        amountOut = uint256(-amountRemaining);
+      }
+
+      if (exactIn && sqrtRatioNextX96 != sqrtRatioTargetX96) {
+        // we didn't reach the target, so take the remainder of the maximum input as fee
+        feeAmount = uint256(amountRemaining) - amountIn;
+      } else {
+        feeAmount = FullMath.mulDivRoundingUp(amountIn, feePips, 1e6 - feePips);
+      }
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/Tick.sol
+++ b/src/dex/v3/core/libraries/Tick.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { SafeCast } from "./SafeCast.sol";
+
+import { TickMath } from "./TickMath.sol";
+
+/// @title Tick
+/// @notice Contains functions for managing tick processes and relevant calculations
+library Tick {
+  error LO();
+
+  using SafeCast for int256;
+
+  // info stored for each initialized individual tick
+  struct Info {
+    // the total position liquidity that references this tick
+    uint128 liquidityGross;
+    // amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left),
+    int128 liquidityNet;
+    // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+    // only has relative meaning, not absolute — the value depends on when the tick is initialized
+    uint256 feeGrowthOutside0X128;
+    uint256 feeGrowthOutside1X128;
+    // the cumulative tick value on the other side of the tick
+    int56 tickCumulativeOutside;
+    // the seconds per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+    // only has relative meaning, not absolute — the value depends on when the tick is initialized
+    uint160 secondsPerLiquidityOutsideX128;
+    // the seconds spent on the other side of the tick (relative to the current tick)
+    // only has relative meaning, not absolute — the value depends on when the tick is initialized
+    uint32 secondsOutside;
+    // true iff the tick is initialized, i.e. the value is exactly equivalent to the expression liquidityGross != 0
+    // these 8 bits are set to prevent fresh sstores when crossing newly initialized ticks
+    bool initialized;
+  }
+
+  /// @notice Derives max liquidity per tick from given tick spacing
+  /// @dev Executed within the pool constructor
+  /// @param tickSpacing The amount of required tick separation, realized in multiples of `tickSpacing`
+  ///     e.g., a tickSpacing of 3 requires ticks to be initialized every 3rd tick i.e., ..., -6, -3, 0, 3, 6, ...
+  /// @return The max liquidity per tick
+  function tickSpacingToMaxLiquidityPerTick(int24 tickSpacing) internal pure returns (uint128) {
+    unchecked {
+      int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
+      int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
+      uint24 numTicks = uint24((maxTick - minTick) / tickSpacing) + 1;
+      return type(uint128).max / numTicks;
+    }
+  }
+
+  /// @notice Retrieves fee growth data
+  /// @param self The mapping containing all tick information for initialized ticks
+  /// @param tickLower The lower tick boundary of the position
+  /// @param tickUpper The upper tick boundary of the position
+  /// @param tickCurrent The current tick
+  /// @param feeGrowthGlobal0X128 The all-time global fee growth, per unit of liquidity, in token0
+  /// @param feeGrowthGlobal1X128 The all-time global fee growth, per unit of liquidity, in token1
+  /// @return feeGrowthInside0X128 The all-time fee growth in token0, per unit of liquidity, inside the position's tick boundaries
+  /// @return feeGrowthInside1X128 The all-time fee growth in token1, per unit of liquidity, inside the position's tick boundaries
+  function getFeeGrowthInside(
+    mapping(int24 => Tick.Info) storage self,
+    int24 tickLower,
+    int24 tickUpper,
+    int24 tickCurrent,
+    uint256 feeGrowthGlobal0X128,
+    uint256 feeGrowthGlobal1X128
+  ) internal view returns (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) {
+    unchecked {
+      Info storage lower = self[tickLower];
+      Info storage upper = self[tickUpper];
+
+      // calculate fee growth below
+      uint256 feeGrowthBelow0X128;
+      uint256 feeGrowthBelow1X128;
+      if (tickCurrent >= tickLower) {
+        feeGrowthBelow0X128 = lower.feeGrowthOutside0X128;
+        feeGrowthBelow1X128 = lower.feeGrowthOutside1X128;
+      } else {
+        feeGrowthBelow0X128 = feeGrowthGlobal0X128 - lower.feeGrowthOutside0X128;
+        feeGrowthBelow1X128 = feeGrowthGlobal1X128 - lower.feeGrowthOutside1X128;
+      }
+
+      // calculate fee growth above
+      uint256 feeGrowthAbove0X128;
+      uint256 feeGrowthAbove1X128;
+      if (tickCurrent < tickUpper) {
+        feeGrowthAbove0X128 = upper.feeGrowthOutside0X128;
+        feeGrowthAbove1X128 = upper.feeGrowthOutside1X128;
+      } else {
+        feeGrowthAbove0X128 = feeGrowthGlobal0X128 - upper.feeGrowthOutside0X128;
+        feeGrowthAbove1X128 = feeGrowthGlobal1X128 - upper.feeGrowthOutside1X128;
+      }
+
+      feeGrowthInside0X128 = feeGrowthGlobal0X128 - feeGrowthBelow0X128 - feeGrowthAbove0X128;
+      feeGrowthInside1X128 = feeGrowthGlobal1X128 - feeGrowthBelow1X128 - feeGrowthAbove1X128;
+    }
+  }
+
+  /// @notice Updates a tick and returns true if the tick was flipped from initialized to uninitialized, or vice versa
+  /// @param self The mapping containing all tick information for initialized ticks
+  /// @param tick The tick that will be updated
+  /// @param tickCurrent The current tick
+  /// @param liquidityDelta A new amount of liquidity to be added (subtracted) when tick is crossed from left to right (right to left)
+  /// @param feeGrowthGlobal0X128 The all-time global fee growth, per unit of liquidity, in token0
+  /// @param feeGrowthGlobal1X128 The all-time global fee growth, per unit of liquidity, in token1
+  /// @param secondsPerLiquidityCumulativeX128 The all-time seconds per max(1, liquidity) of the pool
+  /// @param tickCumulative The tick * time elapsed since the pool was first initialized
+  /// @param time The current block timestamp cast to a uint32
+  /// @param upper true for updating a position's upper tick, or false for updating a position's lower tick
+  /// @param maxLiquidity The maximum liquidity allocation for a single tick
+  /// @return flipped Whether the tick was flipped from initialized to uninitialized, or vice versa
+  function update(
+    mapping(int24 => Tick.Info) storage self,
+    int24 tick,
+    int24 tickCurrent,
+    int128 liquidityDelta,
+    uint256 feeGrowthGlobal0X128,
+    uint256 feeGrowthGlobal1X128,
+    uint160 secondsPerLiquidityCumulativeX128,
+    int56 tickCumulative,
+    uint32 time,
+    bool upper,
+    uint128 maxLiquidity
+  ) internal returns (bool flipped) {
+    Tick.Info storage info = self[tick];
+
+    uint128 liquidityGrossBefore = info.liquidityGross;
+    uint128 liquidityGrossAfter = liquidityDelta < 0
+      ? liquidityGrossBefore - uint128(-liquidityDelta)
+      : liquidityGrossBefore + uint128(liquidityDelta);
+
+    if (liquidityGrossAfter > maxLiquidity) revert LO();
+
+    flipped = (liquidityGrossAfter == 0) != (liquidityGrossBefore == 0);
+
+    if (liquidityGrossBefore == 0) {
+      // by convention, we assume that all growth before a tick was initialized happened _below_ the tick
+      if (tick <= tickCurrent) {
+        info.feeGrowthOutside0X128 = feeGrowthGlobal0X128;
+        info.feeGrowthOutside1X128 = feeGrowthGlobal1X128;
+        info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128;
+        info.tickCumulativeOutside = tickCumulative;
+        info.secondsOutside = time;
+      }
+      info.initialized = true;
+    }
+
+    info.liquidityGross = liquidityGrossAfter;
+
+    // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
+    info.liquidityNet = upper ? info.liquidityNet - liquidityDelta : info.liquidityNet + liquidityDelta;
+  }
+
+  /// @notice Clears tick data
+  /// @param self The mapping containing all initialized tick information for initialized ticks
+  /// @param tick The tick that will be cleared
+  function clear(mapping(int24 => Tick.Info) storage self, int24 tick) internal {
+    delete self[tick];
+  }
+
+  /// @notice Transitions to next tick as needed by price movement
+  /// @param self The mapping containing all tick information for initialized ticks
+  /// @param tick The destination tick of the transition
+  /// @param feeGrowthGlobal0X128 The all-time global fee growth, per unit of liquidity, in token0
+  /// @param feeGrowthGlobal1X128 The all-time global fee growth, per unit of liquidity, in token1
+  /// @param secondsPerLiquidityCumulativeX128 The current seconds per liquidity
+  /// @param tickCumulative The tick * time elapsed since the pool was first initialized
+  /// @param time The current block.timestamp
+  /// @return liquidityNet The amount of liquidity added (subtracted) when tick is crossed from left to right (right to left)
+  function cross(
+    mapping(int24 => Tick.Info) storage self,
+    int24 tick,
+    uint256 feeGrowthGlobal0X128,
+    uint256 feeGrowthGlobal1X128,
+    uint160 secondsPerLiquidityCumulativeX128,
+    int56 tickCumulative,
+    uint32 time
+  ) internal returns (int128 liquidityNet) {
+    unchecked {
+      Tick.Info storage info = self[tick];
+      info.feeGrowthOutside0X128 = feeGrowthGlobal0X128 - info.feeGrowthOutside0X128;
+      info.feeGrowthOutside1X128 = feeGrowthGlobal1X128 - info.feeGrowthOutside1X128;
+      info.secondsPerLiquidityOutsideX128 = secondsPerLiquidityCumulativeX128 - info.secondsPerLiquidityOutsideX128;
+      info.tickCumulativeOutside = tickCumulative - info.tickCumulativeOutside;
+      info.secondsOutside = time - info.secondsOutside;
+      liquidityNet = info.liquidityNet;
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/TickBitmap.sol
+++ b/src/dex/v3/core/libraries/TickBitmap.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { BitMath } from "./BitMath.sol";
+
+/// @title Packed tick initialized state library
+/// @notice Stores a packed mapping of tick index to its initialized state
+/// @dev The mapping uses int16 for keys since ticks are represented as int24 and there are 256 (2^8) values per word.
+library TickBitmap {
+  /// @notice Computes the position in the mapping where the initialized bit for a tick lives
+  /// @param tick The tick for which to compute the position
+  /// @return wordPos The key in the mapping containing the word in which the bit is stored
+  /// @return bitPos The bit position in the word where the flag is stored
+  function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
+    unchecked {
+      wordPos = int16(tick >> 8);
+      bitPos = uint8(int8(tick % 256));
+    }
+  }
+
+  /// @notice Flips the initialized state for a given tick from false to true, or vice versa
+  /// @param self The mapping in which to flip the tick
+  /// @param tick The tick to flip
+  /// @param tickSpacing The spacing between usable ticks
+  function flipTick(mapping(int16 => uint256) storage self, int24 tick, int24 tickSpacing) internal {
+    unchecked {
+      require(tick % tickSpacing == 0); // ensure that the tick is spaced
+      (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
+      uint256 mask = 1 << bitPos;
+      self[wordPos] ^= mask;
+    }
+  }
+
+  /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
+  /// to the left (less than or equal to) or right (greater than) of the given tick
+  /// @param self The mapping in which to compute the next initialized tick
+  /// @param tick The starting tick
+  /// @param tickSpacing The spacing between usable ticks
+  /// @param lte Whether to search for the next initialized tick to the left (less than or equal to the starting tick)
+  /// @return next The next initialized or uninitialized tick up to 256 ticks away from the current tick
+  /// @return initialized Whether the next tick is initialized, as the function only searches within up to 256 ticks
+  function nextInitializedTickWithinOneWord(
+    mapping(int16 => uint256) storage self,
+    int24 tick,
+    int24 tickSpacing,
+    bool lte
+  ) internal view returns (int24 next, bool initialized) {
+    unchecked {
+      int24 compressed = tick / tickSpacing;
+      if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
+
+      if (lte) {
+        (int16 wordPos, uint8 bitPos) = position(compressed);
+        // all the 1s at or to the right of the current bitPos
+        uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
+        uint256 masked = self[wordPos] & mask;
+
+        // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
+        initialized = masked != 0;
+        // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+        next = initialized
+          ? (compressed - int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) * tickSpacing
+          : (compressed - int24(uint24(bitPos))) * tickSpacing;
+      } else {
+        // start from the word of the next tick, since the current tick state doesn't matter
+        (int16 wordPos, uint8 bitPos) = position(compressed + 1);
+        // all the 1s at or to the left of the bitPos
+        uint256 mask = ~((1 << bitPos) - 1);
+        uint256 masked = self[wordPos] & mask;
+
+        // if there are no initialized ticks to the left of the current tick, return leftmost in the word
+        initialized = masked != 0;
+        // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+        next = initialized
+          ? (compressed + 1 + int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) * tickSpacing
+          : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) * tickSpacing;
+      }
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/TickMath.sol
+++ b/src/dex/v3/core/libraries/TickMath.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+/// @title Math library for computing sqrt prices from ticks and vice versa
+/// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports
+/// prices between 2**-128 and 2**128
+library TickMath {
+  error T();
+  error R();
+
+  /// @dev The minimum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**-128
+  int24 internal constant MIN_TICK = -887272;
+  /// @dev The maximum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**128
+  int24 internal constant MAX_TICK = -MIN_TICK;
+
+  /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+  uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+  /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+  uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+  /// @notice Calculates sqrt(1.0001^tick) * 2^96
+  /// @dev Throws if |tick| > max tick
+  /// @param tick The input tick for the above formula
+  /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
+  /// at the given tick
+  function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
+    unchecked {
+      uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
+      if (absTick > uint256(int256(MAX_TICK))) revert T();
+
+      uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
+      if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+      if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+      if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+      if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+      if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+      if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+      if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+      if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+      if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+      if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+      if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+      if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+      if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+      if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+      if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+      if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+      if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+      if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+      if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+
+      if (tick > 0) ratio = type(uint256).max / ratio;
+
+      // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+      // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+      // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+      sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+    }
+  }
+
+  /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
+  /// @dev Throws in case sqrtPriceX96 < MIN_SQRT_RATIO, as MIN_SQRT_RATIO is the lowest value getRatioAtTick may
+  /// ever return.
+  /// @param sqrtPriceX96 The sqrt ratio for which to compute the tick as a Q64.96
+  /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio
+  function getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
+    unchecked {
+      // second inequality must be < because the price can never reach the price at the max tick
+      if (!(sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO)) revert R();
+      uint256 ratio = uint256(sqrtPriceX96) << 32;
+
+      uint256 r = ratio;
+      uint256 msb = 0;
+
+      assembly {
+        let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(5, gt(r, 0xFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(4, gt(r, 0xFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(3, gt(r, 0xFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(2, gt(r, 0xF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(1, gt(r, 0x3))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := gt(r, 0x1)
+        msb := or(msb, f)
+      }
+
+      if (msb >= 128) r = ratio >> (msb - 127);
+      else r = ratio << (127 - msb);
+
+      int256 log_2 = (int256(msb) - 128) << 64;
+
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(63, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(62, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(61, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(60, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(59, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(58, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(57, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(56, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(55, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(54, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(53, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(52, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(51, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(50, f))
+      }
+
+      int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+
+      int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
+      int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
+
+      tick = tickLow == tickHi
+        ? tickLow
+        : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96
+          ? tickHi
+          : tickLow;
+    }
+  }
+}

--- a/src/dex/v3/core/libraries/TransferHelper.sol
+++ b/src/dex/v3/core/libraries/TransferHelper.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.0;
+
+import { IERC20Minimal } from "../interfaces/IERC20Minimal.sol";
+
+/// @title TransferHelper
+/// @notice Contains helper methods for interacting with ERC20 tokens that do not consistently return true/false
+library TransferHelper {
+  error TF();
+
+  /// @notice Transfers tokens from msg.sender to a recipient
+  /// @dev Calls transfer on token contract, errors with TF if transfer fails
+  /// @param token The contract address of the token which will be transferred
+  /// @param to The recipient of the transfer
+  /// @param value The value of the transfer
+  function safeTransfer(address token, address to, uint256 value) internal {
+    (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20Minimal.transfer.selector, to, value));
+    if (!(success && (data.length == 0 || abi.decode(data, (bool))))) revert TF();
+  }
+}

--- a/src/dex/v3/core/libraries/UnsafeMath.sol
+++ b/src/dex/v3/core/libraries/UnsafeMath.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math functions that do not check inputs or outputs
+/// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks
+library UnsafeMath {
+  /// @notice Returns ceil(x / y)
+  /// @dev division by 0 has unspecified behavior, and must be checked externally
+  /// @param x The dividend
+  /// @param y The divisor
+  /// @return z The quotient, ceil(x / y)
+  function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    assembly {
+      z := add(div(x, y), gt(mod(x, y), 0))
+    }
+  }
+}

--- a/src/dex/v3/periphery/NonfungiblePositionManager.sol
+++ b/src/dex/v3/periphery/NonfungiblePositionManager.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../core/interfaces/IListaV3Pool.sol";
+import "../core/libraries/FixedPoint128.sol";
+import "../core/libraries/FullMath.sol";
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import "./interfaces/INonfungiblePositionManager.sol";
+import "./interfaces/INonfungibleTokenPositionDescriptor.sol";
+import "./libraries/PositionKey.sol";
+import "./libraries/PoolAddress.sol";
+import "./base/LiquidityManagement.sol";
+import "./base/PeripheryImmutableState.sol";
+import "./base/Multicall.sol";
+import "./base/ERC721Permit.sol";
+import "./base/PeripheryValidation.sol";
+import "./base/SelfPermit.sol";
+import "./base/PoolInitializer.sol";
+
+/// @title NFT positions
+/// @notice Wraps Lista V3 positions in the ERC721 non-fungible token interface
+contract NonfungiblePositionManager is
+  INonfungiblePositionManager,
+  Multicall,
+  ERC721Permit,
+  PeripheryImmutableState,
+  PoolInitializer,
+  LiquidityManagement,
+  PeripheryValidation,
+  SelfPermit,
+  Initializable,
+  UUPSUpgradeable
+{
+  // details about the lista position
+  struct Position {
+    // the nonce for permits
+    uint96 nonce;
+    // the address that is approved for spending this token
+    address operator;
+    // the ID of the pool with which this token is connected
+    uint80 poolId;
+    // the tick range of the position
+    int24 tickLower;
+    int24 tickUpper;
+    // the liquidity of the position
+    uint128 liquidity;
+    // the fee growth of the aggregate position as of the last action on the individual position
+    uint256 feeGrowthInside0LastX128;
+    uint256 feeGrowthInside1LastX128;
+    // how many uncollected tokens are owed to the position, as of the last computation
+    uint128 tokensOwed0;
+    uint128 tokensOwed1;
+  }
+
+  /// @dev IDs of pools assigned by this contract
+  mapping(address => uint80) private _poolIds;
+
+  /// @dev Pool keys by pool ID, to save on SSTOREs for position data
+  mapping(uint80 => PoolAddress.PoolKey) private _poolIdToPoolKey;
+
+  /// @dev The token ID position data
+  mapping(uint256 => Position) private _positions;
+
+  /// @dev The ID of the next token that will be minted. Skips 0
+  uint176 private _nextId = 1;
+  /// @dev The ID of the next pool that is used for the first time. Skips 0
+  uint80 private _nextPoolId = 1;
+
+  /// @dev The address of the token descriptor contract, which handles generating token URIs for position tokens
+  address private _tokenDescriptor;
+
+  /// @dev Owner for upgrade authorization
+  address public admin;
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor()
+    ERC721Permit("Lista V3 Positions NFT-V1", "LISTA-V3-POS", "1")
+    PeripheryImmutableState(address(0), address(0))
+  {
+    _disableInitializers();
+  }
+
+  function initialize(
+    address _factory,
+    address _WETH9,
+    address _tokenDescriptor_,
+    address _admin,
+    bytes32 _poolInitCodeHash
+  ) external initializer {
+    require(_factory != address(0) && _WETH9 != address(0) && _admin != address(0), "zero address");
+    factory = _factory;
+    WETH9 = _WETH9;
+    poolInitCodeHash = _poolInitCodeHash;
+    _tokenDescriptor = _tokenDescriptor_;
+    admin = _admin;
+    _nextId = 1;
+    _nextPoolId = 1;
+  }
+
+  /// @dev Override name/symbol to return constants — avoids reliance on ERC721 storage
+  ///      which is set by the constructor (runs on implementation, not proxy).
+  function name() public pure override(ERC721, IERC721Metadata) returns (string memory) {
+    return "Lista V3 Positions NFT-V1";
+  }
+
+  function symbol() public pure override(ERC721, IERC721Metadata) returns (string memory) {
+    return "LISTA-V3-POS";
+  }
+
+  function _authorizeUpgrade(address) internal override {
+    require(msg.sender == admin, "not admin");
+  }
+
+  /// @inheritdoc INonfungiblePositionManager
+  function positions(
+    uint256 tokenId
+  )
+    external
+    view
+    override
+    returns (
+      uint96 nonce,
+      address operator,
+      address token0,
+      address token1,
+      uint24 fee,
+      int24 tickLower,
+      int24 tickUpper,
+      uint128 liquidity,
+      uint256 feeGrowthInside0LastX128,
+      uint256 feeGrowthInside1LastX128,
+      uint128 tokensOwed0,
+      uint128 tokensOwed1
+    )
+  {
+    Position memory position = _positions[tokenId];
+    require(position.poolId != 0, "Invalid token ID");
+    PoolAddress.PoolKey memory poolKey = _poolIdToPoolKey[position.poolId];
+    return (
+      position.nonce,
+      position.operator,
+      poolKey.token0,
+      poolKey.token1,
+      poolKey.fee,
+      position.tickLower,
+      position.tickUpper,
+      position.liquidity,
+      position.feeGrowthInside0LastX128,
+      position.feeGrowthInside1LastX128,
+      position.tokensOwed0,
+      position.tokensOwed1
+    );
+  }
+
+  /// @dev Caches a pool key
+  function cachePoolKey(address pool, PoolAddress.PoolKey memory poolKey) private returns (uint80 poolId) {
+    poolId = _poolIds[pool];
+    if (poolId == 0) {
+      _poolIds[pool] = (poolId = _nextPoolId++);
+      _poolIdToPoolKey[poolId] = poolKey;
+    }
+  }
+
+  /// @inheritdoc INonfungiblePositionManager
+  function mint(
+    MintParams calldata params
+  )
+    external
+    payable
+    override
+    checkDeadline(params.deadline)
+    returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
+  {
+    IListaV3Pool pool;
+    (liquidity, amount0, amount1, pool) = addLiquidity(
+      AddLiquidityParams({
+        token0: params.token0,
+        token1: params.token1,
+        fee: params.fee,
+        recipient: address(this),
+        tickLower: params.tickLower,
+        tickUpper: params.tickUpper,
+        amount0Desired: params.amount0Desired,
+        amount1Desired: params.amount1Desired,
+        amount0Min: params.amount0Min,
+        amount1Min: params.amount1Min
+      })
+    );
+
+    _mint(params.recipient, (tokenId = _nextId++));
+
+    bytes32 positionKey = PositionKey.compute(address(this), params.tickLower, params.tickUpper);
+    (, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, , ) = pool.positions(positionKey);
+
+    // idempotent set
+    uint80 poolId = cachePoolKey(
+      address(pool),
+      PoolAddress.PoolKey({ token0: params.token0, token1: params.token1, fee: params.fee })
+    );
+
+    _positions[tokenId] = Position({
+      nonce: 0,
+      operator: address(0),
+      poolId: poolId,
+      tickLower: params.tickLower,
+      tickUpper: params.tickUpper,
+      liquidity: liquidity,
+      feeGrowthInside0LastX128: feeGrowthInside0LastX128,
+      feeGrowthInside1LastX128: feeGrowthInside1LastX128,
+      tokensOwed0: 0,
+      tokensOwed1: 0
+    });
+
+    emit IncreaseLiquidity(tokenId, liquidity, amount0, amount1);
+  }
+
+  modifier isAuthorizedForToken(uint256 tokenId) {
+    address owner = _requireOwned(tokenId);
+    require(_isAuthorized(owner, msg.sender, tokenId), "Not approved");
+    _;
+  }
+
+  function tokenURI(uint256 tokenId) public view override(ERC721, IERC721Metadata) returns (string memory) {
+    _requireOwned(tokenId);
+    return INonfungibleTokenPositionDescriptor(_tokenDescriptor).tokenURI(this, tokenId);
+  }
+
+  // save bytecode by removing implementation of unused method
+  function baseURI() public pure returns (string memory) {}
+
+  /// @inheritdoc INonfungiblePositionManager
+  function increaseLiquidity(
+    IncreaseLiquidityParams calldata params
+  )
+    external
+    payable
+    override
+    checkDeadline(params.deadline)
+    returns (uint128 liquidity, uint256 amount0, uint256 amount1)
+  {
+    Position storage position = _positions[params.tokenId];
+
+    PoolAddress.PoolKey memory poolKey = _poolIdToPoolKey[position.poolId];
+
+    IListaV3Pool pool;
+    (liquidity, amount0, amount1, pool) = addLiquidity(
+      AddLiquidityParams({
+        token0: poolKey.token0,
+        token1: poolKey.token1,
+        fee: poolKey.fee,
+        tickLower: position.tickLower,
+        tickUpper: position.tickUpper,
+        amount0Desired: params.amount0Desired,
+        amount1Desired: params.amount1Desired,
+        amount0Min: params.amount0Min,
+        amount1Min: params.amount1Min,
+        recipient: address(this)
+      })
+    );
+
+    bytes32 positionKey = PositionKey.compute(address(this), position.tickLower, position.tickUpper);
+
+    // this is now updated to the current transaction
+    (, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, , ) = pool.positions(positionKey);
+
+    position.tokensOwed0 += uint128(
+      FullMath.mulDiv(
+        feeGrowthInside0LastX128 - position.feeGrowthInside0LastX128,
+        position.liquidity,
+        FixedPoint128.Q128
+      )
+    );
+    position.tokensOwed1 += uint128(
+      FullMath.mulDiv(
+        feeGrowthInside1LastX128 - position.feeGrowthInside1LastX128,
+        position.liquidity,
+        FixedPoint128.Q128
+      )
+    );
+
+    position.feeGrowthInside0LastX128 = feeGrowthInside0LastX128;
+    position.feeGrowthInside1LastX128 = feeGrowthInside1LastX128;
+    position.liquidity += liquidity;
+
+    emit IncreaseLiquidity(params.tokenId, liquidity, amount0, amount1);
+  }
+
+  /// @inheritdoc INonfungiblePositionManager
+  function decreaseLiquidity(
+    DecreaseLiquidityParams calldata params
+  )
+    external
+    payable
+    override
+    isAuthorizedForToken(params.tokenId)
+    checkDeadline(params.deadline)
+    returns (uint256 amount0, uint256 amount1)
+  {
+    require(params.liquidity > 0);
+    Position storage position = _positions[params.tokenId];
+
+    uint128 positionLiquidity = position.liquidity;
+    require(positionLiquidity >= params.liquidity);
+
+    PoolAddress.PoolKey memory poolKey = _poolIdToPoolKey[position.poolId];
+    IListaV3Pool pool = IListaV3Pool(PoolAddress.computeAddress(factory, poolKey, poolInitCodeHash));
+    (amount0, amount1) = pool.burn(position.tickLower, position.tickUpper, params.liquidity);
+
+    require(amount0 >= params.amount0Min && amount1 >= params.amount1Min, "Price slippage check");
+
+    bytes32 positionKey = PositionKey.compute(address(this), position.tickLower, position.tickUpper);
+    // this is now updated to the current transaction
+    (, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, , ) = pool.positions(positionKey);
+
+    position.tokensOwed0 +=
+      uint128(amount0) +
+      uint128(
+        FullMath.mulDiv(
+          feeGrowthInside0LastX128 - position.feeGrowthInside0LastX128,
+          positionLiquidity,
+          FixedPoint128.Q128
+        )
+      );
+    position.tokensOwed1 +=
+      uint128(amount1) +
+      uint128(
+        FullMath.mulDiv(
+          feeGrowthInside1LastX128 - position.feeGrowthInside1LastX128,
+          positionLiquidity,
+          FixedPoint128.Q128
+        )
+      );
+
+    position.feeGrowthInside0LastX128 = feeGrowthInside0LastX128;
+    position.feeGrowthInside1LastX128 = feeGrowthInside1LastX128;
+    // subtraction is safe because we checked positionLiquidity is gte params.liquidity
+    position.liquidity = positionLiquidity - params.liquidity;
+
+    emit DecreaseLiquidity(params.tokenId, params.liquidity, amount0, amount1);
+  }
+
+  /// @inheritdoc INonfungiblePositionManager
+  function collect(
+    CollectParams calldata params
+  ) external payable override isAuthorizedForToken(params.tokenId) returns (uint256 amount0, uint256 amount1) {
+    require(params.amount0Max > 0 || params.amount1Max > 0);
+    // allow collecting to the nft position manager address with address 0
+    address recipient = params.recipient == address(0) ? address(this) : params.recipient;
+
+    Position storage position = _positions[params.tokenId];
+
+    PoolAddress.PoolKey memory poolKey = _poolIdToPoolKey[position.poolId];
+
+    IListaV3Pool pool = IListaV3Pool(PoolAddress.computeAddress(factory, poolKey, poolInitCodeHash));
+
+    (uint128 tokensOwed0, uint128 tokensOwed1) = (position.tokensOwed0, position.tokensOwed1);
+
+    // trigger an update of the position fees owed and fee growth snapshots if it has any liquidity
+    if (position.liquidity > 0) {
+      pool.burn(position.tickLower, position.tickUpper, 0);
+      (, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, , ) = pool.positions(
+        PositionKey.compute(address(this), position.tickLower, position.tickUpper)
+      );
+
+      tokensOwed0 += uint128(
+        FullMath.mulDiv(
+          feeGrowthInside0LastX128 - position.feeGrowthInside0LastX128,
+          position.liquidity,
+          FixedPoint128.Q128
+        )
+      );
+      tokensOwed1 += uint128(
+        FullMath.mulDiv(
+          feeGrowthInside1LastX128 - position.feeGrowthInside1LastX128,
+          position.liquidity,
+          FixedPoint128.Q128
+        )
+      );
+
+      position.feeGrowthInside0LastX128 = feeGrowthInside0LastX128;
+      position.feeGrowthInside1LastX128 = feeGrowthInside1LastX128;
+    }
+
+    // compute the arguments to give to the pool#collect method
+    (uint128 amount0Collect, uint128 amount1Collect) = (
+      params.amount0Max > tokensOwed0 ? tokensOwed0 : params.amount0Max,
+      params.amount1Max > tokensOwed1 ? tokensOwed1 : params.amount1Max
+    );
+
+    // the actual amounts collected are returned
+    (amount0, amount1) = pool.collect(
+      recipient,
+      position.tickLower,
+      position.tickUpper,
+      amount0Collect,
+      amount1Collect
+    );
+
+    // sometimes there will be a few less wei than expected due to rounding down in core, but we just subtract the full amount expected
+    // instead of the actual amount so we can burn the token
+    (position.tokensOwed0, position.tokensOwed1) = (tokensOwed0 - amount0Collect, tokensOwed1 - amount1Collect);
+
+    emit Collect(params.tokenId, recipient, amount0Collect, amount1Collect);
+  }
+
+  /// @inheritdoc INonfungiblePositionManager
+  function burn(uint256 tokenId) external payable override isAuthorizedForToken(tokenId) {
+    Position storage position = _positions[tokenId];
+    require(position.liquidity == 0 && position.tokensOwed0 == 0 && position.tokensOwed1 == 0, "Not cleared");
+    delete _positions[tokenId];
+    _burn(tokenId);
+  }
+
+  function _getAndIncrementNonce(uint256 tokenId) internal override returns (uint256) {
+    return uint256(_positions[tokenId].nonce++);
+  }
+
+  /// @inheritdoc IERC721
+  function getApproved(uint256 tokenId) public view override(ERC721, IERC721) returns (address) {
+    _requireOwned(tokenId);
+
+    return _positions[tokenId].operator;
+  }
+
+  /// @dev Overrides _approve to use the operator in the position, which is packed with the position permit nonce
+  function _approve(address to, uint256 tokenId, address auth, bool emitEvent) internal override {
+    _positions[tokenId].operator = to;
+    if (emitEvent) {
+      emit Approval(ownerOf(tokenId), to, tokenId);
+    }
+  }
+}

--- a/src/dex/v3/periphery/NonfungibleTokenPositionDescriptor.sol
+++ b/src/dex/v3/periphery/NonfungibleTokenPositionDescriptor.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../core/interfaces/IListaV3Pool.sol";
+import "../core/interfaces/IListaV3Factory.sol";
+
+import "./libraries/SafeERC20Namer.sol";
+import "./libraries/ChainId.sol";
+import "./interfaces/INonfungiblePositionManager.sol";
+import "./interfaces/INonfungibleTokenPositionDescriptor.sol";
+import "./interfaces/IERC20Metadata.sol";
+import "./libraries/PoolAddress.sol";
+import "./libraries/NFTDescriptor.sol";
+import "./libraries/TokenRatioSortOrder.sol";
+
+/// @title Describes NFT token positions
+/// @notice Produces a string containing the data URI for a JSON metadata string
+contract NonfungibleTokenPositionDescriptor is INonfungibleTokenPositionDescriptor {
+  address private constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+  address private constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  address private constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+  address private constant TBTC = 0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa;
+  address private constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+
+  address public immutable WETH9;
+  /// @dev A null-terminated string
+  bytes32 public immutable nativeCurrencyLabelBytes;
+
+  constructor(address _WETH9, bytes32 _nativeCurrencyLabelBytes) {
+    WETH9 = _WETH9;
+    nativeCurrencyLabelBytes = _nativeCurrencyLabelBytes;
+  }
+
+  /// @notice Returns the native currency label as a string
+  function nativeCurrencyLabel() public view returns (string memory) {
+    uint256 len = 0;
+    while (len < 32 && nativeCurrencyLabelBytes[len] != 0) {
+      len++;
+    }
+    bytes memory b = new bytes(len);
+    for (uint256 i = 0; i < len; i++) {
+      b[i] = nativeCurrencyLabelBytes[i];
+    }
+    return string(b);
+  }
+
+  /// @inheritdoc INonfungibleTokenPositionDescriptor
+  function tokenURI(
+    INonfungiblePositionManager positionManager,
+    uint256 tokenId
+  ) external view override returns (string memory) {
+    (, , address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, , , , , ) = positionManager
+      .positions(tokenId);
+
+    IListaV3Pool pool = IListaV3Pool(IListaV3Factory(positionManager.factory()).getPool(token0, token1, fee));
+
+    bool _flipRatio = flipRatio(token0, token1, ChainId.get());
+    address quoteTokenAddress = !_flipRatio ? token1 : token0;
+    address baseTokenAddress = !_flipRatio ? token0 : token1;
+    (, int24 tick, , , , , ) = pool.slot0();
+
+    return
+      NFTDescriptor.constructTokenURI(
+        NFTDescriptor.ConstructTokenURIParams({
+          tokenId: tokenId,
+          quoteTokenAddress: quoteTokenAddress,
+          baseTokenAddress: baseTokenAddress,
+          quoteTokenSymbol: quoteTokenAddress == WETH9
+            ? nativeCurrencyLabel()
+            : SafeERC20Namer.tokenSymbol(quoteTokenAddress),
+          baseTokenSymbol: baseTokenAddress == WETH9
+            ? nativeCurrencyLabel()
+            : SafeERC20Namer.tokenSymbol(baseTokenAddress),
+          quoteTokenDecimals: IERC20Metadata(quoteTokenAddress).decimals(),
+          baseTokenDecimals: IERC20Metadata(baseTokenAddress).decimals(),
+          flipRatio: _flipRatio,
+          tickLower: tickLower,
+          tickUpper: tickUpper,
+          tickCurrent: tick,
+          tickSpacing: pool.tickSpacing(),
+          fee: fee,
+          poolAddress: address(pool)
+        })
+      );
+  }
+
+  function flipRatio(address token0, address token1, uint256 chainId) public view returns (bool) {
+    return tokenRatioPriority(token0, chainId) > tokenRatioPriority(token1, chainId);
+  }
+
+  function tokenRatioPriority(address token, uint256 chainId) public view returns (int256) {
+    if (token == WETH9) {
+      return TokenRatioSortOrder.DENOMINATOR;
+    }
+    if (chainId == 1) {
+      if (token == USDC) {
+        return TokenRatioSortOrder.NUMERATOR_MOST;
+      } else if (token == USDT) {
+        return TokenRatioSortOrder.NUMERATOR_MORE;
+      } else if (token == DAI) {
+        return TokenRatioSortOrder.NUMERATOR;
+      } else if (token == TBTC) {
+        return TokenRatioSortOrder.DENOMINATOR_MORE;
+      } else if (token == WBTC) {
+        return TokenRatioSortOrder.DENOMINATOR_MOST;
+      } else {
+        return 0;
+      }
+    }
+    return 0;
+  }
+}

--- a/src/dex/v3/periphery/SwapRouter.sol
+++ b/src/dex/v3/periphery/SwapRouter.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../core/libraries/SafeCast.sol";
+import "../core/libraries/TickMath.sol";
+import "../core/interfaces/IListaV3Pool.sol";
+
+import "./interfaces/ISwapRouter.sol";
+import "./base/PeripheryImmutableState.sol";
+import "./base/PeripheryValidation.sol";
+import "./base/PeripheryPaymentsWithFee.sol";
+import "./base/Multicall.sol";
+import "./base/SelfPermit.sol";
+import "./libraries/Path.sol";
+import "./libraries/PoolAddress.sol";
+import "./libraries/CallbackValidation.sol";
+import "./interfaces/external/IWETH9.sol";
+
+/// @title Lista V3 Swap Router
+/// @notice Router for stateless execution of swaps against Lista V3
+contract SwapRouter is
+  ISwapRouter,
+  PeripheryImmutableState,
+  PeripheryValidation,
+  PeripheryPaymentsWithFee,
+  Multicall,
+  SelfPermit
+{
+  using Path for bytes;
+  using SafeCast for uint256;
+
+  /// @dev Used as the placeholder value for amountInCached, because the computed amount in for an exact output swap
+  /// can never actually be this value
+  uint256 private constant DEFAULT_AMOUNT_IN_CACHED = type(uint256).max;
+
+  /// @dev Transient storage variable used for returning the computed amount in for an exact output swap.
+  uint256 private amountInCached = DEFAULT_AMOUNT_IN_CACHED;
+
+  constructor(address _factory, address _WETH9) PeripheryImmutableState(_factory, _WETH9) {}
+
+  /// @dev Returns the pool for the given token pair and fee. The pool contract may or may not exist.
+  function getPool(address tokenA, address tokenB, uint24 fee) private view returns (IListaV3Pool) {
+    return
+      IListaV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee), poolInitCodeHash));
+  }
+
+  struct SwapCallbackData {
+    bytes path;
+    address payer;
+  }
+
+  /// @inheritdoc IListaV3SwapCallback
+  function listaV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata _data) external override {
+    require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
+    SwapCallbackData memory data = abi.decode(_data, (SwapCallbackData));
+    (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
+    CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
+
+    (bool isExactInput, uint256 amountToPay) = amount0Delta > 0
+      ? (tokenIn < tokenOut, uint256(amount0Delta))
+      : (tokenOut < tokenIn, uint256(amount1Delta));
+    if (isExactInput) {
+      pay(tokenIn, data.payer, msg.sender, amountToPay);
+    } else {
+      // either initiate the next swap or pay
+      if (data.path.hasMultiplePools()) {
+        data.path = data.path.skipToken();
+        exactOutputInternal(amountToPay, msg.sender, 0, data);
+      } else {
+        amountInCached = amountToPay;
+        tokenIn = tokenOut; // swap in/out because exact output swaps are reversed
+        pay(tokenIn, data.payer, msg.sender, amountToPay);
+      }
+    }
+  }
+
+  /// @dev Performs a single exact input swap
+  function exactInputInternal(
+    uint256 amountIn,
+    address recipient,
+    uint160 sqrtPriceLimitX96,
+    SwapCallbackData memory data
+  ) private returns (uint256 amountOut) {
+    // allow swapping to the router address with address 0
+    if (recipient == address(0)) recipient = address(this);
+
+    (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
+
+    bool zeroForOne = tokenIn < tokenOut;
+
+    (int256 amount0, int256 amount1) = getPool(tokenIn, tokenOut, fee).swap(
+      recipient,
+      zeroForOne,
+      amountIn.toInt256(),
+      sqrtPriceLimitX96 == 0
+        ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+        : sqrtPriceLimitX96,
+      abi.encode(data)
+    );
+
+    return uint256(-(zeroForOne ? amount1 : amount0));
+  }
+
+  /// @inheritdoc ISwapRouter
+  function exactInputSingle(
+    ExactInputSingleParams calldata params
+  ) external payable override checkDeadline(params.deadline) returns (uint256 amountOut) {
+    amountOut = exactInputInternal(
+      params.amountIn,
+      params.recipient,
+      params.sqrtPriceLimitX96,
+      SwapCallbackData({ path: abi.encodePacked(params.tokenIn, params.fee, params.tokenOut), payer: msg.sender })
+    );
+    require(amountOut >= params.amountOutMinimum, "Too little received");
+  }
+
+  /// @inheritdoc ISwapRouter
+  function exactInput(
+    ExactInputParams memory params
+  ) external payable override checkDeadline(params.deadline) returns (uint256 amountOut) {
+    address payer = msg.sender; // msg.sender pays for the first hop
+
+    while (true) {
+      bool hasMultiplePools = params.path.hasMultiplePools();
+
+      // the outputs of prior swaps become the inputs to subsequent ones
+      params.amountIn = exactInputInternal(
+        params.amountIn,
+        hasMultiplePools ? address(this) : params.recipient, // for intermediate swaps, this contract custodies
+        0,
+        SwapCallbackData({
+          path: params.path.getFirstPool(), // only the first pool in the path is necessary
+          payer: payer
+        })
+      );
+
+      // decide whether to continue or terminate
+      if (hasMultiplePools) {
+        payer = address(this); // at this point, the caller has paid
+        params.path = params.path.skipToken();
+      } else {
+        amountOut = params.amountIn;
+        break;
+      }
+    }
+
+    require(amountOut >= params.amountOutMinimum, "Too little received");
+  }
+
+  /// @dev Performs a single exact output swap
+  function exactOutputInternal(
+    uint256 amountOut,
+    address recipient,
+    uint160 sqrtPriceLimitX96,
+    SwapCallbackData memory data
+  ) private returns (uint256 amountIn) {
+    // allow swapping to the router address with address 0
+    if (recipient == address(0)) recipient = address(this);
+
+    (address tokenOut, address tokenIn, uint24 fee) = data.path.decodeFirstPool();
+
+    bool zeroForOne = tokenIn < tokenOut;
+
+    (int256 amount0Delta, int256 amount1Delta) = getPool(tokenIn, tokenOut, fee).swap(
+      recipient,
+      zeroForOne,
+      -amountOut.toInt256(),
+      sqrtPriceLimitX96 == 0
+        ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+        : sqrtPriceLimitX96,
+      abi.encode(data)
+    );
+
+    uint256 amountOutReceived;
+    (amountIn, amountOutReceived) = zeroForOne
+      ? (uint256(amount0Delta), uint256(-amount1Delta))
+      : (uint256(amount1Delta), uint256(-amount0Delta));
+    // it's technically possible to not receive the full output amount,
+    // so if no price limit has been specified, require this possibility away
+    if (sqrtPriceLimitX96 == 0) require(amountOutReceived == amountOut);
+  }
+
+  /// @inheritdoc ISwapRouter
+  function exactOutputSingle(
+    ExactOutputSingleParams calldata params
+  ) external payable override checkDeadline(params.deadline) returns (uint256 amountIn) {
+    // avoid an SLOAD by using the swap return data
+    amountIn = exactOutputInternal(
+      params.amountOut,
+      params.recipient,
+      params.sqrtPriceLimitX96,
+      SwapCallbackData({ path: abi.encodePacked(params.tokenOut, params.fee, params.tokenIn), payer: msg.sender })
+    );
+
+    require(amountIn <= params.amountInMaximum, "Too much requested");
+    // has to be reset even though we don't use it in the single hop case
+    amountInCached = DEFAULT_AMOUNT_IN_CACHED;
+  }
+
+  /// @inheritdoc ISwapRouter
+  function exactOutput(
+    ExactOutputParams calldata params
+  ) external payable override checkDeadline(params.deadline) returns (uint256 amountIn) {
+    // it's okay that the payer is fixed to msg.sender here, as they're only paying for the "final" exact output
+    // swap, which happens first, and subsequent swaps are paid for within nested callback frames
+    exactOutputInternal(
+      params.amountOut,
+      params.recipient,
+      0,
+      SwapCallbackData({ path: params.path, payer: msg.sender })
+    );
+
+    amountIn = amountInCached;
+    require(amountIn <= params.amountInMaximum, "Too much requested");
+    amountInCached = DEFAULT_AMOUNT_IN_CACHED;
+  }
+}

--- a/src/dex/v3/periphery/base/BlockTimestamp.sol
+++ b/src/dex/v3/periphery/base/BlockTimestamp.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+/// @title Function for getting block timestamp
+/// @dev Base contract that is overridden for tests
+abstract contract BlockTimestamp {
+  /// @dev Method that exists purely to be overridden for tests
+  /// @return The current block timestamp
+  function _blockTimestamp() internal view virtual returns (uint256) {
+    return block.timestamp;
+  }
+}

--- a/src/dex/v3/periphery/base/ERC721Permit.sol
+++ b/src/dex/v3/periphery/base/ERC721Permit.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+
+import "../libraries/ChainId.sol";
+import "../interfaces/external/IERC1271.sol";
+import "../interfaces/IERC721Permit.sol";
+import "./BlockTimestamp.sol";
+
+/// @title ERC721 with permit
+/// @notice Nonfungible tokens that support an approve via signature, i.e. permit
+abstract contract ERC721Permit is BlockTimestamp, ERC721Enumerable, IERC721Permit {
+  /// @dev Gets the current nonce for a token ID and then increments it, returning the original value
+  function _getAndIncrementNonce(uint256 tokenId) internal virtual returns (uint256);
+
+  /// @dev The hash of the name used in the permit signature verification
+  bytes32 private immutable nameHash;
+
+  /// @dev The hash of the version string used in the permit signature verification
+  bytes32 private immutable versionHash;
+
+  /// @notice Computes the nameHash and versionHash
+  constructor(string memory name_, string memory symbol_, string memory version_) ERC721(name_, symbol_) {
+    nameHash = keccak256(bytes(name_));
+    versionHash = keccak256(bytes(version_));
+  }
+
+  /// @inheritdoc IERC721Permit
+  function DOMAIN_SEPARATOR() public view override returns (bytes32) {
+    return
+      keccak256(
+        abi.encode(
+          // keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)')
+          0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f,
+          nameHash,
+          versionHash,
+          ChainId.get(),
+          address(this)
+        )
+      );
+  }
+
+  /// @inheritdoc IERC721Permit
+  /// @dev Value is equal to keccak256("Permit(address spender,uint256 tokenId,uint256 nonce,uint256 deadline)");
+  bytes32 public constant override PERMIT_TYPEHASH = 0x49ecf333e5b8c95c40fdafc95c1ad136e8914a8fb55e9dc8bb01eaa83a2df9ad;
+
+  /// @inheritdoc IERC721Permit
+  function permit(
+    address spender,
+    uint256 tokenId,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable override {
+    require(_blockTimestamp() <= deadline, "Permit expired");
+
+    bytes32 digest = keccak256(
+      abi.encodePacked(
+        "\x19\x01",
+        DOMAIN_SEPARATOR(),
+        keccak256(abi.encode(PERMIT_TYPEHASH, spender, tokenId, _getAndIncrementNonce(tokenId), deadline))
+      )
+    );
+    address owner = ownerOf(tokenId);
+    require(spender != owner, "ERC721Permit: approval to current owner");
+
+    if (owner.code.length > 0) {
+      require(IERC1271(owner).isValidSignature(digest, abi.encodePacked(r, s, v)) == 0x1626ba7e, "Unauthorized");
+    } else {
+      address recoveredAddress = ecrecover(digest, v, r, s);
+      require(recoveredAddress != address(0), "Invalid signature");
+      require(recoveredAddress == owner, "Unauthorized");
+    }
+
+    _approve(spender, tokenId, address(0));
+  }
+}

--- a/src/dex/v3/periphery/base/LiquidityManagement.sol
+++ b/src/dex/v3/periphery/base/LiquidityManagement.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../../core/interfaces/IListaV3Factory.sol";
+import "../../core/interfaces/callback/IListaV3MintCallback.sol";
+import "../../core/libraries/TickMath.sol";
+
+import "../libraries/PoolAddress.sol";
+import "../libraries/CallbackValidation.sol";
+import "../libraries/LiquidityAmounts.sol";
+
+import "./PeripheryPayments.sol";
+import "./PeripheryImmutableState.sol";
+
+/// @title Liquidity management functions
+/// @notice Internal functions for safely managing liquidity in Lista V3
+abstract contract LiquidityManagement is IListaV3MintCallback, PeripheryImmutableState, PeripheryPayments {
+  struct MintCallbackData {
+    PoolAddress.PoolKey poolKey;
+    address payer;
+  }
+
+  /// @inheritdoc IListaV3MintCallback
+  function listaV3MintCallback(uint256 amount0Owed, uint256 amount1Owed, bytes calldata data) external override {
+    MintCallbackData memory decoded = abi.decode(data, (MintCallbackData));
+    CallbackValidation.verifyCallback(factory, decoded.poolKey);
+
+    if (amount0Owed > 0) pay(decoded.poolKey.token0, decoded.payer, msg.sender, amount0Owed);
+    if (amount1Owed > 0) pay(decoded.poolKey.token1, decoded.payer, msg.sender, amount1Owed);
+  }
+
+  struct AddLiquidityParams {
+    address token0;
+    address token1;
+    uint24 fee;
+    address recipient;
+    int24 tickLower;
+    int24 tickUpper;
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+  }
+
+  /// @notice Add liquidity to an initialized pool
+  function addLiquidity(
+    AddLiquidityParams memory params
+  ) internal returns (uint128 liquidity, uint256 amount0, uint256 amount1, IListaV3Pool pool) {
+    PoolAddress.PoolKey memory poolKey = PoolAddress.PoolKey({
+      token0: params.token0,
+      token1: params.token1,
+      fee: params.fee
+    });
+
+    pool = IListaV3Pool(PoolAddress.computeAddress(factory, poolKey, poolInitCodeHash));
+
+    // compute the liquidity amount
+    {
+      (uint160 sqrtPriceX96, , , , , , ) = pool.slot0();
+      uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(params.tickLower);
+      uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(params.tickUpper);
+
+      liquidity = LiquidityAmounts.getLiquidityForAmounts(
+        sqrtPriceX96,
+        sqrtRatioAX96,
+        sqrtRatioBX96,
+        params.amount0Desired,
+        params.amount1Desired
+      );
+    }
+
+    (amount0, amount1) = pool.mint(
+      params.recipient,
+      params.tickLower,
+      params.tickUpper,
+      liquidity,
+      abi.encode(MintCallbackData({ poolKey: poolKey, payer: msg.sender }))
+    );
+
+    require(amount0 >= params.amount0Min && amount1 >= params.amount1Min, "Price slippage check");
+  }
+}

--- a/src/dex/v3/periphery/base/Multicall.sol
+++ b/src/dex/v3/periphery/base/Multicall.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../interfaces/IMulticall.sol";
+
+/// @title Multicall
+/// @notice Enables calling multiple methods in a single call to the contract
+abstract contract Multicall is IMulticall {
+  /// @inheritdoc IMulticall
+  function multicall(bytes[] calldata data) public payable override returns (bytes[] memory results) {
+    results = new bytes[](data.length);
+    for (uint256 i = 0; i < data.length; i++) {
+      (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+
+      if (!success) {
+        // Next 5 lines from https://ethereum.stackexchange.com/a/83577
+        if (result.length < 68) revert();
+        assembly {
+          result := add(result, 0x04)
+        }
+        revert(abi.decode(result, (string)));
+      }
+
+      results[i] = result;
+    }
+  }
+}

--- a/src/dex/v3/periphery/base/PeripheryImmutableState.sol
+++ b/src/dex/v3/periphery/base/PeripheryImmutableState.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "../interfaces/IPeripheryImmutableState.sol";
+
+/// @title Immutable state
+/// @notice State used by periphery contracts — stored as regular storage for UUPS compatibility.
+abstract contract PeripheryImmutableState is IPeripheryImmutableState {
+  /// @inheritdoc IPeripheryImmutableState
+  address public override factory;
+  /// @inheritdoc IPeripheryImmutableState
+  address public override WETH9;
+
+  /// @dev The keccak256 of the pool proxy creation code, used to compute pool addresses.
+  bytes32 public poolInitCodeHash;
+
+  constructor(address _factory, address _WETH9) {
+    factory = _factory;
+    WETH9 = _WETH9;
+  }
+}

--- a/src/dex/v3/periphery/base/PeripheryPayments.sol
+++ b/src/dex/v3/periphery/base/PeripheryPayments.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "../interfaces/IPeripheryPayments.sol";
+import "../interfaces/external/IWETH9.sol";
+
+import "../libraries/TransferHelper.sol";
+
+import "./PeripheryImmutableState.sol";
+
+abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableState {
+  receive() external payable {
+    require(msg.sender == WETH9, "Not WETH9");
+  }
+
+  /// @inheritdoc IPeripheryPayments
+  function unwrapWETH9(uint256 amountMinimum, address recipient) public payable override {
+    uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
+    require(balanceWETH9 >= amountMinimum, "Insufficient WETH9");
+
+    if (balanceWETH9 > 0) {
+      IWETH9(WETH9).withdraw(balanceWETH9);
+      TransferHelper.safeTransferETH(recipient, balanceWETH9);
+    }
+  }
+
+  /// @inheritdoc IPeripheryPayments
+  function sweepToken(address token, uint256 amountMinimum, address recipient) public payable override {
+    uint256 balanceToken = IERC20(token).balanceOf(address(this));
+    require(balanceToken >= amountMinimum, "Insufficient token");
+
+    if (balanceToken > 0) {
+      TransferHelper.safeTransfer(token, recipient, balanceToken);
+    }
+  }
+
+  /// @inheritdoc IPeripheryPayments
+  function refundETH() external payable override {
+    if (address(this).balance > 0) TransferHelper.safeTransferETH(msg.sender, address(this).balance);
+  }
+
+  /// @param token The token to pay
+  /// @param payer The entity that must pay
+  /// @param recipient The entity that will receive payment
+  /// @param value The amount to pay
+  function pay(address token, address payer, address recipient, uint256 value) internal {
+    if (token == WETH9 && address(this).balance >= value) {
+      // pay with WETH9
+      IWETH9(WETH9).deposit{ value: value }(); // wrap only what is needed to pay
+      IWETH9(WETH9).transfer(recipient, value);
+    } else if (payer == address(this)) {
+      // pay with tokens already in the contract (for the exact input multihop case)
+      TransferHelper.safeTransfer(token, recipient, value);
+    } else {
+      // pull payment
+      TransferHelper.safeTransferFrom(token, payer, recipient, value);
+    }
+  }
+}

--- a/src/dex/v3/periphery/base/PeripheryPaymentsWithFee.sol
+++ b/src/dex/v3/periphery/base/PeripheryPaymentsWithFee.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "./PeripheryPayments.sol";
+import "../interfaces/IPeripheryPaymentsWithFee.sol";
+
+import "../interfaces/external/IWETH9.sol";
+import "../libraries/TransferHelper.sol";
+
+abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPaymentsWithFee {
+  /// @inheritdoc IPeripheryPaymentsWithFee
+  function unwrapWETH9WithFee(
+    uint256 amountMinimum,
+    address recipient,
+    uint256 feeBips,
+    address feeRecipient
+  ) public payable override {
+    require(feeBips > 0 && feeBips <= 100);
+
+    uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
+    require(balanceWETH9 >= amountMinimum, "Insufficient WETH9");
+
+    if (balanceWETH9 > 0) {
+      IWETH9(WETH9).withdraw(balanceWETH9);
+      uint256 feeAmount = (balanceWETH9 * feeBips) / 10_000;
+      if (feeAmount > 0) TransferHelper.safeTransferETH(feeRecipient, feeAmount);
+      TransferHelper.safeTransferETH(recipient, balanceWETH9 - feeAmount);
+    }
+  }
+
+  /// @inheritdoc IPeripheryPaymentsWithFee
+  function sweepTokenWithFee(
+    address token,
+    uint256 amountMinimum,
+    address recipient,
+    uint256 feeBips,
+    address feeRecipient
+  ) public payable override {
+    require(feeBips > 0 && feeBips <= 100);
+
+    uint256 balanceToken = IERC20(token).balanceOf(address(this));
+    require(balanceToken >= amountMinimum, "Insufficient token");
+
+    if (balanceToken > 0) {
+      uint256 feeAmount = (balanceToken * feeBips) / 10_000;
+      if (feeAmount > 0) TransferHelper.safeTransfer(token, feeRecipient, feeAmount);
+      TransferHelper.safeTransfer(token, recipient, balanceToken - feeAmount);
+    }
+  }
+}

--- a/src/dex/v3/periphery/base/PeripheryValidation.sol
+++ b/src/dex/v3/periphery/base/PeripheryValidation.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "./BlockTimestamp.sol";
+
+abstract contract PeripheryValidation is BlockTimestamp {
+  modifier checkDeadline(uint256 deadline) {
+    require(_blockTimestamp() <= deadline, "Transaction too old");
+    _;
+  }
+}

--- a/src/dex/v3/periphery/base/PoolInitializer.sol
+++ b/src/dex/v3/periphery/base/PoolInitializer.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "../../core/interfaces/IListaV3Factory.sol";
+import "../../core/interfaces/IListaV3Pool.sol";
+
+import "./PeripheryImmutableState.sol";
+import "../interfaces/IPoolInitializer.sol";
+
+/// @title Creates and initializes V3 Pools
+abstract contract PoolInitializer is IPoolInitializer, PeripheryImmutableState {
+  /// @inheritdoc IPoolInitializer
+  function createAndInitializePoolIfNecessary(
+    address token0,
+    address token1,
+    uint24 fee,
+    uint160 sqrtPriceX96
+  ) external payable override returns (address pool) {
+    require(token0 < token1);
+    pool = IListaV3Factory(factory).getPool(token0, token1, fee);
+
+    if (pool == address(0)) {
+      pool = IListaV3Factory(factory).createPool(token0, token1, fee);
+      IListaV3Pool(pool).initialize(sqrtPriceX96);
+    } else {
+      (uint160 sqrtPriceX96Existing, , , , , , ) = IListaV3Pool(pool).slot0();
+      if (sqrtPriceX96Existing == 0) {
+        IListaV3Pool(pool).initialize(sqrtPriceX96);
+      }
+    }
+  }
+}

--- a/src/dex/v3/periphery/base/SelfPermit.sol
+++ b/src/dex/v3/periphery/base/SelfPermit.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+
+import "../interfaces/ISelfPermit.sol";
+import "../interfaces/external/IERC20PermitAllowed.sol";
+
+/// @title Self Permit
+/// @notice Functionality to call permit on any EIP-2612-compliant token for use in the route
+/// @dev These functions are expected to be embedded in multicalls to allow EOAs to approve a contract and call a function
+/// that requires an approval in a single transaction.
+abstract contract SelfPermit is ISelfPermit {
+  /// @inheritdoc ISelfPermit
+  function selfPermit(
+    address token,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public payable override {
+    IERC20Permit(token).permit(msg.sender, address(this), value, deadline, v, r, s);
+  }
+
+  /// @inheritdoc ISelfPermit
+  function selfPermitIfNecessary(
+    address token,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable override {
+    if (IERC20(token).allowance(msg.sender, address(this)) < value) selfPermit(token, value, deadline, v, r, s);
+  }
+
+  /// @inheritdoc ISelfPermit
+  function selfPermitAllowed(
+    address token,
+    uint256 nonce,
+    uint256 expiry,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public payable override {
+    IERC20PermitAllowed(token).permit(msg.sender, address(this), nonce, expiry, true, v, r, s);
+  }
+
+  /// @inheritdoc ISelfPermit
+  function selfPermitAllowedIfNecessary(
+    address token,
+    uint256 nonce,
+    uint256 expiry,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable override {
+    if (IERC20(token).allowance(msg.sender, address(this)) < type(uint256).max)
+      selfPermitAllowed(token, nonce, expiry, v, r, s);
+  }
+}

--- a/src/dex/v3/periphery/interfaces/IERC20Metadata.sol
+++ b/src/dex/v3/periphery/interfaces/IERC20Metadata.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title IERC20Metadata
+/// @title Interface for ERC20 Metadata
+/// @notice Extension to IERC20 that includes token metadata
+interface IERC20Metadata is IERC20 {
+  /// @return The name of the token
+  function name() external view returns (string memory);
+
+  /// @return The symbol of the token
+  function symbol() external view returns (string memory);
+
+  /// @return The number of decimal places the token has
+  function decimals() external view returns (uint8);
+}

--- a/src/dex/v3/periphery/interfaces/IERC721Permit.sol
+++ b/src/dex/v3/periphery/interfaces/IERC721Permit.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title ERC721 with permit
+/// @notice Extension to ERC721 that includes a permit function for signature based approvals
+interface IERC721Permit is IERC721 {
+  /// @notice The permit typehash used in the permit signature
+  /// @return The typehash for the permit
+  function PERMIT_TYPEHASH() external pure returns (bytes32);
+
+  /// @notice The domain separator used in the permit signature
+  /// @return The domain seperator used in encoding of permit signature
+  function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+  /// @notice Approve of a specific token ID for spending by spender via signature
+  /// @param spender The account that is being approved
+  /// @param tokenId The ID of the token that is being approved for spending
+  /// @param deadline The deadline timestamp by which the call must be mined for the approve to work
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function permit(address spender, uint256 tokenId, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external payable;
+}

--- a/src/dex/v3/periphery/interfaces/IMulticall.sol
+++ b/src/dex/v3/periphery/interfaces/IMulticall.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Multicall interface
+/// @notice Enables calling multiple methods in a single call to the contract
+interface IMulticall {
+  /// @notice Call multiple functions in the current contract and return the data from all of them if they all succeed
+  /// @dev The `msg.value` should not be trusted for any method callable from multicall.
+  /// @param data The encoded function data for each of the calls to make to this contract
+  /// @return results The results from each of the calls passed in via data
+  function multicall(bytes[] calldata data) external payable returns (bytes[] memory results);
+}

--- a/src/dex/v3/periphery/interfaces/INonfungiblePositionManager.sol
+++ b/src/dex/v3/periphery/interfaces/INonfungiblePositionManager.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+
+import "./IPoolInitializer.sol";
+import "./IERC721Permit.sol";
+import "./IPeripheryPayments.sol";
+import "./IPeripheryImmutableState.sol";
+import "../libraries/PoolAddress.sol";
+
+/// @title Non-fungible token for positions
+/// @notice Wraps Lista V3 positions in a non-fungible token interface which allows for them to be transferred
+/// and authorized.
+interface INonfungiblePositionManager is
+  IPoolInitializer,
+  IPeripheryPayments,
+  IPeripheryImmutableState,
+  IERC721Metadata,
+  IERC721Enumerable,
+  IERC721Permit
+{
+  /// @notice Emitted when liquidity is increased for a position NFT
+  /// @dev Also emitted when a token is minted
+  /// @param tokenId The ID of the token for which liquidity was increased
+  /// @param liquidity The amount by which liquidity for the NFT position was increased
+  /// @param amount0 The amount of token0 that was paid for the increase in liquidity
+  /// @param amount1 The amount of token1 that was paid for the increase in liquidity
+  event IncreaseLiquidity(uint256 indexed tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+  /// @notice Emitted when liquidity is decreased for a position NFT
+  /// @param tokenId The ID of the token for which liquidity was decreased
+  /// @param liquidity The amount by which liquidity for the NFT position was decreased
+  /// @param amount0 The amount of token0 that was accounted for the decrease in liquidity
+  /// @param amount1 The amount of token1 that was accounted for the decrease in liquidity
+  event DecreaseLiquidity(uint256 indexed tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+  /// @notice Emitted when tokens are collected for a position NFT
+  /// @dev The amounts reported may not be exactly equivalent to the amounts transferred, due to rounding behavior
+  /// @param tokenId The ID of the token for which underlying tokens were collected
+  /// @param recipient The address of the account that received the collected tokens
+  /// @param amount0 The amount of token0 owed to the position that was collected
+  /// @param amount1 The amount of token1 owed to the position that was collected
+  event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1);
+
+  /// @notice Returns the position information associated with a given token ID.
+  /// @dev Throws if the token ID is not valid.
+  /// @param tokenId The ID of the token that represents the position
+  /// @return nonce The nonce for permits
+  /// @return operator The address that is approved for spending
+  /// @return token0 The address of the token0 for a specific pool
+  /// @return token1 The address of the token1 for a specific pool
+  /// @return fee The fee associated with the pool
+  /// @return tickLower The lower end of the tick range for the position
+  /// @return tickUpper The higher end of the tick range for the position
+  /// @return liquidity The liquidity of the position
+  /// @return feeGrowthInside0LastX128 The fee growth of token0 as of the last action on the individual position
+  /// @return feeGrowthInside1LastX128 The fee growth of token1 as of the last action on the individual position
+  /// @return tokensOwed0 The uncollected amount of token0 owed to the position as of the last computation
+  /// @return tokensOwed1 The uncollected amount of token1 owed to the position as of the last computation
+  function positions(
+    uint256 tokenId
+  )
+    external
+    view
+    returns (
+      uint96 nonce,
+      address operator,
+      address token0,
+      address token1,
+      uint24 fee,
+      int24 tickLower,
+      int24 tickUpper,
+      uint128 liquidity,
+      uint256 feeGrowthInside0LastX128,
+      uint256 feeGrowthInside1LastX128,
+      uint128 tokensOwed0,
+      uint128 tokensOwed1
+    );
+
+  struct MintParams {
+    address token0;
+    address token1;
+    uint24 fee;
+    int24 tickLower;
+    int24 tickUpper;
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    address recipient;
+    uint256 deadline;
+  }
+
+  /// @notice Creates a new position wrapped in a NFT
+  /// @dev Call this when the pool does exist and is initialized. Note that if the pool is created but not initialized
+  /// a method does not exist, i.e. the pool is assumed to be initialized.
+  /// @param params The params necessary to mint a position, encoded as `MintParams` in calldata
+  /// @return tokenId The ID of the token that represents the minted position
+  /// @return liquidity The amount of liquidity for this position
+  /// @return amount0 The amount of token0
+  /// @return amount1 The amount of token1
+  function mint(
+    MintParams calldata params
+  ) external payable returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+
+  struct IncreaseLiquidityParams {
+    uint256 tokenId;
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+  }
+
+  /// @notice Increases the amount of liquidity in a position, with tokens paid by the `msg.sender`
+  /// @param params tokenId The ID of the token for which liquidity is being increased,
+  /// amount0Desired The desired amount of token0 to be spent,
+  /// amount1Desired The desired amount of token1 to be spent,
+  /// amount0Min The minimum amount of token0 to spend, which serves as a slippage check,
+  /// amount1Min The minimum amount of token1 to spend, which serves as a slippage check,
+  /// deadline The time by which the transaction must be included to effect the change
+  /// @return liquidity The new liquidity amount as a result of the increase
+  /// @return amount0 The amount of token0 to acheive resulting liquidity
+  /// @return amount1 The amount of token1 to acheive resulting liquidity
+  function increaseLiquidity(
+    IncreaseLiquidityParams calldata params
+  ) external payable returns (uint128 liquidity, uint256 amount0, uint256 amount1);
+
+  struct DecreaseLiquidityParams {
+    uint256 tokenId;
+    uint128 liquidity;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+  }
+
+  /// @notice Decreases the amount of liquidity in a position and accounts it to the position
+  /// @param params tokenId The ID of the token for which liquidity is being decreased,
+  /// amount The amount by which liquidity will be decreased,
+  /// amount0Min The minimum amount of token0 that should be accounted for the burned liquidity,
+  /// amount1Min The minimum amount of token1 that should be accounted for the burned liquidity,
+  /// deadline The time by which the transaction must be included to effect the change
+  /// @return amount0 The amount of token0 accounted to the position's tokens owed
+  /// @return amount1 The amount of token1 accounted to the position's tokens owed
+  function decreaseLiquidity(
+    DecreaseLiquidityParams calldata params
+  ) external payable returns (uint256 amount0, uint256 amount1);
+
+  struct CollectParams {
+    uint256 tokenId;
+    address recipient;
+    uint128 amount0Max;
+    uint128 amount1Max;
+  }
+
+  /// @notice Collects up to a maximum amount of fees owed to a specific position to the recipient
+  /// @param params tokenId The ID of the NFT for which tokens are being collected,
+  /// recipient The account that should receive the tokens,
+  /// amount0Max The maximum amount of token0 to collect,
+  /// amount1Max The maximum amount of token1 to collect
+  /// @return amount0 The amount of fees collected in token0
+  /// @return amount1 The amount of fees collected in token1
+  function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1);
+
+  /// @notice Burns a token ID, which deletes it from the NFT contract. The token must have 0 liquidity and all tokens
+  /// must be collected first.
+  /// @param tokenId The ID of the token that is being burned
+  function burn(uint256 tokenId) external payable;
+}

--- a/src/dex/v3/periphery/interfaces/INonfungibleTokenPositionDescriptor.sol
+++ b/src/dex/v3/periphery/interfaces/INonfungibleTokenPositionDescriptor.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import "./INonfungiblePositionManager.sol";
+
+/// @title Describes position NFT tokens via URI
+interface INonfungibleTokenPositionDescriptor {
+  /// @notice Produces the URI describing a particular token ID for a position manager
+  /// @dev Note this URI may be a data: URI with the JSON contents directly inlined
+  /// @param positionManager The position manager for which to describe the token
+  /// @param tokenId The ID of the token for which to produce a description, which may not be valid
+  /// @return The URI of the ERC721-compliant metadata
+  function tokenURI(INonfungiblePositionManager positionManager, uint256 tokenId) external view returns (string memory);
+}

--- a/src/dex/v3/periphery/interfaces/IPeripheryImmutableState.sol
+++ b/src/dex/v3/periphery/interfaces/IPeripheryImmutableState.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Immutable state
+/// @notice Functions that return immutable state of the router
+interface IPeripheryImmutableState {
+  /// @return Returns the address of the Lista V3 factory
+  function factory() external view returns (address);
+
+  /// @return Returns the address of WETH9
+  function WETH9() external view returns (address);
+}

--- a/src/dex/v3/periphery/interfaces/IPeripheryPayments.sol
+++ b/src/dex/v3/periphery/interfaces/IPeripheryPayments.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+/// @title Periphery Payments
+/// @notice Functions to ease deposits and withdrawals of ETH
+interface IPeripheryPayments {
+  /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH.
+  /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
+  /// @param amountMinimum The minimum amount of WETH9 to unwrap
+  /// @param recipient The address receiving ETH
+  function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
+
+  /// @notice Refunds any ETH balance held by this contract to the `msg.sender`
+  /// @dev Useful for bundling with mint or increase liquidity that uses ether, or exact output swaps
+  /// that use ether for the input amount
+  function refundETH() external payable;
+
+  /// @notice Transfers the full amount of a token held by this contract to recipient
+  /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
+  /// @param token The contract address of the token which will be transferred to `recipient`
+  /// @param amountMinimum The minimum amount of token required for a transfer
+  /// @param recipient The destination address of the token
+  function sweepToken(address token, uint256 amountMinimum, address recipient) external payable;
+}

--- a/src/dex/v3/periphery/interfaces/IPeripheryPaymentsWithFee.sol
+++ b/src/dex/v3/periphery/interfaces/IPeripheryPaymentsWithFee.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+import "./IPeripheryPayments.sol";
+
+/// @title Periphery Payments
+/// @notice Functions to ease deposits and withdrawals of ETH
+interface IPeripheryPaymentsWithFee is IPeripheryPayments {
+  /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with a percentage between
+  /// 0 (exclusive), and 1 (inclusive) going to feeRecipient
+  /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
+  function unwrapWETH9WithFee(
+    uint256 amountMinimum,
+    address recipient,
+    uint256 feeBips,
+    address feeRecipient
+  ) external payable;
+
+  /// @notice Transfers the full amount of a token held by this contract to recipient, with a percentage between
+  /// 0 (exclusive) and 1 (inclusive) going to feeRecipient
+  /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
+  function sweepTokenWithFee(
+    address token,
+    uint256 amountMinimum,
+    address recipient,
+    uint256 feeBips,
+    address feeRecipient
+  ) external payable;
+}

--- a/src/dex/v3/periphery/interfaces/IPoolInitializer.sol
+++ b/src/dex/v3/periphery/interfaces/IPoolInitializer.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Creates and initializes V3 Pools
+/// @notice Provides a method for creating and initializing a pool, if necessary, for bundling with other methods that
+/// require the pool to exist.
+interface IPoolInitializer {
+  /// @notice Creates a new pool if it does not exist, then initializes if not initialized
+  /// @dev This method can be bundled with others via IMulticall for the first action (e.g. mint) performed against a pool
+  /// @param token0 The contract address of token0 of the pool
+  /// @param token1 The contract address of token1 of the pool
+  /// @param fee The fee amount of the v3 pool for the specified token pair
+  /// @param sqrtPriceX96 The initial square root price of the pool as a Q64.96 value
+  /// @return pool Returns the pool address based on the pair of tokens and fee, will return the newly created pool address if necessary
+  function createAndInitializePoolIfNecessary(
+    address token0,
+    address token1,
+    uint24 fee,
+    uint160 sqrtPriceX96
+  ) external payable returns (address pool);
+}

--- a/src/dex/v3/periphery/interfaces/IQuoter.sol
+++ b/src/dex/v3/periphery/interfaces/IQuoter.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Quoter Interface
+/// @notice Supports quoting the calculated amounts from exact input or exact output swaps
+/// @dev These functions are not marked view because they rely on calling non-view functions and reverting
+/// to compute the result. They are also not gas efficient and should not be called on-chain.
+interface IQuoter {
+  /// @notice Returns the amount out received for a given exact input swap without executing the swap
+  /// @param path The path of the swap, i.e. each token pair and the pool fee
+  /// @param amountIn The amount of the first token to swap
+  /// @return amountOut The amount of the last token that would be received
+  function quoteExactInput(bytes memory path, uint256 amountIn) external returns (uint256 amountOut);
+
+  /// @notice Returns the amount out received for a given exact input but for a swap of a single pool
+  /// @param tokenIn The token being swapped in
+  /// @param tokenOut The token being swapped out
+  /// @param fee The fee of the token pool to consider for the pair
+  /// @param amountIn The desired input amount
+  /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+  /// @return amountOut The amount of `tokenOut` that would be received
+  function quoteExactInputSingle(
+    address tokenIn,
+    address tokenOut,
+    uint24 fee,
+    uint256 amountIn,
+    uint160 sqrtPriceLimitX96
+  ) external returns (uint256 amountOut);
+
+  /// @notice Returns the amount in required for a given exact output swap without executing the swap
+  /// @param path The path of the swap, i.e. each token pair and the pool fee. Path must be provided in reverse order
+  /// @param amountOut The amount of the last token to receive
+  /// @return amountIn The amount of first token required to be paid
+  function quoteExactOutput(bytes memory path, uint256 amountOut) external returns (uint256 amountIn);
+
+  /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
+  /// @param tokenIn The token being swapped in
+  /// @param tokenOut The token being swapped out
+  /// @param fee The fee of the token pool to consider for the pair
+  /// @param amountOut The desired output amount
+  /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+  /// @return amountIn The amount required as the input for the swap in order to receive `amountOut`
+  function quoteExactOutputSingle(
+    address tokenIn,
+    address tokenOut,
+    uint24 fee,
+    uint256 amountOut,
+    uint160 sqrtPriceLimitX96
+  ) external returns (uint256 amountIn);
+}

--- a/src/dex/v3/periphery/interfaces/IQuoterV2.sol
+++ b/src/dex/v3/periphery/interfaces/IQuoterV2.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title QuoterV2 Interface
+/// @notice Supports quoting the calculated amounts from exact input or exact output swaps.
+/// @notice For each pool also tells you the number of initialized ticks crossed and the sqrt price of the pool after the swap.
+/// @dev These functions are not marked view because they rely on calling non-view functions and reverting
+/// to compute the result. They are also not gas efficient and should not be called on-chain.
+interface IQuoterV2 {
+  /// @notice Returns the amount out received for a given exact input swap without executing the swap
+  /// @param path The path of the swap, i.e. each token pair and the pool fee
+  /// @param amountIn The amount of the first token to swap
+  /// @return amountOut The amount of the last token that would be received
+  /// @return sqrtPriceX96AfterList List of the sqrt price after the swap for each pool in the path
+  /// @return initializedTicksCrossedList List of the initialized ticks that the swap crossed for each pool in the path
+  /// @return gasEstimate The estimate of the gas that the swap consumes
+  function quoteExactInput(
+    bytes memory path,
+    uint256 amountIn
+  )
+    external
+    returns (
+      uint256 amountOut,
+      uint160[] memory sqrtPriceX96AfterList,
+      uint32[] memory initializedTicksCrossedList,
+      uint256 gasEstimate
+    );
+
+  struct QuoteExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint256 amountIn;
+    uint24 fee;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  /// @notice Returns the amount out received for a given exact input but for a swap of a single pool
+  /// @param params The params for the quote, encoded as `QuoteExactInputSingleParams`
+  /// tokenIn The token being swapped in
+  /// tokenOut The token being swapped out
+  /// fee The fee of the token pool to consider for the pair
+  /// amountIn The desired input amount
+  /// sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+  /// @return amountOut The amount of `tokenOut` that would be received
+  /// @return sqrtPriceX96After The sqrt price of the pool after the swap
+  /// @return initializedTicksCrossed The number of initialized ticks that the swap crossed
+  /// @return gasEstimate The estimate of the gas that the swap consumes
+  function quoteExactInputSingle(
+    QuoteExactInputSingleParams memory params
+  )
+    external
+    returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate);
+
+  /// @notice Returns the amount in required for a given exact output swap without executing the swap
+  /// @param path The path of the swap, i.e. each token pair and the pool fee. Path must be provided in reverse order
+  /// @param amountOut The amount of the last token to receive
+  /// @return amountIn The amount of first token required to be paid
+  /// @return sqrtPriceX96AfterList List of the sqrt price after the swap for each pool in the path
+  /// @return initializedTicksCrossedList List of the initialized ticks that the swap crossed for each pool in the path
+  /// @return gasEstimate The estimate of the gas that the swap consumes
+  function quoteExactOutput(
+    bytes memory path,
+    uint256 amountOut
+  )
+    external
+    returns (
+      uint256 amountIn,
+      uint160[] memory sqrtPriceX96AfterList,
+      uint32[] memory initializedTicksCrossedList,
+      uint256 gasEstimate
+    );
+
+  struct QuoteExactOutputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint256 amount;
+    uint24 fee;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
+  /// @param params The params for the quote, encoded as `QuoteExactOutputSingleParams`
+  /// tokenIn The token being swapped in
+  /// tokenOut The token being swapped out
+  /// fee The fee of the token pool to consider for the pair
+  /// amountOut The desired output amount
+  /// sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+  /// @return amountIn The amount required as the input for the swap in order to receive `amountOut`
+  /// @return sqrtPriceX96After The sqrt price of the pool after the swap
+  /// @return initializedTicksCrossed The number of initialized ticks that the swap crossed
+  /// @return gasEstimate The estimate of the gas that the swap consumes
+  function quoteExactOutputSingle(
+    QuoteExactOutputSingleParams memory params
+  ) external returns (uint256 amountIn, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate);
+}

--- a/src/dex/v3/periphery/interfaces/ISelfPermit.sol
+++ b/src/dex/v3/periphery/interfaces/ISelfPermit.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+/// @title Self Permit
+/// @notice Functionality to call permit on any EIP-2612-compliant token for use in the route
+interface ISelfPermit {
+  /// @notice Permits this contract to spend a given token from `msg.sender`
+  /// @dev The `owner` is always msg.sender and the `spender` is always address(this).
+  /// @param token The address of the token spent
+  /// @param value The amount that can be spent of token
+  /// @param deadline A timestamp, the current blocktime must be less than or equal to this timestamp
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external payable;
+
+  /// @notice Permits this contract to spend a given token from `msg.sender`
+  /// @dev The `owner` is always msg.sender and the `spender` is always address(this).
+  /// Can be used instead of #selfPermit to prevent calls from failing due to a frontrun of a call to #selfPermit
+  /// @param token The address of the token spent
+  /// @param value The amount that can be spent of token
+  /// @param deadline A timestamp, the current blocktime must be less than or equal to this timestamp
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function selfPermitIfNecessary(
+    address token,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable;
+
+  /// @notice Permits this contract to spend the sender's tokens for permit signatures that have the `allowed` parameter
+  /// @dev The `owner` is always msg.sender and the `spender` is always address(this)
+  /// @param token The address of the token spent
+  /// @param nonce The current nonce of the owner
+  /// @param expiry The timestamp at which the permit is no longer valid
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function selfPermitAllowed(
+    address token,
+    uint256 nonce,
+    uint256 expiry,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable;
+
+  /// @notice Permits this contract to spend the sender's tokens for permit signatures that have the `allowed` parameter
+  /// @dev The `owner` is always msg.sender and the `spender` is always address(this)
+  /// Can be used instead of #selfPermitAllowed to prevent calls from failing due to a frontrun of a call to #selfPermitAllowed.
+  /// @param token The address of the token spent
+  /// @param nonce The current nonce of the owner
+  /// @param expiry The timestamp at which the permit is no longer valid
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function selfPermitAllowedIfNecessary(
+    address token,
+    uint256 nonce,
+    uint256 expiry,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable;
+}

--- a/src/dex/v3/periphery/interfaces/ISwapRouter.sol
+++ b/src/dex/v3/periphery/interfaces/ISwapRouter.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+import "../../core/interfaces/callback/IListaV3SwapCallback.sol";
+
+/// @title Router token swapping functionality
+/// @notice Functions for swapping tokens via Lista V3
+interface ISwapRouter is IListaV3SwapCallback {
+  struct ExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 deadline;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  /// @notice Swaps `amountIn` of one token for as much as possible of another token
+  /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
+  /// @return amountOut The amount of the received token
+  function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+  struct ExactInputParams {
+    bytes path;
+    address recipient;
+    uint256 deadline;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+  }
+
+  /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
+  /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
+  /// @return amountOut The amount of the received token
+  function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+
+  struct ExactOutputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 deadline;
+    uint256 amountOut;
+    uint256 amountInMaximum;
+    uint160 sqrtPriceLimitX96;
+  }
+
+  /// @notice Swaps as little as possible of one token for `amountOut` of another token
+  /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
+  /// @return amountIn The amount of the input token
+  function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+  struct ExactOutputParams {
+    bytes path;
+    address recipient;
+    uint256 deadline;
+    uint256 amountOut;
+    uint256 amountInMaximum;
+  }
+
+  /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
+  /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
+  /// @return amountIn The amount of the input token
+  function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+}

--- a/src/dex/v3/periphery/interfaces/ITickLens.sol
+++ b/src/dex/v3/periphery/interfaces/ITickLens.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Tick Lens
+/// @notice Provides functions for fetching chunks of tick data for a pool
+/// @dev This avoids the waterfall of fetching the tick bitmap, parsing the bitmap to know which ticks to fetch, and
+/// then sending additional multicalls to fetch the tick data
+interface ITickLens {
+  struct PopulatedTick {
+    int24 tick;
+    int128 liquidityNet;
+    uint128 liquidityGross;
+  }
+
+  /// @notice Get all the tick data for the populated ticks from a word of the tick bitmap of a pool
+  /// @param pool The address of the pool for which to fetch populated tick data
+  /// @param tickBitmapIndex The index of the word in the tick bitmap for which to parse the bitmap and
+  /// fetch all the populated ticks
+  /// @return populatedTicks An array of tick data for the given word in the tick bitmap
+  function getPopulatedTicksInWord(
+    address pool,
+    int16 tickBitmapIndex
+  ) external view returns (PopulatedTick[] memory populatedTicks);
+}

--- a/src/dex/v3/periphery/interfaces/external/IERC1271.sol
+++ b/src/dex/v3/periphery/interfaces/external/IERC1271.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Interface for verifying contract-based account signatures
+/// @notice Interface that verifies provided signature for the data
+/// @dev Interface defined by EIP-1271
+interface IERC1271 {
+  /// @notice Returns whether the provided signature is valid for the provided data
+  /// @dev MUST return the bytes4 magic value 0x1626ba7e when function passes.
+  /// MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5).
+  /// MUST allow external calls.
+  /// @param hash Hash of the data to be signed
+  /// @param signature Signature byte array associated with _data
+  /// @return magicValue The bytes4 magic value 0x1626ba7e
+  function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue);
+}

--- a/src/dex/v3/periphery/interfaces/external/IERC20PermitAllowed.sol
+++ b/src/dex/v3/periphery/interfaces/external/IERC20PermitAllowed.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Interface for permit
+/// @notice Interface used by DAI/CHAI for permit
+interface IERC20PermitAllowed {
+  /// @notice Approve the spender to spend some tokens via the holder signature
+  /// @dev This is the permit interface used by DAI and CHAI
+  /// @param holder The address of the token holder, the token owner
+  /// @param spender The address of the token spender
+  /// @param nonce The holder's nonce, increases at each call to permit
+  /// @param expiry The timestamp at which the permit is no longer valid
+  /// @param allowed Boolean that sets approval amount, true for type(uint256).max and false for 0
+  /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function permit(
+    address holder,
+    address spender,
+    uint256 nonce,
+    uint256 expiry,
+    bool allowed,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external;
+}

--- a/src/dex/v3/periphery/interfaces/external/IWETH9.sol
+++ b/src/dex/v3/periphery/interfaces/external/IWETH9.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title Interface for WETH9
+interface IWETH9 is IERC20 {
+  /// @notice Deposit ether to get wrapped ether
+  function deposit() external payable;
+
+  /// @notice Withdraw wrapped ether to get ether
+  function withdraw(uint256) external;
+}

--- a/src/dex/v3/periphery/lens/ListaInterfaceMulticall.sol
+++ b/src/dex/v3/periphery/lens/ListaInterfaceMulticall.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+/// @notice A fork of Multicall2 specifically tailored for the Lista Interface
+contract ListaInterfaceMulticall {
+  struct Call {
+    address target;
+    uint256 gasLimit;
+    bytes callData;
+  }
+
+  struct Result {
+    bool success;
+    uint256 gasUsed;
+    bytes returnData;
+  }
+
+  function getCurrentBlockTimestamp() public view returns (uint256 timestamp) {
+    timestamp = block.timestamp;
+  }
+
+  function getEthBalance(address addr) public view returns (uint256 balance) {
+    balance = addr.balance;
+  }
+
+  function multicall(Call[] memory calls) public returns (uint256 blockNumber, Result[] memory returnData) {
+    blockNumber = block.number;
+    returnData = new Result[](calls.length);
+    for (uint256 i = 0; i < calls.length; i++) {
+      (address target, uint256 gasLimit, bytes memory callData) = (
+        calls[i].target,
+        calls[i].gasLimit,
+        calls[i].callData
+      );
+      uint256 gasLeftBefore = gasleft();
+      (bool success, bytes memory ret) = target.call{ gas: gasLimit }(callData);
+      uint256 gasUsed = gasLeftBefore - gasleft();
+      returnData[i] = Result(success, gasUsed, ret);
+    }
+  }
+}

--- a/src/dex/v3/periphery/lens/Quoter.sol
+++ b/src/dex/v3/periphery/lens/Quoter.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../../core/libraries/SafeCast.sol";
+import "../../core/libraries/TickMath.sol";
+import "../../core/interfaces/IListaV3Pool.sol";
+import "../../core/interfaces/callback/IListaV3SwapCallback.sol";
+
+import "../interfaces/IQuoter.sol";
+import "../base/PeripheryImmutableState.sol";
+import "../libraries/Path.sol";
+import "../libraries/PoolAddress.sol";
+import "../libraries/CallbackValidation.sol";
+
+/// @title Provides quotes for swaps
+/// @notice Allows getting the expected amount out or amount in for a given swap without executing the swap
+/// @dev These functions are not gas efficient and should _not_ be called on chain. Instead, optimistically execute
+/// the swap and check the amounts in the callback.
+contract Quoter is IQuoter, IListaV3SwapCallback, PeripheryImmutableState {
+  using Path for bytes;
+  using SafeCast for uint256;
+
+  /// @dev Transient storage variable used to check a safety condition in exact output swaps.
+  uint256 private amountOutCached;
+
+  constructor(address _factory, address _WETH9) PeripheryImmutableState(_factory, _WETH9) {}
+
+  function getPool(address tokenA, address tokenB, uint24 fee) private view returns (IListaV3Pool) {
+    return
+      IListaV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee), poolInitCodeHash));
+  }
+
+  /// @inheritdoc IListaV3SwapCallback
+  function listaV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes memory path) external view override {
+    require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
+    (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+    CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
+
+    (bool isExactInput, uint256 amountToPay, uint256 amountReceived) = amount0Delta > 0
+      ? (tokenIn < tokenOut, uint256(amount0Delta), uint256(-amount1Delta))
+      : (tokenOut < tokenIn, uint256(amount1Delta), uint256(-amount0Delta));
+    if (isExactInput) {
+      assembly {
+        let ptr := mload(0x40)
+        mstore(ptr, amountReceived)
+        revert(ptr, 32)
+      }
+    } else {
+      // if the cache has been populated, ensure that the full output amount has been received
+      if (amountOutCached != 0) require(amountReceived == amountOutCached);
+      assembly {
+        let ptr := mload(0x40)
+        mstore(ptr, amountToPay)
+        revert(ptr, 32)
+      }
+    }
+  }
+
+  /// @dev Parses a revert reason that should contain the numeric quote
+  function parseRevertReason(bytes memory reason) private pure returns (uint256) {
+    if (reason.length != 32) {
+      if (reason.length < 68) revert("Unexpected error");
+      assembly {
+        reason := add(reason, 0x04)
+      }
+      revert(abi.decode(reason, (string)));
+    }
+    return abi.decode(reason, (uint256));
+  }
+
+  /// @inheritdoc IQuoter
+  function quoteExactInputSingle(
+    address tokenIn,
+    address tokenOut,
+    uint24 fee,
+    uint256 amountIn,
+    uint160 sqrtPriceLimitX96
+  ) public override returns (uint256 amountOut) {
+    bool zeroForOne = tokenIn < tokenOut;
+
+    try
+      getPool(tokenIn, tokenOut, fee).swap(
+        address(this), // address(0) might cause issues with some tokens
+        zeroForOne,
+        amountIn.toInt256(),
+        sqrtPriceLimitX96 == 0
+          ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+          : sqrtPriceLimitX96,
+        abi.encodePacked(tokenIn, fee, tokenOut)
+      )
+    {} catch (bytes memory reason) {
+      return parseRevertReason(reason);
+    }
+  }
+
+  /// @inheritdoc IQuoter
+  function quoteExactInput(bytes memory path, uint256 amountIn) external override returns (uint256 amountOut) {
+    while (true) {
+      bool hasMultiplePools = path.hasMultiplePools();
+
+      (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+
+      // the outputs of prior swaps become the inputs to subsequent ones
+      amountIn = quoteExactInputSingle(tokenIn, tokenOut, fee, amountIn, 0);
+
+      // decide whether to continue or terminate
+      if (hasMultiplePools) {
+        path = path.skipToken();
+      } else {
+        return amountIn;
+      }
+    }
+  }
+
+  /// @inheritdoc IQuoter
+  function quoteExactOutputSingle(
+    address tokenIn,
+    address tokenOut,
+    uint24 fee,
+    uint256 amountOut,
+    uint160 sqrtPriceLimitX96
+  ) public override returns (uint256 amountIn) {
+    bool zeroForOne = tokenIn < tokenOut;
+
+    // if no price limit has been specified, cache the output amount for comparison in the swap callback
+    if (sqrtPriceLimitX96 == 0) amountOutCached = amountOut;
+    try
+      getPool(tokenIn, tokenOut, fee).swap(
+        address(this), // address(0) might cause issues with some tokens
+        zeroForOne,
+        -amountOut.toInt256(),
+        sqrtPriceLimitX96 == 0
+          ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+          : sqrtPriceLimitX96,
+        abi.encodePacked(tokenOut, fee, tokenIn)
+      )
+    {} catch (bytes memory reason) {
+      if (sqrtPriceLimitX96 == 0) delete amountOutCached; // clear cache
+      return parseRevertReason(reason);
+    }
+  }
+
+  /// @inheritdoc IQuoter
+  function quoteExactOutput(bytes memory path, uint256 amountOut) external override returns (uint256 amountIn) {
+    while (true) {
+      bool hasMultiplePools = path.hasMultiplePools();
+
+      (address tokenOut, address tokenIn, uint24 fee) = path.decodeFirstPool();
+
+      // the inputs of prior swaps become the outputs of subsequent ones
+      amountOut = quoteExactOutputSingle(tokenIn, tokenOut, fee, amountOut, 0);
+
+      // decide whether to continue or terminate
+      if (hasMultiplePools) {
+        path = path.skipToken();
+      } else {
+        return amountOut;
+      }
+    }
+  }
+}

--- a/src/dex/v3/periphery/lens/QuoterV2.sol
+++ b/src/dex/v3/periphery/lens/QuoterV2.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+pragma abicoder v2;
+
+import "../../core/libraries/SafeCast.sol";
+import "../../core/libraries/TickMath.sol";
+import "../../core/libraries/TickBitmap.sol";
+import "../../core/interfaces/IListaV3Pool.sol";
+import "../../core/interfaces/callback/IListaV3SwapCallback.sol";
+
+import "../interfaces/IQuoterV2.sol";
+import "../base/PeripheryImmutableState.sol";
+import "../libraries/Path.sol";
+import "../libraries/PoolAddress.sol";
+import "../libraries/CallbackValidation.sol";
+import "../libraries/PoolTicksCounter.sol";
+
+/// @title Provides quotes for swaps
+/// @notice Allows getting the expected amount out or amount in for a given swap without executing the swap
+/// @dev These functions are not gas efficient and should _not_ be called on chain. Instead, optimistically execute
+/// the swap and check the amounts in the callback.
+contract QuoterV2 is IQuoterV2, IListaV3SwapCallback, PeripheryImmutableState {
+  using Path for bytes;
+  using SafeCast for uint256;
+  using PoolTicksCounter for IListaV3Pool;
+
+  /// @dev Transient storage variable used to check a safety condition in exact output swaps.
+  uint256 private amountOutCached;
+
+  constructor(address _factory, address _WETH9) PeripheryImmutableState(_factory, _WETH9) {}
+
+  function getPool(address tokenA, address tokenB, uint24 fee) private view returns (IListaV3Pool) {
+    return
+      IListaV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee), poolInitCodeHash));
+  }
+
+  /// @inheritdoc IListaV3SwapCallback
+  function listaV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes memory path) external view override {
+    require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
+    (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+    CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
+
+    (bool isExactInput, uint256 amountToPay, uint256 amountReceived) = amount0Delta > 0
+      ? (tokenIn < tokenOut, uint256(amount0Delta), uint256(-amount1Delta))
+      : (tokenOut < tokenIn, uint256(amount1Delta), uint256(-amount0Delta));
+
+    IListaV3Pool pool = getPool(tokenIn, tokenOut, fee);
+    (uint160 sqrtPriceX96After, int24 tickAfter, , , , , ) = pool.slot0();
+
+    if (isExactInput) {
+      assembly {
+        let ptr := mload(0x40)
+        mstore(ptr, amountReceived)
+        mstore(add(ptr, 0x20), sqrtPriceX96After)
+        mstore(add(ptr, 0x40), tickAfter)
+        revert(ptr, 96)
+      }
+    } else {
+      // if the cache has been populated, ensure that the full output amount has been received
+      if (amountOutCached != 0) require(amountReceived == amountOutCached);
+      assembly {
+        let ptr := mload(0x40)
+        mstore(ptr, amountToPay)
+        mstore(add(ptr, 0x20), sqrtPriceX96After)
+        mstore(add(ptr, 0x40), tickAfter)
+        revert(ptr, 96)
+      }
+    }
+  }
+
+  /// @dev Parses a revert reason that should contain the numeric quote
+  function parseRevertReason(
+    bytes memory reason
+  ) private pure returns (uint256 amount, uint160 sqrtPriceX96After, int24 tickAfter) {
+    if (reason.length != 96) {
+      if (reason.length < 68) revert("Unexpected error");
+      assembly {
+        reason := add(reason, 0x04)
+      }
+      revert(abi.decode(reason, (string)));
+    }
+    return abi.decode(reason, (uint256, uint160, int24));
+  }
+
+  function handleRevert(
+    bytes memory reason,
+    IListaV3Pool pool,
+    uint256 gasEstimate
+  ) private view returns (uint256 amount, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256) {
+    int24 tickBefore;
+    int24 tickAfter;
+    (, tickBefore, , , , , ) = pool.slot0();
+    (amount, sqrtPriceX96After, tickAfter) = parseRevertReason(reason);
+
+    initializedTicksCrossed = pool.countInitializedTicksCrossed(tickBefore, tickAfter);
+
+    return (amount, sqrtPriceX96After, initializedTicksCrossed, gasEstimate);
+  }
+
+  function quoteExactInputSingle(
+    QuoteExactInputSingleParams memory params
+  )
+    public
+    override
+    returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+  {
+    bool zeroForOne = params.tokenIn < params.tokenOut;
+    IListaV3Pool pool = getPool(params.tokenIn, params.tokenOut, params.fee);
+
+    uint256 gasBefore = gasleft();
+    try
+      pool.swap(
+        address(this), // address(0) might cause issues with some tokens
+        zeroForOne,
+        params.amountIn.toInt256(),
+        params.sqrtPriceLimitX96 == 0
+          ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+          : params.sqrtPriceLimitX96,
+        abi.encodePacked(params.tokenIn, params.fee, params.tokenOut)
+      )
+    {} catch (bytes memory reason) {
+      gasEstimate = gasBefore - gasleft();
+      return handleRevert(reason, pool, gasEstimate);
+    }
+  }
+
+  function quoteExactInput(
+    bytes memory path,
+    uint256 amountIn
+  )
+    public
+    override
+    returns (
+      uint256 amountOut,
+      uint160[] memory sqrtPriceX96AfterList,
+      uint32[] memory initializedTicksCrossedList,
+      uint256 gasEstimate
+    )
+  {
+    sqrtPriceX96AfterList = new uint160[](path.numPools());
+    initializedTicksCrossedList = new uint32[](path.numPools());
+
+    uint256 i = 0;
+    while (true) {
+      (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+
+      // the outputs of prior swaps become the inputs to subsequent ones
+      (
+        uint256 _amountOut,
+        uint160 _sqrtPriceX96After,
+        uint32 _initializedTicksCrossed,
+        uint256 _gasEstimate
+      ) = quoteExactInputSingle(
+          QuoteExactInputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: tokenOut,
+            fee: fee,
+            amountIn: amountIn,
+            sqrtPriceLimitX96: 0
+          })
+        );
+
+      sqrtPriceX96AfterList[i] = _sqrtPriceX96After;
+      initializedTicksCrossedList[i] = _initializedTicksCrossed;
+      amountIn = _amountOut;
+      gasEstimate += _gasEstimate;
+      i++;
+
+      // decide whether to continue or terminate
+      if (path.hasMultiplePools()) {
+        path = path.skipToken();
+      } else {
+        return (amountIn, sqrtPriceX96AfterList, initializedTicksCrossedList, gasEstimate);
+      }
+    }
+  }
+
+  function quoteExactOutputSingle(
+    QuoteExactOutputSingleParams memory params
+  )
+    public
+    override
+    returns (uint256 amountIn, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+  {
+    bool zeroForOne = params.tokenIn < params.tokenOut;
+    IListaV3Pool pool = getPool(params.tokenIn, params.tokenOut, params.fee);
+
+    // if no price limit has been specified, cache the output amount for comparison in the swap callback
+    if (params.sqrtPriceLimitX96 == 0) amountOutCached = params.amount;
+    uint256 gasBefore = gasleft();
+    try
+      pool.swap(
+        address(this), // address(0) might cause issues with some tokens
+        zeroForOne,
+        -params.amount.toInt256(),
+        params.sqrtPriceLimitX96 == 0
+          ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+          : params.sqrtPriceLimitX96,
+        abi.encodePacked(params.tokenOut, params.fee, params.tokenIn)
+      )
+    {} catch (bytes memory reason) {
+      gasEstimate = gasBefore - gasleft();
+      if (params.sqrtPriceLimitX96 == 0) delete amountOutCached; // clear cache
+      return handleRevert(reason, pool, gasEstimate);
+    }
+  }
+
+  function quoteExactOutput(
+    bytes memory path,
+    uint256 amountOut
+  )
+    public
+    override
+    returns (
+      uint256 amountIn,
+      uint160[] memory sqrtPriceX96AfterList,
+      uint32[] memory initializedTicksCrossedList,
+      uint256 gasEstimate
+    )
+  {
+    sqrtPriceX96AfterList = new uint160[](path.numPools());
+    initializedTicksCrossedList = new uint32[](path.numPools());
+
+    uint256 i = 0;
+    while (true) {
+      (address tokenOut, address tokenIn, uint24 fee) = path.decodeFirstPool();
+
+      // the inputs of prior swaps become the outputs of subsequent ones
+      (
+        uint256 _amountIn,
+        uint160 _sqrtPriceX96After,
+        uint32 _initializedTicksCrossed,
+        uint256 _gasEstimate
+      ) = quoteExactOutputSingle(
+          QuoteExactOutputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: tokenOut,
+            amount: amountOut,
+            fee: fee,
+            sqrtPriceLimitX96: 0
+          })
+        );
+
+      sqrtPriceX96AfterList[i] = _sqrtPriceX96After;
+      initializedTicksCrossedList[i] = _initializedTicksCrossed;
+      amountOut = _amountIn;
+      gasEstimate += _gasEstimate;
+      i++;
+
+      // decide whether to continue or terminate
+      if (path.hasMultiplePools()) {
+        path = path.skipToken();
+      } else {
+        return (amountOut, sqrtPriceX96AfterList, initializedTicksCrossedList, gasEstimate);
+      }
+    }
+  }
+}

--- a/src/dex/v3/periphery/lens/README.md
+++ b/src/dex/v3/periphery/lens/README.md
@@ -1,0 +1,4 @@
+# lens
+
+These contracts are not designed to be called on-chain. They simplify
+fetching on-chain data from off-chain.

--- a/src/dex/v3/periphery/lens/TickLens.sol
+++ b/src/dex/v3/periphery/lens/TickLens.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+pragma abicoder v2;
+
+import "../../core/interfaces/IListaV3Pool.sol";
+
+import "../interfaces/ITickLens.sol";
+
+/// @title Tick Lens contract
+contract TickLens is ITickLens {
+  /// @inheritdoc ITickLens
+  function getPopulatedTicksInWord(
+    address pool,
+    int16 tickBitmapIndex
+  ) public view override returns (PopulatedTick[] memory populatedTicks) {
+    // fetch bitmap
+    uint256 bitmap = IListaV3Pool(pool).tickBitmap(tickBitmapIndex);
+    unchecked {
+      // calculate the number of populated ticks
+      uint256 numberOfPopulatedTicks;
+      for (uint256 i = 0; i < 256; i++) {
+        if (bitmap & (1 << i) > 0) numberOfPopulatedTicks++;
+      }
+
+      // fetch populated tick data
+      int24 tickSpacing = IListaV3Pool(pool).tickSpacing();
+      populatedTicks = new PopulatedTick[](numberOfPopulatedTicks);
+      for (uint256 i = 0; i < 256; i++) {
+        if (bitmap & (1 << i) > 0) {
+          int24 populatedTick = ((int24(tickBitmapIndex) << 8) + int24(uint24(i))) * tickSpacing;
+          (uint128 liquidityGross, int128 liquidityNet, , , , , , ) = IListaV3Pool(pool).ticks(populatedTick);
+          populatedTicks[--numberOfPopulatedTicks] = PopulatedTick({
+            tick: populatedTick,
+            liquidityNet: liquidityNet,
+            liquidityGross: liquidityGross
+          });
+        }
+      }
+    }
+  }
+}

--- a/src/dex/v3/periphery/libraries/AddressStringUtil.sol
+++ b/src/dex/v3/periphery/libraries/AddressStringUtil.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// from https://github.com/Lista/solidity-lib/blob/master/contracts/libraries/AddressStringUtil.sol
+// modified for solidity 0.8
+
+pragma solidity 0.8.34;
+
+library AddressStringUtil {
+  // converts an address to the uppercase hex string, extracting only len bytes (up to 20, multiple of 2)
+  function toAsciiString(address addr, uint256 len) internal pure returns (string memory) {
+    require(len % 2 == 0 && len > 0 && len <= 40, "AddressStringUtil: INVALID_LEN");
+
+    bytes memory s = new bytes(len);
+    uint256 addrNum = uint256(uint160(addr));
+    for (uint256 i = 0; i < len / 2; i++) {
+      // shift right and truncate all but the least significant byte to extract the byte at position 19-i
+      uint8 b = uint8(addrNum >> (8 * (19 - i)));
+      // first hex character is the most significant 4 bits
+      uint8 hi = b >> 4;
+      // second hex character is the least significant 4 bits
+      uint8 lo = b - (hi << 4);
+      s[2 * i] = char(hi);
+      s[2 * i + 1] = char(lo);
+    }
+    return string(s);
+  }
+
+  // hi and lo are only 4 bits and between 0 and 16
+  // this method converts those values to the unicode/ascii code point for the hex representation
+  // uses upper case for the characters
+  function char(uint8 b) private pure returns (bytes1 c) {
+    if (b < 10) {
+      return bytes1(b + 0x30);
+    } else {
+      return bytes1(b + 0x37);
+    }
+  }
+}

--- a/src/dex/v3/periphery/libraries/BytesLib.sol
+++ b/src/dex/v3/periphery/libraries/BytesLib.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * @title Solidity Bytes Arrays Utils
+ * @author Gonçalo Sá <goncalo.sa@consensys.net>
+ *
+ * @dev Bytes tightly packed arrays utility library for ethereum contracts written in Solidity.
+ *      The library lets you concatenate, slice and type cast bytes arrays both in memory and storage.
+ */
+pragma solidity 0.8.34 <0.9.0;
+
+library BytesLib {
+  function slice(bytes memory _bytes, uint256 _start, uint256 _length) internal pure returns (bytes memory) {
+    require(_length + 31 >= _length, "slice_overflow");
+    require(_bytes.length >= _start + _length, "slice_outOfBounds");
+
+    bytes memory tempBytes;
+
+    assembly {
+      switch iszero(_length)
+      case 0 {
+        // Get a location of some free memory and store it in tempBytes as
+        // Solidity does for memory variables.
+        tempBytes := mload(0x40)
+
+        // The first word of the slice result is potentially a partial
+        // word read from the original array. To read it, we calculate
+        // the length of that partial word and start copying that many
+        // bytes into the array. The first word we copy will start with
+        // data we don't care about, but the last `lengthmod` bytes will
+        // land at the beginning of the contents of the new array. When
+        // we're done copying, we overwrite the full first word with
+        // the actual length of the slice.
+        let lengthmod := and(_length, 31)
+
+        // The multiplication in the next line is necessary
+        // because when slicing multiples of 32 bytes (lengthmod == 0)
+        // the following copy loop was copying the origin's length
+        // and then ending prematurely not copying everything it should.
+        let mc := add(add(tempBytes, lengthmod), mul(0x20, iszero(lengthmod)))
+        let end := add(mc, _length)
+
+        for {
+          // The multiplication in the next line has the same exact purpose
+          // as the one above.
+          let cc := add(add(add(_bytes, lengthmod), mul(0x20, iszero(lengthmod))), _start)
+        } lt(mc, end) {
+          mc := add(mc, 0x20)
+          cc := add(cc, 0x20)
+        } {
+          mstore(mc, mload(cc))
+        }
+
+        mstore(tempBytes, _length)
+
+        //update free-memory pointer
+        //allocating the array padded to 32 bytes like the compiler does now
+        mstore(0x40, and(add(mc, 31), not(31)))
+      }
+      //if we want a zero-length slice let's just return a zero-length array
+      default {
+        tempBytes := mload(0x40)
+        //zero out the 32 bytes slice we are about to return
+        //we need to do it because Solidity does not garbage collect
+        mstore(tempBytes, 0)
+
+        mstore(0x40, add(tempBytes, 0x20))
+      }
+    }
+
+    return tempBytes;
+  }
+
+  function toAddress(bytes memory _bytes, uint256 _start) internal pure returns (address) {
+    require(_bytes.length >= _start + 20, "toAddress_outOfBounds");
+    address tempAddress;
+
+    assembly {
+      tempAddress := div(mload(add(add(_bytes, 0x20), _start)), 0x1000000000000000000000000)
+    }
+
+    return tempAddress;
+  }
+
+  function toUint24(bytes memory _bytes, uint256 _start) internal pure returns (uint24) {
+    require(_start + 3 >= _start, "toUint24_overflow");
+    require(_bytes.length >= _start + 3, "toUint24_outOfBounds");
+    uint24 tempUint;
+
+    assembly {
+      tempUint := mload(add(add(_bytes, 0x3), _start))
+    }
+
+    return tempUint;
+  }
+}

--- a/src/dex/v3/periphery/libraries/CallbackValidation.sol
+++ b/src/dex/v3/periphery/libraries/CallbackValidation.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "../../core/interfaces/IListaV3Pool.sol";
+import "../../core/interfaces/IListaV3Factory.sol";
+import "./PoolAddress.sol";
+
+/// @notice Provides validation for callbacks from Lista V3 Pools
+library CallbackValidation {
+  /// @notice Returns the address of a valid Lista V3 Pool
+  /// @param factory The contract address of the Lista V3 factory
+  /// @param tokenA The contract address of either token0 or token1
+  /// @param tokenB The contract address of the other token
+  /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+  /// @return pool The V3 pool contract address
+  function verifyCallback(
+    address factory,
+    address tokenA,
+    address tokenB,
+    uint24 fee
+  ) internal view returns (IListaV3Pool pool) {
+    return
+      verifyCallback(
+        factory,
+        PoolAddress.PoolKey({
+          token0: tokenA < tokenB ? tokenA : tokenB,
+          token1: tokenA < tokenB ? tokenB : tokenA,
+          fee: fee
+        })
+      );
+  }
+
+  /// @notice Returns the address of a valid Lista V3 Pool
+  /// @param factory The contract address of the Lista V3 factory
+  /// @param poolKey The identifying key of the V3 pool
+  /// @return pool The V3 pool contract address
+  function verifyCallback(
+    address factory,
+    PoolAddress.PoolKey memory poolKey
+  ) internal view returns (IListaV3Pool pool) {
+    pool = IListaV3Pool(IListaV3Factory(factory).getPool(poolKey.token0, poolKey.token1, poolKey.fee));
+    require(msg.sender == address(pool));
+  }
+}

--- a/src/dex/v3/periphery/libraries/ChainId.sol
+++ b/src/dex/v3/periphery/libraries/ChainId.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.0;
+
+/// @title Function for getting the current chain ID
+library ChainId {
+  /// @dev Gets the current chain ID
+  /// @return chainId The current chain ID
+  function get() internal view returns (uint256 chainId) {
+    assembly {
+      chainId := chainid()
+    }
+  }
+}

--- a/src/dex/v3/periphery/libraries/HexStrings.sol
+++ b/src/dex/v3/periphery/libraries/HexStrings.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+library HexStrings {
+  bytes16 internal constant ALPHABET = "0123456789abcdef";
+
+  /// @notice Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.
+  /// @dev Credit to Open Zeppelin under MIT license https://github.com/OpenZeppelin/openzeppelin-contracts/blob/243adff49ce1700e0ecb99fe522fb16cff1d1ddc/contracts/utils/Strings.sol#L55
+  function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {
+    bytes memory buffer = new bytes(2 * length + 2);
+    buffer[0] = "0";
+    buffer[1] = "x";
+    for (uint256 i = 2 * length + 1; i > 1; --i) {
+      buffer[i] = ALPHABET[value & 0xf];
+      value >>= 4;
+    }
+    require(value == 0, "Strings: hex length insufficient");
+    return string(buffer);
+  }
+
+  function toHexStringNoPrefix(uint256 value, uint256 length) internal pure returns (string memory) {
+    bytes memory buffer = new bytes(2 * length);
+    for (uint256 i = buffer.length; i > 0; i--) {
+      buffer[i - 1] = ALPHABET[value & 0xf];
+      value >>= 4;
+    }
+    return string(buffer);
+  }
+}

--- a/src/dex/v3/periphery/libraries/LiquidityAmounts.sol
+++ b/src/dex/v3/periphery/libraries/LiquidityAmounts.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import "../../core/libraries/FullMath.sol";
+import "../../core/libraries/FixedPoint96.sol";
+
+/// @title Liquidity amount functions
+/// @notice Provides functions for computing liquidity amounts from token amounts and prices
+library LiquidityAmounts {
+  /// @notice Downcasts uint256 to uint128
+  /// @param x The uint258 to be downcasted
+  /// @return y The passed value, downcasted to uint128
+  function toUint128(uint256 x) private pure returns (uint128 y) {
+    require((y = uint128(x)) == x);
+  }
+
+  /// @notice Computes the amount of liquidity received for a given amount of token0 and price range
+  /// @dev Calculates amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
+  /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+  /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+  /// @param amount0 The amount0 being sent in
+  /// @return liquidity The amount of returned liquidity
+  function getLiquidityForAmount0(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint256 amount0
+  ) internal pure returns (uint128 liquidity) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+    uint256 intermediate = FullMath.mulDiv(sqrtRatioAX96, sqrtRatioBX96, FixedPoint96.Q96);
+    unchecked {
+      return toUint128(FullMath.mulDiv(amount0, intermediate, sqrtRatioBX96 - sqrtRatioAX96));
+    }
+  }
+
+  /// @notice Computes the amount of liquidity received for a given amount of token1 and price range
+  /// @dev Calculates amount1 / (sqrt(upper) - sqrt(lower)).
+  /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+  /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+  /// @param amount1 The amount1 being sent in
+  /// @return liquidity The amount of returned liquidity
+  function getLiquidityForAmount1(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint256 amount1
+  ) internal pure returns (uint128 liquidity) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+    unchecked {
+      return toUint128(FullMath.mulDiv(amount1, FixedPoint96.Q96, sqrtRatioBX96 - sqrtRatioAX96));
+    }
+  }
+
+  /// @notice Computes the maximum amount of liquidity received for a given amount of token0, token1, the current
+  /// pool prices and the prices at the tick boundaries
+  /// @param sqrtRatioX96 A sqrt price representing the current pool prices
+  /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+  /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+  /// @param amount0 The amount of token0 being sent in
+  /// @param amount1 The amount of token1 being sent in
+  /// @return liquidity The maximum amount of liquidity received
+  function getLiquidityForAmounts(
+    uint160 sqrtRatioX96,
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint256 amount0,
+    uint256 amount1
+  ) internal pure returns (uint128 liquidity) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+    if (sqrtRatioX96 <= sqrtRatioAX96) {
+      liquidity = getLiquidityForAmount0(sqrtRatioAX96, sqrtRatioBX96, amount0);
+    } else if (sqrtRatioX96 < sqrtRatioBX96) {
+      uint128 liquidity0 = getLiquidityForAmount0(sqrtRatioX96, sqrtRatioBX96, amount0);
+      uint128 liquidity1 = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioX96, amount1);
+
+      liquidity = liquidity0 < liquidity1 ? liquidity0 : liquidity1;
+    } else {
+      liquidity = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioBX96, amount1);
+    }
+  }
+
+  /// @notice Computes the amount of token0 for a given amount of liquidity and a price range
+  /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+  /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+  /// @param liquidity The liquidity being valued
+  /// @return amount0 The amount of token0
+  function getAmount0ForLiquidity(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity
+  ) internal pure returns (uint256 amount0) {
+    unchecked {
+      if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+      return
+        FullMath.mulDiv(uint256(liquidity) << FixedPoint96.RESOLUTION, sqrtRatioBX96 - sqrtRatioAX96, sqrtRatioBX96) /
+        sqrtRatioAX96;
+    }
+  }
+
+  /// @notice Computes the amount of token1 for a given amount of liquidity and a price range
+  /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+  /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+  /// @param liquidity The liquidity being valued
+  /// @return amount1 The amount of token1
+  function getAmount1ForLiquidity(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity
+  ) internal pure returns (uint256 amount1) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+    unchecked {
+      return FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+    }
+  }
+
+  /// @notice Computes the token0 and token1 value for a given amount of liquidity, the current
+  /// pool prices and the prices at the tick boundaries
+  /// @param sqrtRatioX96 A sqrt price representing the current pool prices
+  /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
+  /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
+  /// @param liquidity The liquidity being valued
+  /// @return amount0 The amount of token0
+  /// @return amount1 The amount of token1
+  function getAmountsForLiquidity(
+    uint160 sqrtRatioX96,
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity
+  ) internal pure returns (uint256 amount0, uint256 amount1) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+    if (sqrtRatioX96 <= sqrtRatioAX96) {
+      amount0 = getAmount0ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+    } else if (sqrtRatioX96 < sqrtRatioBX96) {
+      amount0 = getAmount0ForLiquidity(sqrtRatioX96, sqrtRatioBX96, liquidity);
+      amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioX96, liquidity);
+    } else {
+      amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+    }
+  }
+}

--- a/src/dex/v3/periphery/libraries/NFTDescriptor.sol
+++ b/src/dex/v3/periphery/libraries/NFTDescriptor.sol
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.0;
+pragma abicoder v2;
+
+import "../../core/interfaces/IListaV3Pool.sol";
+import "../../core/libraries/TickMath.sol";
+import "../../core/libraries/BitMath.sol";
+import "../../core/libraries/FullMath.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
+import "./HexStrings.sol";
+import "./NFTSVG.sol";
+
+library NFTDescriptor {
+  using TickMath for int24;
+  using Strings for uint256;
+  using HexStrings for uint256;
+
+  uint256 constant sqrt10X128 = 1076067327063303206878105757264492625226;
+
+  struct ConstructTokenURIParams {
+    uint256 tokenId;
+    address quoteTokenAddress;
+    address baseTokenAddress;
+    string quoteTokenSymbol;
+    string baseTokenSymbol;
+    uint8 quoteTokenDecimals;
+    uint8 baseTokenDecimals;
+    bool flipRatio;
+    int24 tickLower;
+    int24 tickUpper;
+    int24 tickCurrent;
+    int24 tickSpacing;
+    uint24 fee;
+    address poolAddress;
+  }
+
+  function constructTokenURI(ConstructTokenURIParams memory params) public pure returns (string memory) {
+    string memory name = generateName(params, feeToPercentString(params.fee));
+    string memory descriptionPartOne = generateDescriptionPartOne(
+      escapeQuotes(params.quoteTokenSymbol),
+      escapeQuotes(params.baseTokenSymbol),
+      addressToString(params.poolAddress)
+    );
+    string memory descriptionPartTwo = generateDescriptionPartTwo(
+      params.tokenId.toString(),
+      escapeQuotes(params.baseTokenSymbol),
+      addressToString(params.quoteTokenAddress),
+      addressToString(params.baseTokenAddress),
+      feeToPercentString(params.fee)
+    );
+    string memory image = Base64.encode(bytes(generateSVGImage(params)));
+
+    return
+      string(
+        abi.encodePacked(
+          "data:application/json;base64,",
+          Base64.encode(
+            bytes(
+              abi.encodePacked(
+                '{"name":"',
+                name,
+                '", "description":"',
+                descriptionPartOne,
+                descriptionPartTwo,
+                '", "image": "',
+                "data:image/svg+xml;base64,",
+                image,
+                '"}'
+              )
+            )
+          )
+        )
+      );
+  }
+
+  function escapeQuotes(string memory symbol) internal pure returns (string memory) {
+    bytes memory symbolBytes = bytes(symbol);
+    uint8 quotesCount = 0;
+    for (uint8 i = 0; i < symbolBytes.length; i++) {
+      if (symbolBytes[i] == '"') {
+        quotesCount++;
+      }
+    }
+    if (quotesCount > 0) {
+      bytes memory escapedBytes = new bytes(symbolBytes.length + (quotesCount));
+      uint256 index;
+      for (uint8 i = 0; i < symbolBytes.length; i++) {
+        if (symbolBytes[i] == '"') {
+          escapedBytes[index++] = "\\";
+        }
+        escapedBytes[index++] = symbolBytes[i];
+      }
+      return string(escapedBytes);
+    }
+    return symbol;
+  }
+
+  function generateDescriptionPartOne(
+    string memory quoteTokenSymbol,
+    string memory baseTokenSymbol,
+    string memory poolAddress
+  ) private pure returns (string memory) {
+    return
+      string(
+        abi.encodePacked(
+          "This NFT represents a liquidity position in a Lista V3 ",
+          quoteTokenSymbol,
+          "-",
+          baseTokenSymbol,
+          " pool. ",
+          "The owner of this NFT can modify or redeem the position.\\n",
+          "\\nPool Address: ",
+          poolAddress,
+          "\\n",
+          quoteTokenSymbol
+        )
+      );
+  }
+
+  function generateDescriptionPartTwo(
+    string memory tokenId,
+    string memory baseTokenSymbol,
+    string memory quoteTokenAddress,
+    string memory baseTokenAddress,
+    string memory feeTier
+  ) private pure returns (string memory) {
+    return
+      string(
+        abi.encodePacked(
+          " Address: ",
+          quoteTokenAddress,
+          "\\n",
+          baseTokenSymbol,
+          " Address: ",
+          baseTokenAddress,
+          "\\nFee Tier: ",
+          feeTier,
+          "\\nToken ID: ",
+          tokenId,
+          "\\n\\n",
+          unicode"⚠️ DISCLAIMER: Due diligence is imperative when assessing this NFT. Make sure token addresses match the expected tokens, as token symbols may be imitated."
+        )
+      );
+  }
+
+  function generateName(
+    ConstructTokenURIParams memory params,
+    string memory feeTier
+  ) private pure returns (string memory) {
+    return
+      string(
+        abi.encodePacked(
+          "Lista - ",
+          feeTier,
+          " - ",
+          escapeQuotes(params.quoteTokenSymbol),
+          "/",
+          escapeQuotes(params.baseTokenSymbol),
+          " - ",
+          tickToDecimalString(
+            !params.flipRatio ? params.tickLower : params.tickUpper,
+            params.tickSpacing,
+            params.baseTokenDecimals,
+            params.quoteTokenDecimals,
+            params.flipRatio
+          ),
+          "<>",
+          tickToDecimalString(
+            !params.flipRatio ? params.tickUpper : params.tickLower,
+            params.tickSpacing,
+            params.baseTokenDecimals,
+            params.quoteTokenDecimals,
+            params.flipRatio
+          )
+        )
+      );
+  }
+
+  struct DecimalStringParams {
+    // significant figures of decimal
+    uint256 sigfigs;
+    // length of decimal string
+    uint8 bufferLength;
+    // ending index for significant figures (funtion works backwards when copying sigfigs)
+    uint8 sigfigIndex;
+    // index of decimal place (0 if no decimal)
+    uint8 decimalIndex;
+    // start index for trailing/leading 0's for very small/large numbers
+    uint8 zerosStartIndex;
+    // end index for trailing/leading 0's for very small/large numbers
+    uint8 zerosEndIndex;
+    // true if decimal number is less than one
+    bool isLessThanOne;
+    // true if string should include "%"
+    bool isPercent;
+  }
+
+  function generateDecimalString(DecimalStringParams memory params) private pure returns (string memory) {
+    bytes memory buffer = new bytes(params.bufferLength);
+    if (params.isPercent) {
+      buffer[buffer.length - 1] = "%";
+    }
+    if (params.isLessThanOne) {
+      buffer[0] = "0";
+      buffer[1] = ".";
+    }
+
+    // add leading/trailing 0's
+    for (uint256 zerosCursor = params.zerosStartIndex; zerosCursor < params.zerosEndIndex + 1; zerosCursor++) {
+      buffer[zerosCursor] = bytes1(uint8(48));
+    }
+    // add sigfigs
+    unchecked {
+      while (params.sigfigs > 0) {
+        if (params.decimalIndex > 0 && params.sigfigIndex == params.decimalIndex) {
+          buffer[params.sigfigIndex--] = ".";
+        }
+        buffer[params.sigfigIndex--] = bytes1(uint8(uint256(48) + (params.sigfigs % 10)));
+        params.sigfigs /= 10;
+      }
+    }
+    return string(buffer);
+  }
+
+  function tickToDecimalString(
+    int24 tick,
+    int24 tickSpacing,
+    uint8 baseTokenDecimals,
+    uint8 quoteTokenDecimals,
+    bool flipRatio
+  ) internal pure returns (string memory) {
+    if (tick == (TickMath.MIN_TICK / tickSpacing) * tickSpacing) {
+      return !flipRatio ? "MIN" : "MAX";
+    } else if (tick == (TickMath.MAX_TICK / tickSpacing) * tickSpacing) {
+      return !flipRatio ? "MAX" : "MIN";
+    } else {
+      uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
+      if (flipRatio) {
+        sqrtRatioX96 = uint160(uint256(1 << 192) / sqrtRatioX96);
+      }
+      return fixedPointToDecimalString(sqrtRatioX96, baseTokenDecimals, quoteTokenDecimals);
+    }
+  }
+
+  function sigfigsRounded(uint256 value, uint8 digits) private pure returns (uint256, bool) {
+    bool extraDigit;
+    if (digits > 5) {
+      value = value / ((10 ** (digits - 5)));
+    }
+    bool roundUp = value % 10 > 4;
+    value = value / 10;
+    if (roundUp) {
+      value = value + 1;
+    }
+    // 99999 -> 100000 gives an extra sigfig
+    if (value == 100000) {
+      value /= 10;
+      extraDigit = true;
+    }
+    return (value, extraDigit);
+  }
+
+  function adjustForDecimalPrecision(
+    uint160 sqrtRatioX96,
+    uint8 baseTokenDecimals,
+    uint8 quoteTokenDecimals
+  ) private pure returns (uint256 adjustedSqrtRatioX96) {
+    uint256 difference = abs(int256(uint256(baseTokenDecimals)) - int256(uint256(quoteTokenDecimals)));
+    if (difference > 0 && difference <= 18) {
+      if (baseTokenDecimals > quoteTokenDecimals) {
+        adjustedSqrtRatioX96 = sqrtRatioX96 * (10 ** (difference / 2));
+        if (difference % 2 == 1) {
+          adjustedSqrtRatioX96 = FullMath.mulDiv(adjustedSqrtRatioX96, sqrt10X128, 1 << 128);
+        }
+      } else {
+        adjustedSqrtRatioX96 = sqrtRatioX96 / (10 ** (difference / 2));
+        if (difference % 2 == 1) {
+          adjustedSqrtRatioX96 = FullMath.mulDiv(adjustedSqrtRatioX96, 1 << 128, sqrt10X128);
+        }
+      }
+    } else {
+      adjustedSqrtRatioX96 = uint256(sqrtRatioX96);
+    }
+  }
+
+  function abs(int256 x) private pure returns (uint256) {
+    return uint256(x >= 0 ? x : -x);
+  }
+
+  // @notice Returns string that includes first 5 significant figures of a decimal number
+  // @param sqrtRatioX96 a sqrt price
+  function fixedPointToDecimalString(
+    uint160 sqrtRatioX96,
+    uint8 baseTokenDecimals,
+    uint8 quoteTokenDecimals
+  ) internal pure returns (string memory) {
+    uint256 adjustedSqrtRatioX96 = adjustForDecimalPrecision(sqrtRatioX96, baseTokenDecimals, quoteTokenDecimals);
+    uint256 value = FullMath.mulDiv(adjustedSqrtRatioX96, adjustedSqrtRatioX96, 1 << 64);
+
+    bool priceBelow1 = adjustedSqrtRatioX96 < 2 ** 96;
+    if (priceBelow1) {
+      // 10 ** 43 is precision needed to retreive 5 sigfigs of smallest possible price + 1 for rounding
+      value = FullMath.mulDiv(value, 10 ** 44, 1 << 128);
+    } else {
+      // leave precision for 4 decimal places + 1 place for rounding
+      value = FullMath.mulDiv(value, 10 ** 5, 1 << 128);
+    }
+
+    // get digit count
+    uint256 temp = value;
+    uint8 digits;
+    while (temp != 0) {
+      digits++;
+      temp /= 10;
+    }
+    // don't count extra digit kept for rounding
+    digits = digits - 1;
+
+    // address rounding
+    (uint256 sigfigs, bool extraDigit) = sigfigsRounded(value, digits);
+    if (extraDigit) {
+      digits++;
+    }
+
+    DecimalStringParams memory params;
+    if (priceBelow1) {
+      // 7 bytes ( "0." and 5 sigfigs) + leading 0's bytes
+      params.bufferLength = uint8(uint8(7) + (uint8(43) - digits));
+      params.zerosStartIndex = 2;
+      params.zerosEndIndex = uint8(uint256(43) - digits + 1);
+      params.sigfigIndex = uint8(params.bufferLength - 1);
+    } else if (digits >= 9) {
+      // no decimal in price string
+      params.bufferLength = uint8(digits - 4);
+      params.zerosStartIndex = 5;
+      params.zerosEndIndex = uint8(params.bufferLength - 1);
+      params.sigfigIndex = 4;
+    } else {
+      // 5 sigfigs surround decimal
+      params.bufferLength = 6;
+      params.sigfigIndex = 5;
+      params.decimalIndex = uint8(digits - 4);
+    }
+    params.sigfigs = sigfigs;
+    params.isLessThanOne = priceBelow1;
+    params.isPercent = false;
+
+    return generateDecimalString(params);
+  }
+
+  struct FeeDigits {
+    uint24 temp;
+    uint8 numSigfigs;
+    uint256 digits;
+  }
+
+  // @notice Returns string as decimal percentage of fee amount.
+  // @param fee fee amount
+  function feeToPercentString(uint24 fee) internal pure returns (string memory) {
+    if (fee == 0) {
+      return "0%";
+    }
+
+    FeeDigits memory feeDigits = FeeDigits(fee, 0, 0);
+    while (feeDigits.temp != 0) {
+      if (feeDigits.numSigfigs > 0) {
+        // count all digits preceding least significant figure
+        feeDigits.numSigfigs++;
+      } else if (feeDigits.temp % 10 != 0) {
+        feeDigits.numSigfigs++;
+      }
+      feeDigits.digits++;
+      feeDigits.temp /= 10;
+    }
+
+    DecimalStringParams memory params;
+    uint256 nZeros;
+    if (feeDigits.digits >= 5) {
+      // if decimal > 1 (5th digit is the ones place)
+      uint256 decimalPlace = feeDigits.digits - feeDigits.numSigfigs >= 4 ? 0 : 1;
+      nZeros = feeDigits.digits - 5 < (feeDigits.numSigfigs - 1)
+        ? 0
+        : feeDigits.digits - 5 - (feeDigits.numSigfigs - 1);
+      params.zerosStartIndex = feeDigits.numSigfigs;
+      params.zerosEndIndex = uint8(params.zerosStartIndex + nZeros - 1);
+      params.sigfigIndex = uint8(params.zerosStartIndex - 1 + decimalPlace);
+      params.bufferLength = uint8(nZeros + (feeDigits.numSigfigs + 1) + decimalPlace);
+    } else {
+      // else if decimal < 1
+      nZeros = uint256(5) - feeDigits.digits;
+      params.zerosStartIndex = 2;
+      params.zerosEndIndex = uint8(nZeros + params.zerosStartIndex - 1);
+      params.bufferLength = uint8(nZeros + (feeDigits.numSigfigs + 2));
+      params.sigfigIndex = uint8((params.bufferLength) - 2);
+      params.isLessThanOne = true;
+    }
+    params.sigfigs = uint256(fee) / (10 ** (feeDigits.digits - feeDigits.numSigfigs));
+    params.isPercent = true;
+    params.decimalIndex = feeDigits.digits > 4 ? uint8(feeDigits.digits - 4) : 0;
+
+    return generateDecimalString(params);
+  }
+
+  function addressToString(address addr) internal pure returns (string memory) {
+    return HexStrings.toHexString(uint256(uint160(addr)), 20);
+  }
+
+  function generateSVGImage(ConstructTokenURIParams memory params) internal pure returns (string memory svg) {
+    string memory defs = NFTSVG.generateSVGDefs(
+      NFTSVG.SVGDefsParams({
+        color0: tokenToColorHex(uint256(uint160(params.quoteTokenAddress)), 136),
+        color1: tokenToColorHex(uint256(uint160(params.baseTokenAddress)), 136),
+        color2: tokenToColorHex(uint256(uint160(params.quoteTokenAddress)), 0),
+        color3: tokenToColorHex(uint256(uint160(params.baseTokenAddress)), 0),
+        x1: scale(getCircleCoord(uint256(uint160(params.quoteTokenAddress)), 16, params.tokenId), 0, 255, 16, 274),
+        y1: scale(getCircleCoord(uint256(uint160(params.baseTokenAddress)), 16, params.tokenId), 0, 255, 100, 484),
+        x2: scale(getCircleCoord(uint256(uint160(params.quoteTokenAddress)), 32, params.tokenId), 0, 255, 16, 274),
+        y2: scale(getCircleCoord(uint256(uint160(params.baseTokenAddress)), 32, params.tokenId), 0, 255, 100, 484),
+        x3: scale(getCircleCoord(uint256(uint160(params.quoteTokenAddress)), 48, params.tokenId), 0, 255, 16, 274),
+        y3: scale(getCircleCoord(uint256(uint160(params.baseTokenAddress)), 48, params.tokenId), 0, 255, 100, 484)
+      })
+    );
+
+    string memory body = NFTSVG.generateSVGBody(
+      NFTSVG.SVGBodyParams({
+        quoteToken: addressToString(params.quoteTokenAddress),
+        baseToken: addressToString(params.baseTokenAddress),
+        poolAddress: params.poolAddress,
+        quoteTokenSymbol: params.quoteTokenSymbol,
+        baseTokenSymbol: params.baseTokenSymbol,
+        feeTier: feeToPercentString(params.fee),
+        tickLower: params.tickLower,
+        tickUpper: params.tickUpper,
+        tickSpacing: params.tickSpacing,
+        overRange: overRange(params.tickLower, params.tickUpper, params.tickCurrent),
+        tokenId: params.tokenId
+      })
+    );
+
+    return NFTSVG.generateSVG(defs, body);
+  }
+
+  function overRange(int24 tickLower, int24 tickUpper, int24 tickCurrent) private pure returns (int8) {
+    if (tickCurrent < tickLower) {
+      return -1;
+    } else if (tickCurrent > tickUpper) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  function scale(
+    uint256 n,
+    uint256 inMn,
+    uint256 inMx,
+    uint256 outMn,
+    uint256 outMx
+  ) private pure returns (string memory) {
+    return (((n - inMn) * (outMx - outMn)) / (inMx - inMn) + outMn).toString();
+  }
+
+  function tokenToColorHex(uint256 token, uint256 offset) internal pure returns (string memory str) {
+    return string((token >> offset).toHexStringNoPrefix(3));
+  }
+
+  function getCircleCoord(uint256 tokenAddress, uint256 offset, uint256 tokenId) internal pure returns (uint256) {
+    return (sliceTokenHex(tokenAddress, offset) * tokenId) % 255;
+  }
+
+  function sliceTokenHex(uint256 token, uint256 offset) internal pure returns (uint256) {
+    return uint256(uint8(token >> offset));
+  }
+}

--- a/src/dex/v3/periphery/libraries/NFTSVG.sol
+++ b/src/dex/v3/periphery/libraries/NFTSVG.sol
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "../../core/libraries/BitMath.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
+
+/// @title NFTSVG
+/// @notice Provides a function for generating an SVG associated with a Lista NFT
+library NFTSVG {
+  using Strings for uint256;
+
+  string constant curve1 = "M1 1C41 41 105 105 145 145";
+  string constant curve2 = "M1 1C33 49 97 113 145 145";
+  string constant curve3 = "M1 1C33 57 89 113 145 145";
+  string constant curve4 = "M1 1C25 65 81 121 145 145";
+  string constant curve5 = "M1 1C17 73 73 129 145 145";
+  string constant curve6 = "M1 1C9 81 65 137 145 145";
+  string constant curve7 = "M1 1C1 89 57.5 145 145 145";
+  string constant curve8 = "M1 1C1 97 49 145 145 145";
+
+  struct SVGBodyParams {
+    string quoteToken;
+    string baseToken;
+    address poolAddress;
+    string quoteTokenSymbol;
+    string baseTokenSymbol;
+    string feeTier;
+    int24 tickLower;
+    int24 tickUpper;
+    int24 tickSpacing;
+    int8 overRange;
+    uint256 tokenId;
+  }
+
+  struct SVGDefsParams {
+    string color0;
+    string color1;
+    string color2;
+    string color3;
+    string x1;
+    string y1;
+    string x2;
+    string y2;
+    string x3;
+    string y3;
+  }
+
+  function generateSVG(string memory defs, string memory body) internal pure returns (string memory svg) {
+    /*
+        address: "0xe8ab59d3bcde16a29912de83a90eb39628cfc163",
+        msg: "Forged in SVG for Lista in 2021 by 0xe8ab59d3bcde16a29912de83a90eb39628cfc163",
+        sig: "0x2df0e99d9cbfec33a705d83f75666d98b22dea7c1af412c584f7d626d83f02875993df740dc87563b9c73378f8462426da572d7989de88079a382ad96c57b68d1b",
+        version: "2"
+        */
+    return string(abi.encodePacked(defs, body, "</svg>"));
+  }
+
+  function generateSVGBody(SVGBodyParams memory params) internal pure returns (string memory body) {
+    return
+      string(
+        abi.encodePacked(
+          generateSVGBorderText(params.quoteToken, params.baseToken, params.quoteTokenSymbol, params.baseTokenSymbol),
+          generateSVGCardMantle(params.quoteTokenSymbol, params.baseTokenSymbol, params.feeTier),
+          generageSvgCurve(params.tickLower, params.tickUpper, params.tickSpacing, params.overRange),
+          generateSVGPositionDataAndLocationCurve(params.tokenId.toString(), params.tickLower, params.tickUpper),
+          generateSVGRareSparkle(params.tokenId, params.poolAddress)
+        )
+      );
+  }
+
+  function generateSVGDefs(SVGDefsParams memory params) internal pure returns (string memory svg) {
+    svg = string(
+      abi.encodePacked(
+        '<svg width="290" height="500" viewBox="0 0 290 500" xmlns="http://www.w3.org/2000/svg"',
+        " xmlns:xlink='http://www.w3.org/1999/xlink'>",
+        "<defs>",
+        '<filter id="f1"><feImage result="p0" xlink:href="data:image/svg+xml;base64,',
+        Base64.encode(
+          bytes(
+            abi.encodePacked(
+              "<svg width='290' height='500' viewBox='0 0 290 500' xmlns='http://www.w3.org/2000/svg'><rect width='290px' height='500px' fill='#",
+              params.color0,
+              "'/></svg>"
+            )
+          )
+        ),
+        '"/><feImage result="p1" xlink:href="data:image/svg+xml;base64,',
+        Base64.encode(
+          bytes(
+            abi.encodePacked(
+              "<svg width='290' height='500' viewBox='0 0 290 500' xmlns='http://www.w3.org/2000/svg'><circle cx='",
+              params.x1,
+              "' cy='",
+              params.y1,
+              "' r='120px' fill='#",
+              params.color1,
+              "'/></svg>"
+            )
+          )
+        ),
+        '"/><feImage result="p2" xlink:href="data:image/svg+xml;base64,',
+        Base64.encode(
+          bytes(
+            abi.encodePacked(
+              "<svg width='290' height='500' viewBox='0 0 290 500' xmlns='http://www.w3.org/2000/svg'><circle cx='",
+              params.x2,
+              "' cy='",
+              params.y2,
+              "' r='120px' fill='#",
+              params.color2,
+              "'/></svg>"
+            )
+          )
+        ),
+        '" />',
+        '<feImage result="p3" xlink:href="data:image/svg+xml;base64,',
+        Base64.encode(
+          bytes(
+            abi.encodePacked(
+              "<svg width='290' height='500' viewBox='0 0 290 500' xmlns='http://www.w3.org/2000/svg'><circle cx='",
+              params.x3,
+              "' cy='",
+              params.y3,
+              "' r='100px' fill='#",
+              params.color3,
+              "'/></svg>"
+            )
+          )
+        ),
+        '" /><feBlend mode="overlay" in="p0" in2="p1" /><feBlend mode="exclusion" in2="p2" /><feBlend mode="overlay" in2="p3" result="blendOut" /><feGaussianBlur ',
+        'in="blendOut" stdDeviation="42" /></filter> <clipPath id="corners"><rect width="290" height="500" rx="42" ry="42" /></clipPath>',
+        '<path id="text-path-a" d="M40 12 H250 A28 28 0 0 1 278 40 V460 A28 28 0 0 1 250 488 H40 A28 28 0 0 1 12 460 V40 A28 28 0 0 1 40 12 z" />',
+        '<path id="minimap" d="M234 444C234 457.949 242.21 463 253 463" />',
+        '<filter id="top-region-blur"><feGaussianBlur in="SourceGraphic" stdDeviation="24" /></filter>',
+        '<linearGradient id="grad-up" x1="1" x2="0" y1="1" y2="0"><stop offset="0.0" stop-color="white" stop-opacity="1" />',
+        '<stop offset=".9" stop-color="white" stop-opacity="0" /></linearGradient>',
+        '<linearGradient id="grad-down" x1="0" x2="1" y1="0" y2="1"><stop offset="0.0" stop-color="white" stop-opacity="1" /><stop offset="0.9" stop-color="white" stop-opacity="0" /></linearGradient>',
+        '<mask id="fade-up" maskContentUnits="objectBoundingBox"><rect width="1" height="1" fill="url(#grad-up)" /></mask>',
+        '<mask id="fade-down" maskContentUnits="objectBoundingBox"><rect width="1" height="1" fill="url(#grad-down)" /></mask>',
+        '<mask id="none" maskContentUnits="objectBoundingBox"><rect width="1" height="1" fill="white" /></mask>',
+        '<linearGradient id="grad-symbol"><stop offset="0.7" stop-color="white" stop-opacity="1" /><stop offset=".95" stop-color="white" stop-opacity="0" /></linearGradient>',
+        '<mask id="fade-symbol" maskContentUnits="userSpaceOnUse"><rect width="290px" height="200px" fill="url(#grad-symbol)" /></mask></defs>',
+        '<g clip-path="url(#corners)">',
+        '<rect fill="',
+        params.color0,
+        '" x="0px" y="0px" width="290px" height="500px" />',
+        '<rect style="filter: url(#f1)" x="0px" y="0px" width="290px" height="500px" />',
+        ' <g style="filter:url(#top-region-blur); transform:scale(1.5); transform-origin:center top;">',
+        '<rect fill="none" x="0px" y="0px" width="290px" height="500px" />',
+        '<ellipse cx="50%" cy="0px" rx="180px" ry="120px" fill="#000" opacity="0.85" /></g>',
+        '<rect x="0" y="0" width="290" height="500" rx="42" ry="42" fill="rgba(0,0,0,0)" stroke="rgba(255,255,255,0.2)" /></g>'
+      )
+    );
+  }
+
+  function generateSVGBorderText(
+    string memory quoteToken,
+    string memory baseToken,
+    string memory quoteTokenSymbol,
+    string memory baseTokenSymbol
+  ) private pure returns (string memory svg) {
+    svg = string(
+      abi.encodePacked(
+        '<text text-rendering="optimizeSpeed">',
+        '<textPath startOffset="-100%" fill="white" font-family="\'Courier New\', monospace" font-size="10px" xlink:href="#text-path-a">',
+        baseToken,
+        unicode" • ",
+        baseTokenSymbol,
+        ' <animate additive="sum" attributeName="startOffset" from="0%" to="100%" begin="0s" dur="30s" repeatCount="indefinite" />',
+        '</textPath> <textPath startOffset="0%" fill="white" font-family="\'Courier New\', monospace" font-size="10px" xlink:href="#text-path-a">',
+        baseToken,
+        unicode" • ",
+        baseTokenSymbol,
+        ' <animate additive="sum" attributeName="startOffset" from="0%" to="100%" begin="0s" dur="30s" repeatCount="indefinite" /> </textPath>',
+        '<textPath startOffset="50%" fill="white" font-family="\'Courier New\', monospace" font-size="10px" xlink:href="#text-path-a">',
+        quoteToken,
+        unicode" • ",
+        quoteTokenSymbol,
+        ' <animate additive="sum" attributeName="startOffset" from="0%" to="100%" begin="0s" dur="30s"',
+        ' repeatCount="indefinite" /></textPath><textPath startOffset="-50%" fill="white" font-family="\'Courier New\', monospace" font-size="10px" xlink:href="#text-path-a">',
+        quoteToken,
+        unicode" • ",
+        quoteTokenSymbol,
+        ' <animate additive="sum" attributeName="startOffset" from="0%" to="100%" begin="0s" dur="30s" repeatCount="indefinite" /></textPath></text>'
+      )
+    );
+  }
+
+  function generateSVGCardMantle(
+    string memory quoteTokenSymbol,
+    string memory baseTokenSymbol,
+    string memory feeTier
+  ) private pure returns (string memory svg) {
+    svg = string(
+      abi.encodePacked(
+        '<g mask="url(#fade-symbol)"><rect fill="none" x="0px" y="0px" width="290px" height="200px" /> <text y="70px" x="32px" fill="white" font-family="\'Courier New\', monospace" font-weight="200" font-size="36px">',
+        quoteTokenSymbol,
+        "/",
+        baseTokenSymbol,
+        '</text><text y="115px" x="32px" fill="white" font-family="\'Courier New\', monospace" font-weight="200" font-size="36px">',
+        feeTier,
+        "</text></g>",
+        '<rect x="16" y="16" width="258" height="468" rx="26" ry="26" fill="rgba(0,0,0,0)" stroke="rgba(255,255,255,0.2)" />'
+      )
+    );
+  }
+
+  function generageSvgCurve(
+    int24 tickLower,
+    int24 tickUpper,
+    int24 tickSpacing,
+    int8 overRange
+  ) private pure returns (string memory svg) {
+    string memory fade = overRange == 1
+      ? "#fade-up"
+      : overRange == -1
+        ? "#fade-down"
+        : "#none";
+    string memory curve = getCurve(tickLower, tickUpper, tickSpacing);
+    svg = string(
+      abi.encodePacked(
+        '<g mask="url(',
+        fade,
+        ')"',
+        ' style="transform:translate(72px,189px)">'
+        '<rect x="-16px" y="-16px" width="180px" height="180px" fill="none" />'
+        '<path d="',
+        curve,
+        '" stroke="rgba(0,0,0,0.3)" stroke-width="32px" fill="none" stroke-linecap="round" />',
+        '</g><g mask="url(',
+        fade,
+        ')"',
+        ' style="transform:translate(72px,189px)">',
+        '<rect x="-16px" y="-16px" width="180px" height="180px" fill="none" />',
+        '<path d="',
+        curve,
+        '" stroke="rgba(255,255,255,1)" fill="none" stroke-linecap="round" /></g>',
+        generateSVGCurveCircle(overRange)
+      )
+    );
+  }
+
+  function getCurve(int24 tickLower, int24 tickUpper, int24 tickSpacing) internal pure returns (string memory curve) {
+    int24 tickRange = (tickUpper - tickLower) / tickSpacing;
+    if (tickRange <= 4) {
+      curve = curve1;
+    } else if (tickRange <= 8) {
+      curve = curve2;
+    } else if (tickRange <= 16) {
+      curve = curve3;
+    } else if (tickRange <= 32) {
+      curve = curve4;
+    } else if (tickRange <= 64) {
+      curve = curve5;
+    } else if (tickRange <= 128) {
+      curve = curve6;
+    } else if (tickRange <= 256) {
+      curve = curve7;
+    } else {
+      curve = curve8;
+    }
+  }
+
+  function generateSVGCurveCircle(int8 overRange) internal pure returns (string memory svg) {
+    string memory curvex1 = "73";
+    string memory curvey1 = "190";
+    string memory curvex2 = "217";
+    string memory curvey2 = "334";
+    if (overRange == 1 || overRange == -1) {
+      svg = string(
+        abi.encodePacked(
+          '<circle cx="',
+          overRange == -1 ? curvex1 : curvex2,
+          'px" cy="',
+          overRange == -1 ? curvey1 : curvey2,
+          'px" r="4px" fill="white" /><circle cx="',
+          overRange == -1 ? curvex1 : curvex2,
+          'px" cy="',
+          overRange == -1 ? curvey1 : curvey2,
+          'px" r="24px" fill="none" stroke="white" />'
+        )
+      );
+    } else {
+      svg = string(
+        abi.encodePacked(
+          '<circle cx="',
+          curvex1,
+          'px" cy="',
+          curvey1,
+          'px" r="4px" fill="white" />',
+          '<circle cx="',
+          curvex2,
+          'px" cy="',
+          curvey2,
+          'px" r="4px" fill="white" />'
+        )
+      );
+    }
+  }
+
+  function generateSVGPositionDataAndLocationCurve(
+    string memory tokenId,
+    int24 tickLower,
+    int24 tickUpper
+  ) private pure returns (string memory svg) {
+    string memory tickLowerStr = tickToString(tickLower);
+    string memory tickUpperStr = tickToString(tickUpper);
+    uint256 str1length = bytes(tokenId).length + 4;
+    uint256 str2length = bytes(tickLowerStr).length + 10;
+    uint256 str3length = bytes(tickUpperStr).length + 10;
+    (string memory xCoord, string memory yCoord) = rangeLocation(tickLower, tickUpper);
+    svg = string(
+      abi.encodePacked(
+        ' <g style="transform:translate(29px, 384px)">',
+        '<rect width="',
+        uint256(7 * (str1length + 4)).toString(),
+        'px" height="26px" rx="8px" ry="8px" fill="rgba(0,0,0,0.6)" />',
+        '<text x="12px" y="17px" font-family="\'Courier New\', monospace" font-size="12px" fill="white"><tspan fill="rgba(255,255,255,0.6)">ID: </tspan>',
+        tokenId,
+        "</text></g>",
+        ' <g style="transform:translate(29px, 414px)">',
+        '<rect width="',
+        uint256(7 * (str2length + 4)).toString(),
+        'px" height="26px" rx="8px" ry="8px" fill="rgba(0,0,0,0.6)" />',
+        '<text x="12px" y="17px" font-family="\'Courier New\', monospace" font-size="12px" fill="white"><tspan fill="rgba(255,255,255,0.6)">Min Tick: </tspan>',
+        tickLowerStr,
+        "</text></g>",
+        ' <g style="transform:translate(29px, 444px)">',
+        '<rect width="',
+        uint256(7 * (str3length + 4)).toString(),
+        'px" height="26px" rx="8px" ry="8px" fill="rgba(0,0,0,0.6)" />',
+        '<text x="12px" y="17px" font-family="\'Courier New\', monospace" font-size="12px" fill="white"><tspan fill="rgba(255,255,255,0.6)">Max Tick: </tspan>',
+        tickUpperStr,
+        "</text></g>"
+        '<g style="transform:translate(226px, 433px)">',
+        '<rect width="36px" height="36px" rx="8px" ry="8px" fill="none" stroke="rgba(255,255,255,0.2)" />',
+        '<path stroke-linecap="round" d="M8 9C8.00004 22.9494 16.2099 28 27 28" fill="none" stroke="white" />',
+        '<circle style="transform:translate3d(',
+        xCoord,
+        "px, ",
+        yCoord,
+        'px, 0px)" cx="0px" cy="0px" r="4px" fill="white"/></g>'
+      )
+    );
+  }
+
+  function tickToString(int24 tick) private pure returns (string memory) {
+    string memory sign = "";
+    if (tick < 0) {
+      tick = tick * -1;
+      sign = "-";
+    }
+    return string(abi.encodePacked(sign, uint256(uint24(tick)).toString()));
+  }
+
+  function rangeLocation(int24 tickLower, int24 tickUpper) internal pure returns (string memory, string memory) {
+    int24 midPoint = (tickLower + tickUpper) / 2;
+    if (midPoint < -125_000) {
+      return ("8", "7");
+    } else if (midPoint < -75_000) {
+      return ("8", "10.5");
+    } else if (midPoint < -25_000) {
+      return ("8", "14.25");
+    } else if (midPoint < -5_000) {
+      return ("10", "18");
+    } else if (midPoint < 0) {
+      return ("11", "21");
+    } else if (midPoint < 5_000) {
+      return ("13", "23");
+    } else if (midPoint < 25_000) {
+      return ("15", "25");
+    } else if (midPoint < 75_000) {
+      return ("18", "26");
+    } else if (midPoint < 125_000) {
+      return ("21", "27");
+    } else {
+      return ("24", "27");
+    }
+  }
+
+  function generateSVGRareSparkle(uint256 tokenId, address poolAddress) private pure returns (string memory svg) {
+    if (isRare(tokenId, poolAddress)) {
+      svg = string(
+        abi.encodePacked(
+          '<g style="transform:translate(226px, 392px)"><rect width="36px" height="36px" rx="8px" ry="8px" fill="none" stroke="rgba(255,255,255,0.2)" />',
+          '<g><path style="transform:translate(6px,6px)" d="M12 0L12.6522 9.56587L18 1.6077L13.7819 10.2181L22.3923 6L14.4341 ',
+          "11.3478L24 12L14.4341 12.6522L22.3923 18L13.7819 13.7819L18 22.3923L12.6522 14.4341L12 24L11.3478 14.4341L6 22.39",
+          '23L10.2181 13.7819L1.6077 18L9.56587 12.6522L0 12L9.56587 11.3478L1.6077 6L10.2181 10.2181L6 1.6077L11.3478 9.56587L12 0Z" fill="white" />',
+          '<animateTransform attributeName="transform" type="rotate" from="0 18 18" to="360 18 18" dur="10s" repeatCount="indefinite"/></g></g>'
+        )
+      );
+    } else {
+      svg = "";
+    }
+  }
+
+  function isRare(uint256 tokenId, address poolAddress) internal pure returns (bool) {
+    bytes32 h = keccak256(abi.encodePacked(tokenId, poolAddress));
+    return uint256(h) < type(uint256).max / (1 + BitMath.mostSignificantBit(tokenId) * 2);
+  }
+}

--- a/src/dex/v3/periphery/libraries/OracleLibrary.sol
+++ b/src/dex/v3/periphery/libraries/OracleLibrary.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0 <0.9.0;
+
+import "../../core/libraries/FullMath.sol";
+import "../../core/libraries/TickMath.sol";
+import "../../core/interfaces/IListaV3Pool.sol";
+
+/// @title Oracle library
+/// @notice Provides functions to integrate with V3 pool oracle
+library OracleLibrary {
+  /// @notice Calculates time-weighted means of tick and liquidity for a given Lista V3 pool
+  /// @param pool Address of the pool that we want to observe
+  /// @param secondsAgo Number of seconds in the past from which to calculate the time-weighted means
+  /// @return arithmeticMeanTick The arithmetic mean tick from (block.timestamp - secondsAgo) to block.timestamp
+  /// @return harmonicMeanLiquidity The harmonic mean liquidity from (block.timestamp - secondsAgo) to block.timestamp
+  function consult(
+    address pool,
+    uint32 secondsAgo
+  ) internal view returns (int24 arithmeticMeanTick, uint128 harmonicMeanLiquidity) {
+    require(secondsAgo != 0, "BP");
+
+    uint32[] memory secondsAgos = new uint32[](2);
+    secondsAgos[0] = secondsAgo;
+    secondsAgos[1] = 0;
+
+    (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s) = IListaV3Pool(pool).observe(
+      secondsAgos
+    );
+
+    int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
+    uint160 secondsPerLiquidityCumulativesDelta = secondsPerLiquidityCumulativeX128s[1] -
+      secondsPerLiquidityCumulativeX128s[0];
+
+    arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
+    // Always round to negative infinity
+    if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(secondsAgo)) != 0)) arithmeticMeanTick--;
+
+    // We are multiplying here instead of shifting to ensure that harmonicMeanLiquidity doesn't overflow uint128
+    uint192 secondsAgoX160 = uint192(secondsAgo) * type(uint160).max;
+    harmonicMeanLiquidity = uint128(secondsAgoX160 / (uint192(secondsPerLiquidityCumulativesDelta) << 32));
+  }
+
+  /// @notice Given a tick and a token amount, calculates the amount of token received in exchange
+  /// @param tick Tick value used to calculate the quote
+  /// @param baseAmount Amount of token to be converted
+  /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+  /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+  /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+  function getQuoteAtTick(
+    int24 tick,
+    uint128 baseAmount,
+    address baseToken,
+    address quoteToken
+  ) internal pure returns (uint256 quoteAmount) {
+    uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
+
+    // Calculate quoteAmount with better precision if it doesn't overflow when multiplied by itself
+    if (sqrtRatioX96 <= type(uint128).max) {
+      uint256 ratioX192 = uint256(sqrtRatioX96) * sqrtRatioX96;
+      quoteAmount = baseToken < quoteToken
+        ? FullMath.mulDiv(ratioX192, baseAmount, 1 << 192)
+        : FullMath.mulDiv(1 << 192, baseAmount, ratioX192);
+    } else {
+      uint256 ratioX128 = FullMath.mulDiv(sqrtRatioX96, sqrtRatioX96, 1 << 64);
+      quoteAmount = baseToken < quoteToken
+        ? FullMath.mulDiv(ratioX128, baseAmount, 1 << 128)
+        : FullMath.mulDiv(1 << 128, baseAmount, ratioX128);
+    }
+  }
+
+  /// @notice Given a pool, it returns the number of seconds ago of the oldest stored observation
+  /// @param pool Address of Lista V3 pool that we want to observe
+  /// @return secondsAgo The number of seconds ago of the oldest observation stored for the pool
+  function getOldestObservationSecondsAgo(address pool) internal view returns (uint32 secondsAgo) {
+    (, , uint16 observationIndex, uint16 observationCardinality, , , ) = IListaV3Pool(pool).slot0();
+    require(observationCardinality > 0, "NI");
+
+    (uint32 observationTimestamp, , , bool initialized) = IListaV3Pool(pool).observations(
+      (observationIndex + 1) % observationCardinality
+    );
+
+    // The next index might not be initialized if the cardinality is in the process of increasing
+    // In this case the oldest observation is always in index 0
+    if (!initialized) {
+      (observationTimestamp, , , ) = IListaV3Pool(pool).observations(0);
+    }
+
+    unchecked {
+      secondsAgo = uint32(block.timestamp) - observationTimestamp;
+    }
+  }
+
+  /// @notice Given a pool, it returns the tick value as of the start of the current block
+  /// @param pool Address of Lista V3 pool
+  /// @return The tick that the pool was in at the start of the current block
+  function getBlockStartingTickAndLiquidity(address pool) internal view returns (int24, uint128) {
+    (, int24 tick, uint16 observationIndex, uint16 observationCardinality, , , ) = IListaV3Pool(pool).slot0();
+
+    // 2 observations are needed to reliably calculate the block starting tick
+    require(observationCardinality > 1, "NEO");
+
+    // If the latest observation occurred in the past, then no tick-changing trades have happened in this block
+    // therefore the tick in `slot0` is the same as at the beginning of the current block.
+    // We don't need to check if this observation is initialized - it is guaranteed to be.
+    (uint32 observationTimestamp, int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128, ) = IListaV3Pool(
+      pool
+    ).observations(observationIndex);
+    if (observationTimestamp != uint32(block.timestamp)) {
+      return (tick, IListaV3Pool(pool).liquidity());
+    }
+
+    uint256 prevIndex = (uint256(observationIndex) + observationCardinality - 1) % observationCardinality;
+    (
+      uint32 prevObservationTimestamp,
+      int56 prevTickCumulative,
+      uint160 prevSecondsPerLiquidityCumulativeX128,
+      bool prevInitialized
+    ) = IListaV3Pool(pool).observations(prevIndex);
+
+    require(prevInitialized, "ONI");
+
+    uint32 delta = observationTimestamp - prevObservationTimestamp;
+    tick = int24((tickCumulative - int56(uint56(prevTickCumulative))) / int56(uint56(delta)));
+    uint128 liquidity = uint128(
+      (uint192(delta) * type(uint160).max) /
+        (uint192(secondsPerLiquidityCumulativeX128 - prevSecondsPerLiquidityCumulativeX128) << 32)
+    );
+    return (tick, liquidity);
+  }
+
+  /// @notice Information for calculating a weighted arithmetic mean tick
+  struct WeightedTickData {
+    int24 tick;
+    uint128 weight;
+  }
+
+  /// @notice Given an array of ticks and weights, calculates the weighted arithmetic mean tick
+  /// @param weightedTickData An array of ticks and weights
+  /// @return weightedArithmeticMeanTick The weighted arithmetic mean tick
+  /// @dev Each entry of `weightedTickData` should represents ticks from pools with the same underlying pool tokens. If they do not,
+  /// extreme care must be taken to ensure that ticks are comparable (including decimal differences).
+  /// @dev Note that the weighted arithmetic mean tick corresponds to the weighted geometric mean price.
+  function getWeightedArithmeticMeanTick(
+    WeightedTickData[] memory weightedTickData
+  ) internal pure returns (int24 weightedArithmeticMeanTick) {
+    // Accumulates the sum of products between each tick and its weight
+    int256 numerator;
+
+    // Accumulates the sum of the weights
+    uint256 denominator;
+
+    // Products fit in 152 bits, so it would take an array of length ~2**104 to overflow this logic
+    for (uint256 i; i < weightedTickData.length; i++) {
+      numerator += weightedTickData[i].tick * int256(uint256(weightedTickData[i].weight));
+      denominator += weightedTickData[i].weight;
+    }
+
+    weightedArithmeticMeanTick = int24(numerator / int256(denominator));
+    // Always round to negative infinity
+    if (numerator < 0 && (numerator % int256(denominator) != 0)) weightedArithmeticMeanTick--;
+  }
+
+  /// @notice Returns the "synthetic" tick which represents the price of the first entry in `tokens` in terms of the last
+  /// @dev Useful for calculating relative prices along routes.
+  /// @dev There must be one tick for each pairwise set of tokens.
+  /// @param tokens The token contract addresses
+  /// @param ticks The ticks, representing the price of each token pair in `tokens`
+  /// @return syntheticTick The synthetic tick, representing the relative price of the outermost tokens in `tokens`
+  function getChainedPrice(address[] memory tokens, int24[] memory ticks) internal pure returns (int256 syntheticTick) {
+    require(tokens.length - 1 == ticks.length, "DL");
+    for (uint256 i = 1; i <= ticks.length; i++) {
+      // check the tokens for address sort order, then accumulate the
+      // ticks into the running synthetic tick, ensuring that intermediate tokens "cancel out"
+      tokens[i - 1] < tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];
+    }
+  }
+}

--- a/src/dex/v3/periphery/libraries/Path.sol
+++ b/src/dex/v3/periphery/libraries/Path.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.0;
+
+import "./BytesLib.sol";
+
+/// @title Functions for manipulating path data for multihop swaps
+library Path {
+  using BytesLib for bytes;
+
+  /// @dev The length of the bytes encoded address
+  uint256 private constant ADDR_SIZE = 20;
+  /// @dev The length of the bytes encoded fee
+  uint256 private constant FEE_SIZE = 3;
+
+  /// @dev The offset of a single token address and pool fee
+  uint256 private constant NEXT_OFFSET = ADDR_SIZE + FEE_SIZE;
+  /// @dev The offset of an encoded pool key
+  uint256 private constant POP_OFFSET = NEXT_OFFSET + ADDR_SIZE;
+  /// @dev The minimum length of an encoding that contains 2 or more pools
+  uint256 private constant MULTIPLE_POOLS_MIN_LENGTH = POP_OFFSET + NEXT_OFFSET;
+
+  /// @notice Returns true iff the path contains two or more pools
+  /// @param path The encoded swap path
+  /// @return True if path contains two or more pools, otherwise false
+  function hasMultiplePools(bytes memory path) internal pure returns (bool) {
+    return path.length >= MULTIPLE_POOLS_MIN_LENGTH;
+  }
+
+  /// @notice Returns the number of pools in the path
+  /// @param path The encoded swap path
+  /// @return The number of pools in the path
+  function numPools(bytes memory path) internal pure returns (uint256) {
+    // Ignore the first token address. From then on every fee and token offset indicates a pool.
+    return ((path.length - ADDR_SIZE) / NEXT_OFFSET);
+  }
+
+  /// @notice Decodes the first pool in path
+  /// @param path The bytes encoded swap path
+  /// @return tokenA The first token of the given pool
+  /// @return tokenB The second token of the given pool
+  /// @return fee The fee level of the pool
+  function decodeFirstPool(bytes memory path) internal pure returns (address tokenA, address tokenB, uint24 fee) {
+    tokenA = path.toAddress(0);
+    fee = path.toUint24(ADDR_SIZE);
+    tokenB = path.toAddress(NEXT_OFFSET);
+  }
+
+  /// @notice Gets the segment corresponding to the first pool in the path
+  /// @param path The bytes encoded swap path
+  /// @return The segment containing all data necessary to target the first pool in the path
+  function getFirstPool(bytes memory path) internal pure returns (bytes memory) {
+    return path.slice(0, POP_OFFSET);
+  }
+
+  /// @notice Skips a token + fee element from the buffer and returns the remainder
+  /// @param path The swap path
+  /// @return The remaining token + fee elements in the path
+  function skipToken(bytes memory path) internal pure returns (bytes memory) {
+    return path.slice(NEXT_OFFSET, path.length - NEXT_OFFSET);
+  }
+}

--- a/src/dex/v3/periphery/libraries/PoolAddress.sol
+++ b/src/dex/v3/periphery/libraries/PoolAddress.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
+library PoolAddress {
+  /// @notice The identifying key of the pool
+  struct PoolKey {
+    address token0;
+    address token1;
+    uint24 fee;
+  }
+
+  /// @notice Returns PoolKey: the ordered tokens with the matched fee levels
+  function getPoolKey(address tokenA, address tokenB, uint24 fee) internal pure returns (PoolKey memory) {
+    if (tokenA > tokenB) (tokenA, tokenB) = (tokenB, tokenA);
+    return PoolKey({ token0: tokenA, token1: tokenB, fee: fee });
+  }
+
+  /// @notice Deterministically computes the pool address given the factory, PoolKey, and init code hash
+  /// @param factory The Lista V3 factory contract address
+  /// @param key The PoolKey
+  /// @param initCodeHash The keccak256 of the pool proxy creation code (from factory.poolInitCodeHash())
+  /// @return pool The contract address of the V3 pool
+  function computeAddress(
+    address factory,
+    PoolKey memory key,
+    bytes32 initCodeHash
+  ) internal pure returns (address pool) {
+    require(key.token0 < key.token1);
+    pool = address(
+      uint160(
+        uint256(
+          keccak256(
+            abi.encodePacked(hex"ff", factory, keccak256(abi.encode(key.token0, key.token1, key.fee)), initCodeHash)
+          )
+        )
+      )
+    );
+  }
+}

--- a/src/dex/v3/periphery/libraries/PoolTicksCounter.sol
+++ b/src/dex/v3/periphery/libraries/PoolTicksCounter.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.0;
+
+import "../../core/interfaces/IListaV3Pool.sol";
+
+library PoolTicksCounter {
+  /// @dev This function counts the number of initialized ticks that would incur a gas cost between tickBefore and tickAfter.
+  /// When tickBefore and/or tickAfter themselves are initialized, the logic over whether we should count them depends on the
+  /// direction of the swap. If we are swapping upwards (tickAfter > tickBefore) we don't want to count tickBefore but we do
+  /// want to count tickAfter. The opposite is true if we are swapping downwards.
+  function countInitializedTicksCrossed(
+    IListaV3Pool self,
+    int24 tickBefore,
+    int24 tickAfter
+  ) internal view returns (uint32 initializedTicksCrossed) {
+    int16 wordPosLower;
+    int16 wordPosHigher;
+    uint8 bitPosLower;
+    uint8 bitPosHigher;
+    bool tickBeforeInitialized;
+    bool tickAfterInitialized;
+
+    {
+      // Get the key and offset in the tick bitmap of the active tick before and after the swap.
+      int16 wordPos = int16((tickBefore / self.tickSpacing()) >> 8);
+      uint8 bitPos = uint8(int8((tickBefore / self.tickSpacing()) % 256));
+
+      int16 wordPosAfter = int16((tickAfter / self.tickSpacing()) >> 8);
+      uint8 bitPosAfter = uint8(int8((tickAfter / self.tickSpacing()) % 256));
+
+      // In the case where tickAfter is initialized, we only want to count it if we are swapping downwards.
+      // If the initializable tick after the swap is initialized, our original tickAfter is a
+      // multiple of tick spacing, and we are swapping downwards we know that tickAfter is initialized
+      // and we shouldn't count it.
+      tickAfterInitialized =
+        ((self.tickBitmap(wordPosAfter) & (1 << bitPosAfter)) > 0) &&
+        ((tickAfter % self.tickSpacing()) == 0) &&
+        (tickBefore > tickAfter);
+
+      // In the case where tickBefore is initialized, we only want to count it if we are swapping upwards.
+      // Use the same logic as above to decide whether we should count tickBefore or not.
+      tickBeforeInitialized =
+        ((self.tickBitmap(wordPos) & (1 << bitPos)) > 0) &&
+        ((tickBefore % self.tickSpacing()) == 0) &&
+        (tickBefore < tickAfter);
+
+      if (wordPos < wordPosAfter || (wordPos == wordPosAfter && bitPos <= bitPosAfter)) {
+        wordPosLower = wordPos;
+        bitPosLower = bitPos;
+        wordPosHigher = wordPosAfter;
+        bitPosHigher = bitPosAfter;
+      } else {
+        wordPosLower = wordPosAfter;
+        bitPosLower = bitPosAfter;
+        wordPosHigher = wordPos;
+        bitPosHigher = bitPos;
+      }
+    }
+
+    // Count the number of initialized ticks crossed by iterating through the tick bitmap.
+    // Our first mask should include the lower tick and everything to its left.
+    uint256 mask = type(uint256).max << bitPosLower;
+    while (wordPosLower <= wordPosHigher) {
+      // If we're on the final tick bitmap page, ensure we only count up to our
+      // ending tick.
+      if (wordPosLower == wordPosHigher) {
+        mask = mask & (type(uint256).max >> (255 - bitPosHigher));
+      }
+
+      uint256 masked = self.tickBitmap(wordPosLower) & mask;
+      initializedTicksCrossed += countOneBits(masked);
+      wordPosLower++;
+      // Reset our mask so we consider all bits on the next iteration.
+      mask = type(uint256).max;
+    }
+
+    if (tickAfterInitialized) {
+      initializedTicksCrossed -= 1;
+    }
+
+    if (tickBeforeInitialized) {
+      initializedTicksCrossed -= 1;
+    }
+
+    return initializedTicksCrossed;
+  }
+
+  function countOneBits(uint256 x) private pure returns (uint16) {
+    uint16 bits = 0;
+    while (x != 0) {
+      bits++;
+      x &= (x - 1);
+    }
+    return bits;
+  }
+}

--- a/src/dex/v3/periphery/libraries/PositionKey.sol
+++ b/src/dex/v3/periphery/libraries/PositionKey.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+library PositionKey {
+  /// @dev Returns the key of the position in the core library
+  function compute(address owner, int24 tickLower, int24 tickUpper) internal pure returns (bytes32) {
+    return keccak256(abi.encodePacked(owner, tickLower, tickUpper));
+  }
+}

--- a/src/dex/v3/periphery/libraries/PositionValue.sol
+++ b/src/dex/v3/periphery/libraries/PositionValue.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.8 <0.9.0;
+
+import "../../core/interfaces/IListaV3Pool.sol";
+import "../../core/interfaces/IListaV3Factory.sol";
+import "../../core/libraries/FixedPoint128.sol";
+import "../../core/libraries/TickMath.sol";
+import "../../core/libraries/Tick.sol";
+import "../interfaces/INonfungiblePositionManager.sol";
+import "./LiquidityAmounts.sol";
+import "./PoolAddress.sol";
+import "./PositionKey.sol";
+
+/// @title Returns information about the token value held in a Lista V3 NFT
+library PositionValue {
+  /// @notice Returns the total amounts of token0 and token1, i.e. the sum of fees and principal
+  /// that a given nonfungible position manager token is worth
+  /// @param positionManager The Lista V3 NonfungiblePositionManager
+  /// @param tokenId The tokenId of the token for which to get the total value
+  /// @param sqrtRatioX96 The square root price X96 for which to calculate the principal amounts
+  /// @return amount0 The total amount of token0 including principal and fees
+  /// @return amount1 The total amount of token1 including principal and fees
+  function total(
+    INonfungiblePositionManager positionManager,
+    uint256 tokenId,
+    uint160 sqrtRatioX96
+  ) internal view returns (uint256 amount0, uint256 amount1) {
+    (uint256 amount0Principal, uint256 amount1Principal) = principal(positionManager, tokenId, sqrtRatioX96);
+    (uint256 amount0Fee, uint256 amount1Fee) = fees(positionManager, tokenId);
+    return (amount0Principal + amount0Fee, amount1Principal + amount1Fee);
+  }
+
+  /// @notice Calculates the principal (currently acting as liquidity) owed to the token owner in the event
+  /// that the position is burned
+  /// @param positionManager The Lista V3 NonfungiblePositionManager
+  /// @param tokenId The tokenId of the token for which to get the total principal owed
+  /// @param sqrtRatioX96 The square root price X96 for which to calculate the principal amounts
+  /// @return amount0 The principal amount of token0
+  /// @return amount1 The principal amount of token1
+  function principal(
+    INonfungiblePositionManager positionManager,
+    uint256 tokenId,
+    uint160 sqrtRatioX96
+  ) internal view returns (uint256 amount0, uint256 amount1) {
+    (, , , , , int24 tickLower, int24 tickUpper, uint128 liquidity, , , , ) = positionManager.positions(tokenId);
+
+    return
+      LiquidityAmounts.getAmountsForLiquidity(
+        sqrtRatioX96,
+        TickMath.getSqrtRatioAtTick(tickLower),
+        TickMath.getSqrtRatioAtTick(tickUpper),
+        liquidity
+      );
+  }
+
+  struct FeeParams {
+    address token0;
+    address token1;
+    uint24 fee;
+    int24 tickLower;
+    int24 tickUpper;
+    uint128 liquidity;
+    uint256 positionFeeGrowthInside0LastX128;
+    uint256 positionFeeGrowthInside1LastX128;
+    uint256 tokensOwed0;
+    uint256 tokensOwed1;
+  }
+
+  /// @notice Calculates the total fees owed to the token owner
+  /// @param positionManager The Lista V3 NonfungiblePositionManager
+  /// @param tokenId The tokenId of the token for which to get the total fees owed
+  /// @return amount0 The amount of fees owed in token0
+  /// @return amount1 The amount of fees owed in token1
+  function fees(
+    INonfungiblePositionManager positionManager,
+    uint256 tokenId
+  ) internal view returns (uint256 amount0, uint256 amount1) {
+    (
+      ,
+      ,
+      address token0,
+      address token1,
+      uint24 fee,
+      int24 tickLower,
+      int24 tickUpper,
+      uint128 liquidity,
+      uint256 positionFeeGrowthInside0LastX128,
+      uint256 positionFeeGrowthInside1LastX128,
+      uint256 tokensOwed0,
+      uint256 tokensOwed1
+    ) = positionManager.positions(tokenId);
+
+    return
+      _fees(
+        positionManager,
+        FeeParams({
+          token0: token0,
+          token1: token1,
+          fee: fee,
+          tickLower: tickLower,
+          tickUpper: tickUpper,
+          liquidity: liquidity,
+          positionFeeGrowthInside0LastX128: positionFeeGrowthInside0LastX128,
+          positionFeeGrowthInside1LastX128: positionFeeGrowthInside1LastX128,
+          tokensOwed0: tokensOwed0,
+          tokensOwed1: tokensOwed1
+        })
+      );
+  }
+
+  function _fees(
+    INonfungiblePositionManager positionManager,
+    FeeParams memory feeParams
+  ) private view returns (uint256 amount0, uint256 amount1) {
+    (uint256 poolFeeGrowthInside0LastX128, uint256 poolFeeGrowthInside1LastX128) = _getFeeGrowthInside(
+      IListaV3Pool(
+        IListaV3Factory(positionManager.factory()).getPool(feeParams.token0, feeParams.token1, feeParams.fee)
+      ),
+      feeParams.tickLower,
+      feeParams.tickUpper
+    );
+
+    amount0 =
+      FullMath.mulDiv(
+        poolFeeGrowthInside0LastX128 - feeParams.positionFeeGrowthInside0LastX128,
+        feeParams.liquidity,
+        FixedPoint128.Q128
+      ) +
+      feeParams.tokensOwed0;
+
+    amount1 =
+      FullMath.mulDiv(
+        poolFeeGrowthInside1LastX128 - feeParams.positionFeeGrowthInside1LastX128,
+        feeParams.liquidity,
+        FixedPoint128.Q128
+      ) +
+      feeParams.tokensOwed1;
+  }
+
+  function _getFeeGrowthInside(
+    IListaV3Pool pool,
+    int24 tickLower,
+    int24 tickUpper
+  ) private view returns (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) {
+    (, int24 tickCurrent, , , , , ) = pool.slot0();
+    (, , uint256 lowerFeeGrowthOutside0X128, uint256 lowerFeeGrowthOutside1X128, , , , ) = pool.ticks(tickLower);
+    (, , uint256 upperFeeGrowthOutside0X128, uint256 upperFeeGrowthOutside1X128, , , , ) = pool.ticks(tickUpper);
+
+    if (tickCurrent < tickLower) {
+      feeGrowthInside0X128 = lowerFeeGrowthOutside0X128 - upperFeeGrowthOutside0X128;
+      feeGrowthInside1X128 = lowerFeeGrowthOutside1X128 - upperFeeGrowthOutside1X128;
+    } else if (tickCurrent < tickUpper) {
+      uint256 feeGrowthGlobal0X128 = pool.feeGrowthGlobal0X128();
+      uint256 feeGrowthGlobal1X128 = pool.feeGrowthGlobal1X128();
+      feeGrowthInside0X128 = feeGrowthGlobal0X128 - lowerFeeGrowthOutside0X128 - upperFeeGrowthOutside0X128;
+      feeGrowthInside1X128 = feeGrowthGlobal1X128 - lowerFeeGrowthOutside1X128 - upperFeeGrowthOutside1X128;
+    } else {
+      feeGrowthInside0X128 = upperFeeGrowthOutside0X128 - lowerFeeGrowthOutside0X128;
+      feeGrowthInside1X128 = upperFeeGrowthOutside1X128 - lowerFeeGrowthOutside1X128;
+    }
+  }
+}

--- a/src/dex/v3/periphery/libraries/SafeERC20Namer.sol
+++ b/src/dex/v3/periphery/libraries/SafeERC20Namer.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// from https://github.com/Lista/solidity-lib/blob/master/contracts/libraries/SafeERC20Namer.sol
+// modified for solidity 0.8
+
+pragma solidity 0.8.34;
+
+import "./AddressStringUtil.sol";
+
+// produces token descriptors from inconsistent or absent ERC20 symbol implementations that can return string or bytes32
+// this library will always produce a string symbol to represent the token
+library SafeERC20Namer {
+  function bytes32ToString(bytes32 x) private pure returns (string memory) {
+    bytes memory bytesString = new bytes(32);
+    uint256 charCount = 0;
+    for (uint256 j = 0; j < 32; j++) {
+      bytes1 char = x[j];
+      if (char != 0) {
+        bytesString[charCount] = char;
+        charCount++;
+      }
+    }
+    bytes memory bytesStringTrimmed = new bytes(charCount);
+    for (uint256 j = 0; j < charCount; j++) {
+      bytesStringTrimmed[j] = bytesString[j];
+    }
+    return string(bytesStringTrimmed);
+  }
+
+  // assumes the data is in position 2
+  function parseStringData(bytes memory b) private pure returns (string memory) {
+    uint256 charCount = 0;
+    // first parse the charCount out of the data
+    for (uint256 i = 32; i < 64; i++) {
+      charCount <<= 8;
+      charCount += uint8(b[i]);
+    }
+
+    bytes memory bytesStringTrimmed = new bytes(charCount);
+    for (uint256 i = 0; i < charCount; i++) {
+      bytesStringTrimmed[i] = b[i + 64];
+    }
+
+    return string(bytesStringTrimmed);
+  }
+
+  // uses a heuristic to produce a token name from the address
+  // the heuristic returns the full hex of the address string in upper case
+  function addressToName(address token) private pure returns (string memory) {
+    return AddressStringUtil.toAsciiString(token, 40);
+  }
+
+  // uses a heuristic to produce a token symbol from the address
+  // the heuristic returns the first 6 hex of the address string in upper case
+  function addressToSymbol(address token) private pure returns (string memory) {
+    return AddressStringUtil.toAsciiString(token, 6);
+  }
+
+  // calls an external view token contract method that returns a symbol or name, and parses the output into a string
+  function callAndParseStringReturn(address token, bytes4 selector) private view returns (string memory) {
+    (bool success, bytes memory data) = token.staticcall(abi.encodeWithSelector(selector));
+    // if not implemented, or returns empty data, return empty string
+    if (!success || data.length == 0) {
+      return "";
+    }
+    // bytes32 data always has length 32
+    if (data.length == 32) {
+      bytes32 decoded = abi.decode(data, (bytes32));
+      return bytes32ToString(decoded);
+    } else if (data.length > 64) {
+      return abi.decode(data, (string));
+    }
+    return "";
+  }
+
+  // attempts to extract the token symbol. if it does not implement symbol, returns a symbol derived from the address
+  function tokenSymbol(address token) internal view returns (string memory) {
+    // 0x95d89b41 = bytes4(keccak256("symbol()"))
+    string memory symbol = callAndParseStringReturn(token, 0x95d89b41);
+    if (bytes(symbol).length == 0) {
+      // fallback to 6 uppercase hex of address
+      return addressToSymbol(token);
+    }
+    return symbol;
+  }
+
+  // attempts to extract the token name. if it does not implement name, returns a name derived from the address
+  function tokenName(address token) internal view returns (string memory) {
+    // 0x06fdde03 = bytes4(keccak256("name()"))
+    string memory name = callAndParseStringReturn(token, 0x06fdde03);
+    if (bytes(name).length == 0) {
+      // fallback to full hex of address
+      return addressToName(token);
+    }
+    return name;
+  }
+}

--- a/src/dex/v3/periphery/libraries/SqrtPriceMathPartial.sol
+++ b/src/dex/v3/periphery/libraries/SqrtPriceMathPartial.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import "../../core/libraries/FullMath.sol";
+import "../../core/libraries/UnsafeMath.sol";
+import "../../core/libraries/FixedPoint96.sol";
+
+/// @title Functions based on Q64.96 sqrt price and liquidity
+/// @notice Exposes two functions from @lista/v3-core SqrtPriceMath
+/// that use square root of price as a Q64.96 and liquidity to compute deltas
+library SqrtPriceMathPartial {
+  /// @notice Gets the amount0 delta between two prices
+  /// @dev Calculates liquidity / sqrt(lower) - liquidity / sqrt(upper),
+  /// i.e. liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+  /// @param sqrtRatioAX96 A sqrt price
+  /// @param sqrtRatioBX96 Another sqrt price
+  /// @param liquidity The amount of usable liquidity
+  /// @param roundUp Whether to round the amount up or down
+  /// @return amount0 Amount of token0 required to cover a position of size liquidity between the two passed prices
+  function getAmount0Delta(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity,
+    bool roundUp
+  ) internal pure returns (uint256 amount0) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+    uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+    uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+
+    require(sqrtRatioAX96 > 0);
+
+    return
+      roundUp
+        ? UnsafeMath.divRoundingUp(FullMath.mulDivRoundingUp(numerator1, numerator2, sqrtRatioBX96), sqrtRatioAX96)
+        : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
+  }
+
+  /// @notice Gets the amount1 delta between two prices
+  /// @dev Calculates liquidity * (sqrt(upper) - sqrt(lower))
+  /// @param sqrtRatioAX96 A sqrt price
+  /// @param sqrtRatioBX96 Another sqrt price
+  /// @param liquidity The amount of usable liquidity
+  /// @param roundUp Whether to round the amount up, or down
+  /// @return amount1 Amount of token1 required to cover a position of size liquidity between the two passed prices
+  function getAmount1Delta(
+    uint160 sqrtRatioAX96,
+    uint160 sqrtRatioBX96,
+    uint128 liquidity,
+    bool roundUp
+  ) internal pure returns (uint256 amount1) {
+    if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+    return
+      roundUp
+        ? FullMath.mulDivRoundingUp(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96)
+        : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
+  }
+}

--- a/src/dex/v3/periphery/libraries/TokenRatioSortOrder.sol
+++ b/src/dex/v3/periphery/libraries/TokenRatioSortOrder.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+library TokenRatioSortOrder {
+  int256 constant NUMERATOR_MOST = 300;
+  int256 constant NUMERATOR_MORE = 200;
+  int256 constant NUMERATOR = 100;
+
+  int256 constant DENOMINATOR_MOST = -300;
+  int256 constant DENOMINATOR_MORE = -200;
+  int256 constant DENOMINATOR = -100;
+}

--- a/src/dex/v3/periphery/libraries/TransferHelper.sol
+++ b/src/dex/v3/periphery/libraries/TransferHelper.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+library TransferHelper {
+  /// @notice Transfers tokens from the targeted address to the given destination
+  /// @notice Errors with 'STF' if transfer fails
+  /// @param token The contract address of the token to be transferred
+  /// @param from The originating address from which the tokens will be transferred
+  /// @param to The destination address of the transfer
+  /// @param value The amount to be transferred
+  function safeTransferFrom(address token, address from, address to, uint256 value) internal {
+    (bool success, bytes memory data) = token.call(
+      abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, value)
+    );
+    require(success && (data.length == 0 || abi.decode(data, (bool))), "STF");
+  }
+
+  /// @notice Transfers tokens from msg.sender to a recipient
+  /// @dev Errors with ST if transfer fails
+  /// @param token The contract address of the token which will be transferred
+  /// @param to The recipient of the transfer
+  /// @param value The value of the transfer
+  function safeTransfer(address token, address to, uint256 value) internal {
+    (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
+    require(success && (data.length == 0 || abi.decode(data, (bool))), "ST");
+  }
+
+  /// @notice Approves the stipulated contract to spend the given allowance in the given token
+  /// @dev Errors with 'SA' if transfer fails
+  /// @param token The contract address of the token to be approved
+  /// @param to The target of the approval
+  /// @param value The amount of the given token the target will be allowed to spend
+  function safeApprove(address token, address to, uint256 value) internal {
+    (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.approve.selector, to, value));
+    require(success && (data.length == 0 || abi.decode(data, (bool))), "SA");
+  }
+
+  /// @notice Transfers ETH to the recipient address
+  /// @dev Fails with `STE`
+  /// @param to The destination of the transfer
+  /// @param value The value to be transferred
+  function safeTransferETH(address to, uint256 value) internal {
+    (bool success, ) = to.call{ value: value }(new bytes(0));
+    require(success, "STE");
+  }
+}

--- a/test/dex/v3/ListaV3.t.sol
+++ b/test/dex/v3/ListaV3.t.sol
@@ -1,0 +1,576 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import { ListaV3Factory } from "../../../src/dex/v3/core/ListaV3Factory.sol";
+import { ListaV3Pool } from "../../../src/dex/v3/core/ListaV3Pool.sol";
+import { IListaV3Pool } from "../../../src/dex/v3/core/interfaces/IListaV3Pool.sol";
+import { IListaV3MintCallback } from "../../../src/dex/v3/core/interfaces/callback/IListaV3MintCallback.sol";
+import { IListaV3SwapCallback } from "../../../src/dex/v3/core/interfaces/callback/IListaV3SwapCallback.sol";
+import { TickMath } from "../../../src/dex/v3/core/libraries/TickMath.sol";
+import { LiquidityAmounts } from "../../../src/dex/v3/periphery/libraries/LiquidityAmounts.sol";
+import { NonfungiblePositionManager } from "../../../src/dex/v3/periphery/NonfungiblePositionManager.sol";
+import { INonfungiblePositionManager } from "../../../src/dex/v3/periphery/interfaces/INonfungiblePositionManager.sol";
+import { PoolAddress } from "../../../src/dex/v3/periphery/libraries/PoolAddress.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/* ─────────────────────── Mock ERC20 ─────────────────────── */
+
+contract MockERC20 is ERC20 {
+  uint8 private _dec;
+
+  constructor(string memory name, string memory symbol, uint8 dec_) ERC20(name, symbol) {
+    _dec = dec_;
+  }
+
+  function decimals() public view override returns (uint8) {
+    return _dec;
+  }
+
+  function mint(address to, uint256 amount) external {
+    _mint(to, amount);
+  }
+}
+
+/* ───────────── Mock WETH9 (needed by NPM constructor) ───────────── */
+
+contract MockWETH9 is MockERC20 {
+  constructor() MockERC20("Wrapped BNB", "WBNB", 18) {}
+
+  function deposit() external payable {
+    _mint(msg.sender, msg.value);
+  }
+
+  function withdraw(uint256 amount) external {
+    _burn(msg.sender, amount);
+    (bool ok, ) = msg.sender.call{ value: amount }("");
+    require(ok);
+  }
+
+  receive() external payable {
+    _mint(msg.sender, msg.value);
+  }
+}
+
+/* ──────────── Mock token descriptor (returns empty URI) ──────────── */
+
+contract MockTokenDescriptor {
+  function tokenURI(address, uint256) external pure returns (string memory) {
+    return "";
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Test Suite
+   ═══════════════════════════════════════════════════════════════════ */
+
+contract ListaV3Test is Test, IListaV3MintCallback, IListaV3SwapCallback {
+  ListaV3Factory factory;
+  NonfungiblePositionManager npm;
+  MockWETH9 weth;
+  MockERC20 tokenA;
+  MockERC20 tokenB;
+  address token0;
+  address token1;
+
+  uint24 constant FEE = 3000;
+  int24 constant TICK_SPACING = 60;
+
+  // TickMath constants
+  uint160 constant MIN_SQRT_RATIO = 4295128739;
+  uint160 constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+  function setUp() public {
+    // Deploy Factory behind UUPS proxy
+    ListaV3Factory factoryImpl = new ListaV3Factory();
+    factory = ListaV3Factory(
+      address(new ERC1967Proxy(address(factoryImpl), abi.encodeCall(ListaV3Factory.initialize, (address(this)))))
+    );
+
+    weth = new MockWETH9();
+    MockTokenDescriptor descriptor = new MockTokenDescriptor();
+
+    // Deploy NPM behind UUPS proxy
+    NonfungiblePositionManager npmImpl = new NonfungiblePositionManager();
+    npm = NonfungiblePositionManager(
+      payable(
+        new ERC1967Proxy(
+          address(npmImpl),
+          abi.encodeCall(
+            NonfungiblePositionManager.initialize,
+            (address(factory), address(weth), address(descriptor), address(this), factory.poolInitCodeHash())
+          )
+        )
+      )
+    );
+
+    // Deploy tokens and sort
+    tokenA = new MockERC20("Token A", "TKA", 18);
+    tokenB = new MockERC20("Token B", "TKB", 18);
+    (token0, token1) = address(tokenA) < address(tokenB)
+      ? (address(tokenA), address(tokenB))
+      : (address(tokenB), address(tokenA));
+  }
+
+  /* ─────────────────────── helpers ─────────────────────── */
+
+  function _createAndInitPool(uint160 sqrtPriceX96) internal returns (IListaV3Pool pool) {
+    address poolAddr = factory.createPool(token0, token1, FEE);
+    pool = IListaV3Pool(poolAddr);
+    pool.initialize(sqrtPriceX96);
+  }
+
+  function _mintTokens(address to, uint256 amount0, uint256 amount1) internal {
+    MockERC20(token0).mint(to, amount0);
+    MockERC20(token1).mint(to, amount1);
+  }
+
+  /* ─────────────── V3 pool callbacks (for direct pool interaction) ─────────────── */
+
+  function listaV3MintCallback(uint256 amount0Owed, uint256 amount1Owed, bytes calldata) external override {
+    if (amount0Owed > 0) IERC20(token0).transfer(msg.sender, amount0Owed);
+    if (amount1Owed > 0) IERC20(token1).transfer(msg.sender, amount1Owed);
+  }
+
+  function listaV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata) external override {
+    if (amount0Delta > 0) IERC20(token0).transfer(msg.sender, uint256(amount0Delta));
+    if (amount1Delta > 0) IERC20(token1).transfer(msg.sender, uint256(amount1Delta));
+  }
+
+  /* ═══════════════════════════════════════════════════════════
+     Factory Tests
+     ═══════════════════════════════════════════════════════════ */
+
+  function test_factory_defaultFeeTiers() public view {
+    assertEq(factory.feeAmountTickSpacing(500), 10);
+    assertEq(factory.feeAmountTickSpacing(3000), 60);
+    assertEq(factory.feeAmountTickSpacing(10000), 200);
+    assertEq(factory.feeAmountTickSpacing(100), 0, "unsupported fee should return 0");
+  }
+
+  function test_factory_owner() public view {
+    assertEq(factory.owner(), address(this));
+  }
+
+  function test_factory_createPool() public {
+    address pool = factory.createPool(token0, token1, FEE);
+    assertTrue(pool != address(0), "pool should be created");
+    assertEq(factory.getPool(token0, token1, FEE), pool);
+    assertEq(factory.getPool(token1, token0, FEE), pool, "reverse lookup should work");
+  }
+
+  function test_factory_createPool_revertsOnDuplicate() public {
+    factory.createPool(token0, token1, FEE);
+    vm.expectRevert();
+    factory.createPool(token0, token1, FEE);
+  }
+
+  function test_factory_createPool_revertsOnSameToken() public {
+    vm.expectRevert();
+    factory.createPool(token0, token0, FEE);
+  }
+
+  function test_factory_createPool_revertsOnUnsupportedFee() public {
+    vm.expectRevert();
+    factory.createPool(token0, token1, 100); // 100 not enabled
+  }
+
+  function test_factory_enableFeeAmount() public {
+    factory.enableFeeAmount(100, 1);
+    assertEq(factory.feeAmountTickSpacing(100), 1);
+
+    // Can now create a pool with the new fee
+    address pool = factory.createPool(token0, token1, 100);
+    assertTrue(pool != address(0));
+  }
+
+  function test_factory_setOwner() public {
+    address newOwner = makeAddr("newOwner");
+    factory.setOwner(newOwner);
+    assertEq(factory.owner(), newOwner);
+  }
+
+  function test_factory_setOwner_revertsIfNotOwner() public {
+    vm.prank(makeAddr("rando"));
+    vm.expectRevert();
+    factory.setOwner(makeAddr("newOwner"));
+  }
+
+  /* ═══════════════════════════════════════════════════════════
+     Pool Tests
+     ═══════════════════════════════════════════════════════════ */
+
+  function test_pool_initialize() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336; // sqrt(1) * 2^96 ≈ price = 1.0
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+
+    (uint160 sqrtPrice, int24 tick, , , , , ) = pool.slot0();
+    assertEq(sqrtPrice, sqrtPriceX96);
+    assertEq(tick, 0, "tick should be 0 at price 1.0");
+    assertEq(pool.token0(), token0);
+    assertEq(pool.token1(), token1);
+    assertEq(pool.fee(), FEE);
+    assertEq(pool.tickSpacing(), TICK_SPACING);
+  }
+
+  function test_pool_initialize_revertsOnDouble() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+    vm.expectRevert();
+    pool.initialize(sqrtPriceX96);
+  }
+
+  function test_pool_mint() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336; // price = 1.0
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+
+    // Mint liquidity around tick 0 (price 1.0)
+    int24 tickLower = -TICK_SPACING;
+    int24 tickUpper = TICK_SPACING;
+    uint128 liquidityAmount = 1_000_000;
+
+    _mintTokens(address(this), 10 ether, 10 ether);
+
+    (uint256 amount0, uint256 amount1) = pool.mint(address(this), tickLower, tickUpper, liquidityAmount, "");
+    assertGt(amount0, 0, "should consume token0");
+    assertGt(amount1, 0, "should consume token1");
+
+    // Verify position
+    bytes32 posKey = keccak256(abi.encodePacked(address(this), tickLower, tickUpper));
+    (uint128 liq, , , , ) = pool.positions(posKey);
+    assertEq(liq, liquidityAmount, "position liquidity should match");
+  }
+
+  function test_pool_swap() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+
+    // Add wide-range liquidity
+    int24 tickLower = -600;
+    int24 tickUpper = 600;
+    uint128 liquidityAmount = 100_000_000_000;
+    _mintTokens(address(this), 100 ether, 100 ether);
+    pool.mint(address(this), tickLower, tickUpper, liquidityAmount, "");
+
+    // Swap token0 → token1 (zeroForOne = true, pushes price down)
+    uint256 swapAmount = 0.1 ether;
+    _mintTokens(address(this), swapAmount, 0);
+    uint256 bal1Before = IERC20(token1).balanceOf(address(this));
+
+    pool.swap(address(this), true, int256(swapAmount), MIN_SQRT_RATIO + 1, "");
+
+    uint256 bal1After = IERC20(token1).balanceOf(address(this));
+    assertGt(bal1After, bal1Before, "should receive token1 from swap");
+
+    // Price should have moved down
+    (uint160 newSqrtPrice, , , , , , ) = pool.slot0();
+    assertLt(newSqrtPrice, sqrtPriceX96, "price should decrease after zeroForOne swap");
+  }
+
+  function test_pool_burn_and_collect() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+
+    int24 tickLower = -TICK_SPACING;
+    int24 tickUpper = TICK_SPACING;
+    uint128 liquidityAmount = 1_000_000;
+    _mintTokens(address(this), 10 ether, 10 ether);
+    pool.mint(address(this), tickLower, tickUpper, liquidityAmount, "");
+
+    // Burn all liquidity
+    (uint256 amount0, uint256 amount1) = pool.burn(tickLower, tickUpper, liquidityAmount);
+    assertGt(amount0 + amount1, 0, "should return tokens on burn");
+
+    // Collect
+    uint256 bal0Before = IERC20(token0).balanceOf(address(this));
+    uint256 bal1Before = IERC20(token1).balanceOf(address(this));
+    pool.collect(address(this), tickLower, tickUpper, type(uint128).max, type(uint128).max);
+    uint256 collected0 = IERC20(token0).balanceOf(address(this)) - bal0Before;
+    uint256 collected1 = IERC20(token1).balanceOf(address(this)) - bal1Before;
+
+    assertEq(collected0, amount0, "collected0 should match burned amount0");
+    assertEq(collected1, amount1, "collected1 should match burned amount1");
+  }
+
+  function test_pool_observe() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+
+    // Need to increase cardinality for TWAP
+    pool.increaseObservationCardinalityNext(10);
+
+    // Add liquidity so the pool is active
+    _mintTokens(address(this), 10 ether, 10 ether);
+    pool.mint(address(this), -TICK_SPACING, TICK_SPACING, 1_000_000, "");
+
+    // Observation at time 0 should work
+    uint32[] memory secondsAgos = new uint32[](2);
+    secondsAgos[0] = 0;
+    secondsAgos[1] = 0;
+    (int56[] memory tickCumulatives, ) = pool.observe(secondsAgos);
+    assertEq(tickCumulatives[0], tickCumulatives[1], "same timestamp should give same cumulative");
+  }
+
+  function test_pool_feeGrowth_afterSwaps() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    IListaV3Pool pool = _createAndInitPool(sqrtPriceX96);
+
+    // Add liquidity
+    int24 tickLower = -600;
+    int24 tickUpper = 600;
+    _mintTokens(address(this), 100 ether, 100 ether);
+    pool.mint(address(this), tickLower, tickUpper, 100_000_000_000, "");
+
+    // Perform multiple swaps to generate fees
+    for (uint256 i = 0; i < 5; i++) {
+      _mintTokens(address(this), 1 ether, 1 ether);
+      pool.swap(address(this), true, int256(0.5 ether), MIN_SQRT_RATIO + 1, "");
+      pool.swap(address(this), false, int256(0.5 ether), MAX_SQRT_RATIO - 1, "");
+    }
+
+    // Fee growth should be non-zero
+    uint256 fg0 = pool.feeGrowthGlobal0X128();
+    uint256 fg1 = pool.feeGrowthGlobal1X128();
+    assertGt(fg0 + fg1, 0, "fees should have accrued from swaps");
+  }
+
+  /* ═══════════════════════════════════════════════════════════
+     NonfungiblePositionManager Tests
+     ═══════════════════════════════════════════════════════════ */
+
+  function test_npm_mintPosition() public {
+    // Create and init pool directly via factory (NPM uses computeAddress internally)
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    address poolAddr = factory.createPool(token0, token1, FEE);
+    IListaV3Pool(poolAddr).initialize(sqrtPriceX96);
+
+    // Mint tokens and approve NPM
+    _mintTokens(address(this), 10 ether, 10 ether);
+    IERC20(token0).approve(address(npm), 10 ether);
+    IERC20(token1).approve(address(npm), 10 ether);
+
+    (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) = npm.mint(
+      INonfungiblePositionManager.MintParams({
+        token0: token0,
+        token1: token1,
+        fee: FEE,
+        tickLower: -TICK_SPACING,
+        tickUpper: TICK_SPACING,
+        amount0Desired: 1 ether,
+        amount1Desired: 1 ether,
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: address(this),
+        deadline: block.timestamp
+      })
+    );
+
+    assertEq(tokenId, 1, "first token ID should be 1");
+    assertGt(liquidity, 0, "should have minted liquidity");
+    assertGt(amount0 + amount1, 0, "should have consumed tokens");
+    assertEq(npm.ownerOf(tokenId), address(this));
+  }
+
+  function test_npm_increaseLiquidity() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    address poolAddr = factory.createPool(token0, token1, FEE);
+    IListaV3Pool(poolAddr).initialize(sqrtPriceX96);
+
+    _mintTokens(address(this), 20 ether, 20 ether);
+    IERC20(token0).approve(address(npm), 20 ether);
+    IERC20(token1).approve(address(npm), 20 ether);
+
+    (uint256 tokenId, uint128 liqBefore, , ) = npm.mint(
+      INonfungiblePositionManager.MintParams({
+        token0: token0,
+        token1: token1,
+        fee: FEE,
+        tickLower: -TICK_SPACING,
+        tickUpper: TICK_SPACING,
+        amount0Desired: 1 ether,
+        amount1Desired: 1 ether,
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: address(this),
+        deadline: block.timestamp
+      })
+    );
+
+    (uint128 addedLiq, , ) = npm.increaseLiquidity(
+      INonfungiblePositionManager.IncreaseLiquidityParams({
+        tokenId: tokenId,
+        amount0Desired: 1 ether,
+        amount1Desired: 1 ether,
+        amount0Min: 0,
+        amount1Min: 0,
+        deadline: block.timestamp
+      })
+    );
+
+    assertGt(addedLiq, 0, "should add liquidity");
+
+    // Check total via positions()
+    (, , , , , , , uint128 totalLiq, , , , ) = npm.positions(tokenId);
+    assertEq(totalLiq, liqBefore + addedLiq, "total liquidity should be sum");
+  }
+
+  function test_npm_decreaseLiquidity_and_collect() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    address poolAddr = factory.createPool(token0, token1, FEE);
+    IListaV3Pool(poolAddr).initialize(sqrtPriceX96);
+
+    _mintTokens(address(this), 10 ether, 10 ether);
+    IERC20(token0).approve(address(npm), 10 ether);
+    IERC20(token1).approve(address(npm), 10 ether);
+
+    (uint256 tokenId, uint128 liquidity, , ) = npm.mint(
+      INonfungiblePositionManager.MintParams({
+        token0: token0,
+        token1: token1,
+        fee: FEE,
+        tickLower: -TICK_SPACING,
+        tickUpper: TICK_SPACING,
+        amount0Desired: 1 ether,
+        amount1Desired: 1 ether,
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: address(this),
+        deadline: block.timestamp
+      })
+    );
+
+    // Decrease all liquidity
+    (uint256 dec0, uint256 dec1) = npm.decreaseLiquidity(
+      INonfungiblePositionManager.DecreaseLiquidityParams({
+        tokenId: tokenId,
+        liquidity: liquidity,
+        amount0Min: 0,
+        amount1Min: 0,
+        deadline: block.timestamp
+      })
+    );
+    assertGt(dec0 + dec1, 0, "should return tokens");
+
+    // Collect
+    uint256 bal0Before = IERC20(token0).balanceOf(address(this));
+    uint256 bal1Before = IERC20(token1).balanceOf(address(this));
+    npm.collect(
+      INonfungiblePositionManager.CollectParams({
+        tokenId: tokenId,
+        recipient: address(this),
+        amount0Max: type(uint128).max,
+        amount1Max: type(uint128).max
+      })
+    );
+    uint256 collected0 = IERC20(token0).balanceOf(address(this)) - bal0Before;
+    uint256 collected1 = IERC20(token1).balanceOf(address(this)) - bal1Before;
+    assertGt(collected0 + collected1, 0, "should collect tokens");
+  }
+
+  function test_npm_burn() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    address poolAddr = factory.createPool(token0, token1, FEE);
+    IListaV3Pool(poolAddr).initialize(sqrtPriceX96);
+
+    _mintTokens(address(this), 10 ether, 10 ether);
+    IERC20(token0).approve(address(npm), 10 ether);
+    IERC20(token1).approve(address(npm), 10 ether);
+
+    (uint256 tokenId, uint128 liquidity, , ) = npm.mint(
+      INonfungiblePositionManager.MintParams({
+        token0: token0,
+        token1: token1,
+        fee: FEE,
+        tickLower: -TICK_SPACING,
+        tickUpper: TICK_SPACING,
+        amount0Desired: 1 ether,
+        amount1Desired: 1 ether,
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: address(this),
+        deadline: block.timestamp
+      })
+    );
+
+    // Must decrease + collect before burn
+    npm.decreaseLiquidity(
+      INonfungiblePositionManager.DecreaseLiquidityParams({
+        tokenId: tokenId,
+        liquidity: liquidity,
+        amount0Min: 0,
+        amount1Min: 0,
+        deadline: block.timestamp
+      })
+    );
+    npm.collect(
+      INonfungiblePositionManager.CollectParams({
+        tokenId: tokenId,
+        recipient: address(this),
+        amount0Max: type(uint128).max,
+        amount1Max: type(uint128).max
+      })
+    );
+
+    npm.burn(tokenId);
+
+    vm.expectRevert();
+    npm.ownerOf(tokenId);
+  }
+
+  function test_npm_positions_returnsCorrectData() public {
+    uint160 sqrtPriceX96 = 79228162514264337593543950336;
+    address poolAddr = factory.createPool(token0, token1, FEE);
+    IListaV3Pool(poolAddr).initialize(sqrtPriceX96);
+
+    _mintTokens(address(this), 10 ether, 10 ether);
+    IERC20(token0).approve(address(npm), 10 ether);
+    IERC20(token1).approve(address(npm), 10 ether);
+
+    int24 tickLower = -120;
+    int24 tickUpper = 120;
+
+    (uint256 tokenId, uint128 expectedLiq, , ) = npm.mint(
+      INonfungiblePositionManager.MintParams({
+        token0: token0,
+        token1: token1,
+        fee: FEE,
+        tickLower: tickLower,
+        tickUpper: tickUpper,
+        amount0Desired: 1 ether,
+        amount1Desired: 1 ether,
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: address(this),
+        deadline: block.timestamp
+      })
+    );
+
+    (, , address t0, address t1, uint24 fee, int24 tl, int24 tu, uint128 liq, , , , ) = npm.positions(tokenId);
+
+    assertEq(t0, token0);
+    assertEq(t1, token1);
+    assertEq(fee, FEE);
+    assertEq(tl, tickLower);
+    assertEq(tu, tickUpper);
+    assertEq(liq, expectedLiq);
+  }
+
+  /* ═══════════════════════════════════════════════════════════
+     Init Code Hash (utility test)
+     ═══════════════════════════════════════════════════════════ */
+
+  function test_poolInitCodeHash() public {
+    bytes32 hash = factory.poolInitCodeHash();
+    assertGt(uint256(hash), 0, "poolInitCodeHash should be non-zero");
+    emit log_named_bytes32("poolInitCodeHash", hash);
+
+    // Verify the hash correctly derives pool addresses:
+    // create a pool, then check computeAddress matches
+    address pool = factory.createPool(token0, token1, FEE);
+    address derived = PoolAddress.computeAddress(address(factory), PoolAddress.PoolKey(token0, token1, FEE), hash);
+    assertEq(derived, pool, "computeAddress should match actual pool address");
+  }
+}


### PR DESCRIPTION
## Summary

Fork Uniswap V3 core and periphery contracts into Lista DEX (`src/dex/v3/`). Factory and NonfungiblePositionManager are made UUPS upgradeable; core Pool and SwapRouter remain immutable.

## Change type

- [x] New contract
- [ ] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [ ] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| ListaV3Factory | `src/dex/v3/core/ListaV3Factory.sol` | new |
| ListaV3Pool | `src/dex/v3/core/ListaV3Pool.sol` | new |
| ListaV3PoolDeployer | `src/dex/v3/core/ListaV3PoolDeployer.sol` | new |
| NoDelegateCall | `src/dex/v3/core/NoDelegateCall.sol` | new |
| V3 Core Interfaces (8+3 callbacks) | `src/dex/v3/core/interfaces/` | new |
| V3 Core Libraries (14) | `src/dex/v3/core/libraries/` | new |
| NonfungiblePositionManager | `src/dex/v3/periphery/NonfungiblePositionManager.sol` | new |
| NonfungibleTokenPositionDescriptor | `src/dex/v3/periphery/NonfungibleTokenPositionDescriptor.sol` | new |
| SwapRouter | `src/dex/v3/periphery/SwapRouter.sol` | new |
| Periphery Bases (10) | `src/dex/v3/periphery/base/` | new |
| Periphery Interfaces (15) | `src/dex/v3/periphery/interfaces/` | new |
| Periphery Libraries (15) | `src/dex/v3/periphery/libraries/` | new |
| Lens (Quoter, QuoterV2, TickLens, Multicall) | `src/dex/v3/periphery/lens/` | new |
| NOTICE (license) | `src/dex/v3/NOTICE` | new |
| ListaV3.t.sol | `test/dex/v3/ListaV3.t.sol` | new |

## Interface changes

**New external/public interfaces (V3 fork):**
- `ListaV3Factory`: `initialize()`, `createPool()`, `setOwner()`, `enableFeeAmount()`, `poolInitCodeHash()`
- `ListaV3Pool`: `initialize()`, `mint()`, `burn()`, `collect()`, `swap()`, `flash()`, `setFeeProtocol()`, `increaseObservationCardinalityNext()`
- `NonfungiblePositionManager`: `initialize()`, `mint()`, `increaseLiquidity()`, `decreaseLiquidity()`, `collect()`, `burn()`, `positions()`
- `SwapRouter`: `exactInputSingle()`, `exactInput()`, `exactOutputSingle()`, `exactOutput()`
- `Quoter` / `QuoterV2`: `quoteExactInputSingle()`, `quoteExactInput()`, `quoteExactOutputSingle()`, `quoteExactOutput()`
- All V3 callbacks renamed from `uniswapV3*` to `listaV3*`

No existing contract interfaces are modified.

## Storage layout

N/A — all contracts are new deployments, not upgrades of existing proxies. UUPS pattern implemented on:

| Contract | Upgradeable | Init pattern | Upgrade guard |
|----------|-------------|--------------|---------------|
| ListaV3Factory | Yes (UUPS) | `_disableInitializers()` in constructor, `initialize()` sets owner + 3 default fee tiers | `msg.sender == owner` |
| NonfungiblePositionManager | Yes (UUPS) | `_disableInitializers()` in constructor, `initialize()` sets factory/WETH9/admin/initCodeHash | `msg.sender == admin` |
| ListaV3Pool | No (immutable) | Constructor via deployer pattern | N/A |
| SwapRouter | No (stateless) | Constructor sets factory + WETH9 | N/A |

## Access control

| Contract | Pattern | Authority |
|----------|---------|-----------|
| ListaV3Factory | `msg.sender == owner` | Single owner (set via `initialize()`, transferable via `setOwner()`) |
| ListaV3Pool | `onlyFactoryOwner` modifier | Delegates to factory's `owner()` for `setFeeProtocol()` |
| NonfungiblePositionManager | `msg.sender == admin` | Single admin for upgrades; ERC721 ownership + approval for position operations |
| SwapRouter | None | Stateless, permissionless |

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | All new deployments; no existing proxy storage to collide with |
| Fund safety | 🟡 Low | Pool funds held in immutable ListaV3Pool (no upgrade path); factory owner can set protocol fees up to 1/4 of LP fees via `setFeeProtocol()` |
| Access control | 🟡 Low | Single-signer owner/admin on Factory and PositionManager; recommend multisig for production deployment |
| External call safety | 🟢 None | Standard Uniswap V3 callback validation; `CallbackValidation.verifyCallback()` derives canonical pool address deterministically via `poolInitCodeHash` |

## Test plan

- [x] `forge build` compiles successfully
- [x] `forge test` passes — all PR-related tests pass
- [x] New V3 integration test: `test/dex/v3/ListaV3.t.sol` (576 lines) covers factory deployment, pool creation, initialization, LP minting, swapping, and fee collection
- [ ] Verify `poolInitCodeHash()` matches deployed `ListaV3Pool` creation bytecode on target chain
- [ ] Verify multisig assigned as Factory owner and PositionManager admin before mainnet launch
- [ ] End-to-end testnet deployment: Factory + Pool + PositionManager + SwapRouter, full LP and swap lifecycle
