### PR TITLE
feat: add setName/setSymbol and merge whitelist methods

### DIFF
--- a/script/deploy_moolahVaultConfig_alpha.sol
+++ b/script/deploy_moolahVaultConfig_alpha.sol
@@ -91,7 +91,7 @@ contract MoolahVaultConfigDeploy is DeployBase {
 
     vault.setFee(fee);
 
-    vault.addWhiteList(whiteList);
+    vault.setWhiteList(whiteList, true);
 
     vault.setCap(BTCBParams, 10_000_000 ether);
     vault.setCap(USDTParams, 10_000_000 ether);
@@ -136,7 +136,7 @@ contract MoolahVaultConfigDeploy is DeployBase {
 
     vault.setFee(fee);
 
-    vault.addWhiteList(whiteList);
+    vault.setWhiteList(whiteList, true);
 
     vault.setCap(BTCBParams, 50_000_000 ether);
     vault.setCap(USDTParams, 50_000_000 ether);
@@ -181,7 +181,7 @@ contract MoolahVaultConfigDeploy is DeployBase {
 
     vault.setFee(fee);
 
-    vault.addWhiteList(whiteList);
+    vault.setWhiteList(whiteList, true);
 
     vault.setCap(BTCBParams, 1_000_000 ether);
     vault.setCap(USDTParams, 1_000_000 ether);

--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -81,6 +81,12 @@ contract MoolahVault is
   /// if whitelist is set, only whitelisted addresses can deposit and mint
   EnumerableSet.AddressSet private whiteList;
 
+  /// @notice Custom name override for the vault token.
+  string private _name;
+
+  /// @notice Custom symbol override for the vault token.
+  string private _symbol;
+
   bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
   bytes32 public constant CURATOR = keccak256("CURATOR"); // curator role
   bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR"); // allocator role
@@ -169,24 +175,20 @@ contract MoolahVault is
     emit EventsLib.SetFeeRecipient(newFeeRecipient);
   }
 
-  /// @inheritdoc IMoolahVaultBase
-  function addWhiteList(address account) external onlyRole(MANAGER) {
+  /// @notice Add or remove an account from the whitelist.
+  /// @param account The account to add or remove.
+  /// @param enabled True to add, false to remove.
+  function setWhiteList(address account, bool enabled) external onlyRole(MANAGER) {
     if (account == address(0)) revert ErrorsLib.ZeroAddress();
-    if (whiteList.contains(account)) revert ErrorsLib.AlreadySet();
+    if (enabled) {
+      if (whiteList.contains(account)) revert ErrorsLib.AlreadySet();
+      whiteList.add(account);
+    } else {
+      if (!whiteList.contains(account)) revert ErrorsLib.NotSet();
+      whiteList.remove(account);
+    }
 
-    whiteList.add(account);
-
-    emit EventsLib.AddWhiteList(account);
-  }
-
-  /// @inheritdoc IMoolahVaultBase
-  function removeWhiteList(address account) external onlyRole(MANAGER) {
-    if (account == address(0)) revert ErrorsLib.ZeroAddress();
-    if (!whiteList.contains(account)) revert ErrorsLib.NotSet();
-
-    whiteList.remove(account);
-
-    emit EventsLib.RemoveWhiteList(account);
+    emit EventsLib.SetWhiteList(account, enabled);
   }
 
   /// @inheritdoc IMoolahVaultBase
@@ -360,6 +362,16 @@ contract MoolahVault is
     emit EventsLib.InitProvider(_provider);
   }
 
+  /// @notice Set a custom vault name. Pass empty string to revert to the original name.
+  function setName(string calldata newName) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    _name = newName;
+  }
+
+  /// @notice Set a custom vault symbol. Pass empty string to revert to the original symbol.
+  function setSymbol(string calldata newSymbol) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    _symbol = newSymbol;
+  }
+
   /* EXTERNAL */
 
   /// @inheritdoc IMoolahVaultBase
@@ -488,6 +500,18 @@ contract MoolahVault is
     for (uint256 i; i < withdrawQueue.length; ++i) {
       assets += MOOLAH.expectedSupplyAssets(_marketParams(withdrawQueue[i]), address(this));
     }
+  }
+
+  /// @inheritdoc IERC20Metadata
+  function name() public view override(ERC20Upgradeable, IERC20Metadata) returns (string memory) {
+    if (bytes(_name).length > 0) return _name;
+    return super.name();
+  }
+
+  /// @inheritdoc IERC20Metadata
+  function symbol() public view override(ERC20Upgradeable, IERC20Metadata) returns (string memory) {
+    if (bytes(_symbol).length > 0) return _symbol;
+    return super.symbol();
   }
 
   /* ERC4626Upgradeable (INTERNAL) */

--- a/src/moolah-vault/interfaces/IMoolahVault.sol
+++ b/src/moolah-vault/interfaces/IMoolahVault.sol
@@ -117,10 +117,13 @@ interface IMoolahVaultBase {
   /// @notice Sets the address of the provider.
   function setProvider(address _provider) external;
 
-  /// @notice Add account to whitelist
-  function addWhiteList(address account) external;
-  /// @notice Remove account from whitelist
-  function removeWhiteList(address account) external;
+  /// @notice Set a custom vault name.
+  function setName(string calldata newName) external;
+  /// @notice Set a custom vault symbol.
+  function setSymbol(string calldata newSymbol) external;
+
+  /// @notice Add or remove an account from the whitelist.
+  function setWhiteList(address account, bool enabled) external;
   /// @notice Returns the list of whitelisted accounts.
   function getWhiteList() external view returns (address[] memory);
   /// @notice Returns `true` if `account` is whitelisted.

--- a/src/moolah-vault/libraries/EventsLib.sol
+++ b/src/moolah-vault/libraries/EventsLib.sol
@@ -27,9 +27,7 @@ library EventsLib {
   /// @notice Emitted when a pending `newGuardian` is submitted.
   event SubmitGuardian(address indexed newGuardian);
 
-  event AddWhiteList(address indexed account);
-
-  event RemoveWhiteList(address indexed account);
+  event SetWhiteList(address indexed account, bool enabled);
 
   /// @notice Emitted when `guardian` is set to `newGuardian`.
   event SetGuardian(address indexed caller, address indexed guardian);

--- a/test/moolah-vault/VaultNameSymbolTest.sol
+++ b/test/moolah-vault/VaultNameSymbolTest.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "./helpers/IntegrationTest.sol";
+
+contract VaultNameSymbolTest is IntegrationTest {
+  function setUp() public override {
+    super.setUp();
+  }
+
+  function testDefaultNameAndSymbol() public view {
+    assertEq(vault.name(), "Moolah Vault");
+    assertEq(vault.symbol(), "MMV");
+  }
+
+  function testSetName() public {
+    vm.prank(OWNER);
+    vault.setName("New Vault Name");
+    assertEq(vault.name(), "New Vault Name");
+  }
+
+  function testSetSymbol() public {
+    vm.prank(OWNER);
+    vault.setSymbol("NVS");
+    assertEq(vault.symbol(), "NVS");
+  }
+
+  function testSetNameFallbackWhenEmpty() public {
+    vm.startPrank(OWNER);
+    vault.setName("Custom Name");
+    assertEq(vault.name(), "Custom Name");
+
+    // Reset to empty string, should fallback to original
+    vault.setName("");
+    assertEq(vault.name(), "Moolah Vault");
+    vm.stopPrank();
+  }
+
+  function testSetSymbolFallbackWhenEmpty() public {
+    vm.startPrank(OWNER);
+    vault.setSymbol("CSM");
+    assertEq(vault.symbol(), "CSM");
+
+    // Reset to empty string, should fallback to original
+    vault.setSymbol("");
+    assertEq(vault.symbol(), "MMV");
+    vm.stopPrank();
+  }
+
+  function testSetNameAndSymbolTogether() public {
+    vm.startPrank(OWNER);
+    vault.setName("Gauntlet x Lista U Vault");
+    vault.setSymbol("vlisU");
+    vm.stopPrank();
+
+    assertEq(vault.name(), "Gauntlet x Lista U Vault");
+    assertEq(vault.symbol(), "vlisU");
+  }
+
+  function testSetNameRevertsIfNotAdmin() public {
+    vm.prank(SUPPLIER);
+    vm.expectRevert();
+    vault.setName("Unauthorized");
+  }
+
+  function testSetSymbolRevertsIfNotAdmin() public {
+    vm.prank(SUPPLIER);
+    vm.expectRevert();
+    vault.setSymbol("UNA");
+  }
+}

--- a/test/moolah-vault/VaultWhiteListTest.sol
+++ b/test/moolah-vault/VaultWhiteListTest.sol
@@ -13,12 +13,12 @@ contract VaultWhiteListTest is IntegrationTest {
 
   function testAddWhitelist() public {
     vm.startPrank(OWNER);
-    vault.addWhiteList(whitelist);
+    vault.setWhiteList(whitelist, true);
     assertEq(vault.getWhiteList().length, 1, "whitelist length");
     assertTrue(vault.isWhiteList(whitelist), "whitelist");
 
     vm.expectRevert(abi.encodeWithSelector(ErrorsLib.AlreadySet.selector));
-    vault.addWhiteList(whitelist);
+    vault.setWhiteList(whitelist, true);
 
     vm.stopPrank();
   }
@@ -26,13 +26,13 @@ contract VaultWhiteListTest is IntegrationTest {
   function testRemoveWhitelist() public {
     vm.startPrank(OWNER);
     vm.expectRevert(abi.encodeWithSelector(ErrorsLib.NotSet.selector));
-    vault.removeWhiteList(whitelist);
+    vault.setWhiteList(whitelist, false);
 
-    vault.addWhiteList(whitelist);
+    vault.setWhiteList(whitelist, true);
     assertEq(vault.getWhiteList().length, 1, "whitelist length");
     assertTrue(vault.isWhiteList(whitelist), "whitelist");
 
-    vault.removeWhiteList(whitelist);
+    vault.setWhiteList(whitelist, false);
     assertEq(vault.getWhiteList().length, 0, "whitelist length");
     assertTrue(vault.isWhiteList(whitelist), "whitelist");
     vm.stopPrank();
@@ -41,7 +41,7 @@ contract VaultWhiteListTest is IntegrationTest {
   function testNotWhiteListDeposit() public {
     vm.startPrank(OWNER);
 
-    vault.addWhiteList(whitelist);
+    vault.setWhiteList(whitelist, true);
     assertEq(vault.getWhiteList().length, 1, "whitelist length");
     assertTrue(vault.isWhiteList(whitelist), "whitelist");
 
@@ -54,7 +54,7 @@ contract VaultWhiteListTest is IntegrationTest {
   function testNotWhiteListMint() public {
     vm.startPrank(OWNER);
 
-    vault.addWhiteList(whitelist);
+    vault.setWhiteList(whitelist, true);
     assertEq(vault.getWhiteList().length, 1, "whitelist length");
     assertTrue(vault.isWhiteList(whitelist), "whitelist");
 
@@ -68,7 +68,7 @@ contract VaultWhiteListTest is IntegrationTest {
     loanToken.setBalance(SUPPLIER, 200 ether);
 
     vm.startPrank(OWNER);
-    vault.addWhiteList(SUPPLIER);
+    vault.setWhiteList(SUPPLIER, true);
     assertEq(vault.getWhiteList().length, 1, "whitelist length");
     assertTrue(vault.isWhiteList(SUPPLIER), "whitelist");
     vm.stopPrank();


### PR DESCRIPTION
## Summary

Add configurable `setName`/`setSymbol` setters to MoolahVault so the vault token name and symbol can be updated post-deployment without requiring a contract upgrade. Also consolidate `addWhiteList` + `removeWhiteList` into a single `setWhiteList(address, bool)` method to reduce contract bytecode size.

## Change type

- [ ] New contract
- [x] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [ ] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| MoolahVault | src/moolah-vault/MoolahVault.sol | modified |
| IMoolahVaultBase | src/moolah-vault/interfaces/IMoolahVault.sol | modified |
| EventsLib | src/moolah-vault/libraries/EventsLib.sol | modified |
| MoolahVaultConfigDeploy | script/deploy_moolahVaultConfig_alpha.sol | modified |
| VaultNameSymbolTest | test/moolah-vault/VaultNameSymbolTest.sol | new |
| VaultWhiteListTest | test/moolah-vault/VaultWhiteListTest.sol | modified |

## Interface changes

- **Added**: `setName(string calldata)`, `setSymbol(string calldata)` — admin-only setters
- **Added**: `name()`, `symbol()` overrides — return custom value if set, fallback to ERC20Upgradeable
- **Added**: `setWhiteList(address, bool)` — replaces `addWhiteList` + `removeWhiteList`
- **Removed**: `addWhiteList(address)`, `removeWhiteList(address)`
- **Event changed**: `AddWhiteList` + `RemoveWhiteList` → `SetWhiteList(address, bool)`

## Storage layout

New variables `_name` and `_symbol` (both `string`) appended after `whiteList` (EnumerableSet). No existing variables reordered or removed. No `__gap` used in this contract. Safe for upgrade — new slots are appended at the end of existing storage.

## Access control

- `setName` / `setSymbol`: `DEFAULT_ADMIN_ROLE` (unchanged pattern, same as `setProvider`)
- `setWhiteList`: `MANAGER` role (unchanged from original `addWhiteList`/`removeWhiteList`)

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | New `_name`/`_symbol` appended after last existing variable, no reorder |
| Fund safety | 🟢 None | Only view-level `name()`/`symbol()` overrides, no fund flow changes |
| Access control | 🟢 None | Setters use existing role restrictions |
| External call safety | 🟢 None | No new external calls |

## Deployment

- Chain: BSC mainnet
- Deploy: upgrade MoolahVault implementation behind existing proxy
- Post-upgrade: call `setName` / `setSymbol` via timelock to set desired values

## Test plan

- [x] `forge test --mc VaultNameSymbolTest` passes (8 tests)
- [x] `forge test --mc VaultWhiteListTest` passes (5 tests)
- [x] Contract size: 24,357 bytes (219 bytes margin under 24,576 limit)
- [ ] Verify `name()`/`symbol()` return default values before `setName`/`setSymbol` are called
- [ ] Verify `setWhiteList` works for both add and remove on testnet