### PR TITLE
feat: safe lending vault deploy scripts (ETH/USDT, ETH/USDC)

### DIFF
--- a/script/eth/deploy_createMarket.sol
+++ b/script/eth/deploy_createMarket.sol
@@ -50,52 +50,12 @@ contract CreateMarketDeploy is DeployBase {
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer: ", deployer);
 
-    MarketParams[] memory params = new MarketParams[](6);
-    params[0] = MarketParams({
-      loanToken: USD1,
-      collateralToken: ETH_wstETH,
-      oracle: ETH_wstETHSmartProvider,
-      irm: irm,
-      lltv: lltv86
-    });
-    params[1] = MarketParams({
-      loanToken: USD1,
-      collateralToken: USDT_USDC,
-      oracle: USDT_USDCSmartProvider,
-      irm: irm,
-      lltv: lltv86
-    });
-    params[2] = MarketParams({
-      loanToken: USD1,
-      collateralToken: USDT_USD1,
-      oracle: USDT_USD1SmartProvider,
-      irm: irm,
-      lltv: lltv965
-    });
-    params[3] = MarketParams({
-      loanToken: USD1,
-      collateralToken: WBTC_cbBTC,
-      oracle: WBTC_cbBTCSmartProvider,
-      irm: irm,
-      lltv: lltv965
-    });
-    params[4] = MarketParams({
-      loanToken: USD1,
-      collateralToken: USDT_USDe,
-      oracle: USDT_USDeSmartProvider,
-      irm: irm,
-      lltv: lltv945
-    });
-    params[5] = MarketParams({
-      loanToken: USD1,
-      collateralToken: USDC_USDe,
-      oracle: USDC_USDeSmartProvider,
-      irm: irm,
-      lltv: lltv945
-    });
+    MarketParams[] memory params = new MarketParams[](2);
+    params[0] = MarketParams({ loanToken: USDT, collateralToken: WETH, oracle: multiOracle, irm: irm, lltv: lltv86 });
+    params[1] = MarketParams({ loanToken: USDC, collateralToken: WETH, oracle: multiOracle, irm: irm, lltv: lltv86 });
 
     vm.startBroadcast(deployerPrivateKey);
-    for (uint256 i = 0; i < 6; i++) {
+    for (uint256 i = 0; i < params.length; i++) {
       Id id = params[i].id();
       console.log("market id:");
       console.logBytes32(Id.unwrap(id));

--- a/script/eth/deploy_irm_impl.sol
+++ b/script/eth/deploy_irm_impl.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { InterestRateModel } from "interest-rate-model/InterestRateModel.sol";
+
+contract InterestRateModelImplDeploy is DeployBase {
+  address moolah = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy InterestRateModel implementation
+    InterestRateModel impl = new InterestRateModel(moolah);
+    console.log("InterestRateModel implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/eth/deploy_moolahVault.sol
+++ b/script/eth/deploy_moolahVault.sol
@@ -8,30 +8,40 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { MoolahVault } from "moolah-vault/MoolahVault.sol";
 
 contract MoolahVaultDeploy is DeployBase {
-  // todo update moolah address
   address moolah = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70;
 
-  address asset = 0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d; // USD1
+  address USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+  address USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
-  string name = "Lista USD1 Vault";
-  string symbol = "ListaUSD1";
+  struct VaultConfig {
+    address asset;
+    string name;
+    string symbol;
+  }
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer: ", deployer);
+
+    VaultConfig[] memory configs = new VaultConfig[](2);
+    configs[0] = VaultConfig({ asset: USDT, name: "Lista USDT Savings Vault", symbol: "ListaSafeUSDT" });
+    configs[1] = VaultConfig({ asset: USDC, name: "Lista USDC Savings Vault", symbol: "ListaSafeUSDC" });
+
     vm.startBroadcast(deployerPrivateKey);
+    for (uint256 i = 0; i < configs.length; i++) {
+      VaultConfig memory c = configs[i];
+      console.log("Deploying vault:", c.name);
 
-    // Deploy MoolahVault implementation
-    MoolahVault impl = new MoolahVault(moolah, asset);
-    console.log("MoolahVault implementation: ", address(impl));
+      MoolahVault impl = new MoolahVault(moolah, c.asset);
+      console.log("  implementation:", address(impl));
 
-    // Deploy MoolahVault proxy
-    ERC1967Proxy proxy = new ERC1967Proxy(
-      address(impl),
-      abi.encodeWithSelector(impl.initialize.selector, deployer, deployer, asset, name, symbol)
-    );
-    console.log("MoolahVault proxy: ", address(proxy));
+      ERC1967Proxy proxy = new ERC1967Proxy(
+        address(impl),
+        abi.encodeWithSelector(impl.initialize.selector, deployer, deployer, c.asset, c.name, c.symbol)
+      );
+      console.log("  proxy:", address(proxy));
+    }
     vm.stopBroadcast();
   }
 }

--- a/script/eth/deploy_moolahVaultConfig.sol
+++ b/script/eth/deploy_moolahVaultConfig.sol
@@ -9,79 +9,45 @@ import { Id, MarketParams } from "moolah/interfaces/IMoolah.sol";
 
 contract MoolahVaultConfigDeploy is DeployBase {
   using MarketParamsLib for MarketParams;
-  // todo update vault
-  MoolahVault vault = MoolahVault(0x1A9BeE2F5c85F6b4a0221fB1C733246AF5306Ae3);
+
+  // todo update vault addresses after step 3 deployment
+  MoolahVault usdtVault = MoolahVault(address(0));
+  MoolahVault usdcVault = MoolahVault(address(0));
+
   uint256 fee = 0.1 ether;
   address feeRecipient = 0xd10a024602E042dcb9C19e21682c3b896c8B0d30;
   address skimRecipient = 0x1d60bBBEF79Fb9540D271Dbb01925380323A8f66;
 
-  address USD1 = 0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d;
   address WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-  address WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
-  address wstETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
-  address wBETH = 0xa2E3356610840701BDf5611a53974510Ae27E2e1;
-  address PTUSDe27NOV2025 = 0x62C6E813b9589C3631Ba0Cdb013acdB8544038B7;
-  address cbBTC = 0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf;
+  address USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+  address USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
   address multiOracle = 0xA64FE284EB8279B9b63946DD51813b0116099301;
-  address PTUSDe27NOV2025USD1Oracle = 0xb169d2459F51d02d7fC8A39498ec2801652b594c;
-
   address irm = 0x8b7d334d243b74D63C4b963893267A0F5240F990;
-  address fixedRateIRM = 0x9A7cA2CfB886132B6024789163e770979E4222e1;
-
   uint256 lltv86 = 0.86 ether;
-  uint256 lltv915 = 0.915 ether;
+
+  uint256 cap = 300_000_000e6; // 300M in 6-decimal units (USDT/USDC)
 
   address bot = 0x91fC4BA20685339781888eCA3E9E1c12d40F0e13;
 
-  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
-  bytes32 public constant MANAGER = keccak256("MANAGER");
-  bytes32 public constant CURATOR = keccak256("CURATOR"); // manager role
-  bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR"); // manager role
+  bytes32 public constant CURATOR = keccak256("CURATOR");
+  bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR");
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer: ", deployer);
 
-    MarketParams memory WETHParams = MarketParams({
-      loanToken: USD1,
+    MarketParams memory usdtMarket = MarketParams({
+      loanToken: USDT,
       collateralToken: WETH,
       oracle: multiOracle,
       irm: irm,
       lltv: lltv86
     });
-    MarketParams memory WBTCParams = MarketParams({
-      loanToken: USD1,
-      collateralToken: WBTC,
-      oracle: multiOracle,
-      irm: irm,
-      lltv: lltv86
-    });
-    MarketParams memory wstETHParams = MarketParams({
-      loanToken: USD1,
-      collateralToken: wstETH,
-      oracle: multiOracle,
-      irm: irm,
-      lltv: lltv86
-    });
-    MarketParams memory wBETHParams = MarketParams({
-      loanToken: USD1,
-      collateralToken: wBETH,
-      oracle: multiOracle,
-      irm: irm,
-      lltv: lltv86
-    });
-    MarketParams memory ptUSDe27NOV2025params = MarketParams({
-      loanToken: USD1,
-      collateralToken: PTUSDe27NOV2025,
-      oracle: PTUSDe27NOV2025USD1Oracle,
-      irm: irm,
-      lltv: lltv915
-    });
-    MarketParams memory cbBTCParams = MarketParams({
-      loanToken: USD1,
-      collateralToken: cbBTC,
+    MarketParams memory usdcMarket = MarketParams({
+      loanToken: USDC,
+      collateralToken: WETH,
       oracle: multiOracle,
       irm: irm,
       lltv: lltv86
@@ -89,6 +55,15 @@ contract MoolahVaultConfigDeploy is DeployBase {
 
     vm.startBroadcast(deployerPrivateKey);
 
+    _configVault(usdtVault, usdtMarket, deployer);
+    _configVault(usdcVault, usdcMarket, deployer);
+
+    vm.stopBroadcast();
+
+    console.log("vault config done!");
+  }
+
+  function _configVault(MoolahVault vault, MarketParams memory params, address deployer) internal {
     vault.setFeeRecipient(feeRecipient);
     vault.setSkimRecipient(skimRecipient);
 
@@ -96,35 +71,11 @@ contract MoolahVaultConfigDeploy is DeployBase {
     vault.grantRole(ALLOCATOR, deployer);
     vault.setBotRole(bot);
 
-    // config vault
-
     vault.setFee(fee);
+    vault.setCap(params, cap);
 
-    vault.setCap(WETHParams, 200_000_000 ether);
-    vault.setCap(WBTCParams, 200_000_000 ether);
-    vault.setCap(wstETHParams, 100_000_000 ether);
-    vault.setCap(wBETHParams, 100_000_000 ether);
-    vault.setCap(ptUSDe27NOV2025params, 500_000_000 ether);
-    vault.setCap(cbBTCParams, 200_000_000 ether);
-
-    Id WETHId = WETHParams.id();
-    Id WBTCId = WBTCParams.id();
-    Id wstETHId = wstETHParams.id();
-    Id wBETHId = wBETHParams.id();
-    Id ptUSDe27NOV2025Id = ptUSDe27NOV2025params.id();
-    Id cbBTCId = cbBTCParams.id();
-    Id[] memory supplyQueue = new Id[](6);
-    supplyQueue[0] = WETHId;
-    supplyQueue[1] = WBTCId;
-    supplyQueue[2] = wstETHId;
-    supplyQueue[3] = wBETHId;
-    supplyQueue[4] = ptUSDe27NOV2025Id;
-    supplyQueue[5] = cbBTCId;
-
+    Id[] memory supplyQueue = new Id[](1);
+    supplyQueue[0] = params.id();
     vault.setSupplyQueue(supplyQueue);
-
-    vm.stopBroadcast();
-
-    console.log("vault config done!");
   }
 }

--- a/script/eth/deploy_moolahVaultConfig.sol
+++ b/script/eth/deploy_moolahVaultConfig.sol
@@ -10,9 +10,8 @@ import { Id, MarketParams } from "moolah/interfaces/IMoolah.sol";
 contract MoolahVaultConfigDeploy is DeployBase {
   using MarketParamsLib for MarketParams;
 
-  // todo update vault addresses after step 3 deployment
-  MoolahVault usdtVault = MoolahVault(address(0));
-  MoolahVault usdcVault = MoolahVault(address(0));
+  MoolahVault usdtVault = MoolahVault(0x28643FFD79256719D6AcbCF25Cb44576cAeBCf12);
+  MoolahVault usdcVault = MoolahVault(0x9651Ae50a5763c6f9B883f9d50e8116281CFcab2);
 
   uint256 fee = 0.1 ether;
   address feeRecipient = 0xd10a024602E042dcb9C19e21682c3b896c8B0d30;

--- a/script/eth/deploy_moolahVault_transferRole.sol
+++ b/script/eth/deploy_moolahVault_transferRole.sol
@@ -6,7 +6,10 @@ import { DeployBase } from "../DeployBase.sol";
 import { MoolahVault } from "moolah-vault/MoolahVault.sol";
 
 contract MoolahVaultTransferRoleDeploy is DeployBase {
-  MoolahVault vault = MoolahVault(0x1A9BeE2F5c85F6b4a0221fB1C733246AF5306Ae3);
+  // todo update vault addresses after step 3 deployment
+  MoolahVault usdtVault = MoolahVault(address(0));
+  MoolahVault usdcVault = MoolahVault(address(0));
+
   address admin = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61; // timelock
   address manager = 0x375fdA2Bf66f4CE85EAB29AB6407dCd4a4C428BA; // timelock
   address allocator = 0x85CE862C5BB61938FFcc97DA4A80C8aaE43C6A27;
@@ -14,17 +17,25 @@ contract MoolahVaultTransferRoleDeploy is DeployBase {
 
   bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
   bytes32 public constant MANAGER = keccak256("MANAGER");
-  bytes32 public constant PAUSER = keccak256("PAUSER");
-  bytes32 public constant CURATOR = keccak256("CURATOR"); // manager role
-  bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR"); // manager role
+  bytes32 public constant CURATOR = keccak256("CURATOR");
+  bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR");
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer: ", deployer);
+
     vm.startBroadcast(deployerPrivateKey);
 
-    // setup roles
+    _transferRoles(usdtVault, deployer);
+    _transferRoles(usdcVault, deployer);
+
+    vm.stopBroadcast();
+
+    console.log("setup role done!");
+  }
+
+  function _transferRoles(MoolahVault vault, address deployer) internal {
     vault.grantRole(DEFAULT_ADMIN_ROLE, admin);
     vault.grantRole(MANAGER, manager);
     vault.grantRole(ALLOCATOR, allocator);
@@ -34,9 +45,5 @@ contract MoolahVaultTransferRoleDeploy is DeployBase {
     vault.revokeRole(ALLOCATOR, deployer);
     vault.revokeRole(MANAGER, deployer);
     vault.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-
-    vm.stopBroadcast();
-
-    console.log("setup role done!");
   }
 }

--- a/script/eth/deploy_moolahVault_transferRole.sol
+++ b/script/eth/deploy_moolahVault_transferRole.sol
@@ -6,9 +6,8 @@ import { DeployBase } from "../DeployBase.sol";
 import { MoolahVault } from "moolah-vault/MoolahVault.sol";
 
 contract MoolahVaultTransferRoleDeploy is DeployBase {
-  // todo update vault addresses after step 3 deployment
-  MoolahVault usdtVault = MoolahVault(address(0));
-  MoolahVault usdcVault = MoolahVault(address(0));
+  MoolahVault usdtVault = MoolahVault(0x28643FFD79256719D6AcbCF25Cb44576cAeBCf12);
+  MoolahVault usdcVault = MoolahVault(0x9651Ae50a5763c6f9B883f9d50e8116281CFcab2);
 
   address admin = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61; // timelock
   address manager = 0x375fdA2Bf66f4CE85EAB29AB6407dCd4a4C428BA; // timelock


### PR DESCRIPTION
## Summary

Adds the Foundry deploy scripts for the Safe Lending Vault launch on Ethereum Mainnet: two markets (ETH/USDT, ETH/USDC) plus two savings vaults (Lista USDT/USDC Savings Vault). Scripts are refactored around a `VaultConfig[]` loop and per-vault helpers so the same file drives both vaults.

## Change type

- [ ] New contract
- [ ] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [x] Configuration change
- [x] Migration / deploy script
- [ ] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|---|---|---|
| `CreateMarketDeploy` | `script/eth/deploy_createMarket.sol` | modified |
| `MoolahVaultDeploy` | `script/eth/deploy_moolahVault.sol` | modified |
| `MoolahVaultConfigDeploy` | `script/eth/deploy_moolahVaultConfig.sol` | modified |
| `MoolahVaultTransferRoleDeploy` | `script/eth/deploy_moolahVault_transferRole.sol` | modified |

## Interface changes

None — all changes are in `script/` only; no `src/` contracts touched.

## Storage layout

N/A — scripts only, no upgradeable contracts modified.

## Access control

Unchanged. Scripts invoke existing methods under existing role holders:
- `Moolah.createMarket` — requires OPERATOR (held by deployer `0xd7e38...`)
- Vault `grantRole` / `revokeRole` — deployer becomes initial admin/manager via `initialize`, then revokes after transfer to timelocks

## Risk assessment

| Area | Risk | Note |
|---|---|---|
| Storage collision | 🟢 None | No src contract changes |
| Fund safety | 🟢 None | Market `createMarket` + vault init only. Vault asset custody stays with vault proxy. |
| Access control | 🟢 None | Roles match existing production pattern (timelock admin + timelock manager + allocator/curator) |
| External call safety | 🟢 None | All calls are to already-deployed Moolah / MoolahVault; no new external integrations |

## Deployment

**Chain:** Ethereum Mainnet

| Step | Script | `--verify` |
|---|---|---|
| 2 | `script/eth/deploy_createMarket.sol` | — |
| 3 | `script/eth/deploy_moolahVault.sol` | ✓ |
| 4 | `script/eth/deploy_moolahVaultConfig.sol` | — |
| 6 | `script/eth/deploy_moolahVault_transferRole.sol` | — |

Steps 4 and 6 require operator to paste the step-3 vault proxy addresses into \`usdtVault\` / \`usdcVault\` before running. No new env vars.

Pre-computed market IDs:
- ETH/USDT: \`0xaf3092012cf0d07d7774986721f2c327a9fb26dba63a1e1deb063041955642f7\`
- ETH/USDC: \`0xc28b824aee4556ac975dca5c37be43c019f5a43246f6f8578bb41f31b37795c4\`

## Test plan

- [x] \`forge build\` passes (no new warnings introduced by this commit)
- [x] \`forge test --mc MoolahVault\` passes (15 tests)
- [x] End-to-end anvil-fork simulation of the runbook (steps 2–6 + 4 Safe multi-sig ops) all green; final state verified via \`cast call\` for markets, providers, liquidator whitelists, vault roles
- [ ] Confirm timelock admin / manager addresses still match production before mainnet run
- [ ] Fill vault proxy addresses into steps 4 & 6 scripts after step 3 mainnet run