### PR TITLE
fix: make brokers mapping public in RateCalculator

### DIFF
--- a/src/broker/RateCalculator.sol
+++ b/src/broker/RateCalculator.sol
@@ -18,7 +18,7 @@ contract RateCalculator is UUPSUpgradeable, AccessControlEnumerableUpgradeable, 
   // ------- State variables -------
 
   // broker address => rate config
-  mapping(address => RateConfig) brokers;
+  mapping(address => RateConfig) public brokers;
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -1692,6 +1692,26 @@ contract LendingBrokerTest is Test {
     broker.repay{ value: 1 ether }(1 ether, borrower);
   }
 
+  function test_brokers_returnsRegisteredConfig() public {
+    (uint256 currentRate, uint256 ratePerSecond, uint256 maxRatePerSecond, uint256 lastUpdated) = rateCalc.brokers(
+      address(broker)
+    );
+    assertEq(currentRate, RATE_SCALE);
+    assertEq(ratePerSecond, RATE_SCALE + 1);
+    assertEq(maxRatePerSecond, RATE_SCALE + 2);
+    assertGt(lastUpdated, 0);
+  }
+
+  function test_brokers_unregisteredBroker_returnsZeroes() public view {
+    (uint256 currentRate, uint256 ratePerSecond, uint256 maxRatePerSecond, uint256 lastUpdated) = rateCalc.brokers(
+      address(0xdead)
+    );
+    assertEq(currentRate, 0);
+    assertEq(ratePerSecond, 0);
+    assertEq(maxRatePerSecond, 0);
+    assertEq(lastUpdated, 0);
+  }
+
   function test_borrowAndRepay_native_whenLoanTokenIsWBNB() public {
     vm.deal(borrower, 1000 ether);
     vm.deal(address(WBNB), 1000 ether);


### PR DESCRIPTION
## Summary

Make the `brokers` mapping `public` in `RateCalculator` so its `RateConfig` values can be read directly on-chain via the auto-generated getter.

## Change type

- [ ] New contract
- [x] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [ ] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| RateCalculator | `src/broker/RateCalculator.sol` | modified |
| LendingBrokerTest | `test/broker/LendingBroker.t.sol` | modified |

## Interface changes

- **Added**: auto-generated `brokers(address)` public getter (returns `uint256 currentRate, uint256 ratePerSecond, uint256 maxRatePerSecond, uint256 lastUpdated`)

## Storage layout

Storage is unaffected — changing visibility from default (internal) to `public` only adds an auto-generated getter function; it does not alter the storage slot, offset, or ordering. `brokers` remains at slot 0.

## Access control

Unchanged — no modifier or role changes.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | Visibility change only; slot 0 unchanged |
| Fund safety | 🟢 None | Read-only getter, no state mutation |
| Access control | 🟢 None | No role/modifier changes |
| External call safety | 🟢 None | No external calls added |

## Deployment

Requires upgrading the `RateCalculator` proxy to a new implementation on BSC mainnet. No new env vars needed.

## Test plan

- [x] `forge test --mc LendingBroker` passes (61/61)
- [x] `test_brokers_returnsRegisteredConfig` — verifies correct values for registered broker
- [x] `test_brokers_unregisteredBroker_returnsZeroes` — verifies zeroed values for unregistered address