### PR TITLE
chore: bump MoolahVault impl in factory and add factory impl deploy script

### DIFF
--- a/script/deploy_moolahVaultFactory_impl.sol
+++ b/script/deploy_moolahVaultFactory_impl.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "./DeployBase.sol";
+
+import { MoolahVaultFactory } from "moolah-vault/MoolahVaultFactory.sol";
+
+contract MoolahVaultFactoryImplDeploy is DeployBase {
+  address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy MoolahVaultFactory implementation
+    MoolahVaultFactory impl = new MoolahVaultFactory(moolah);
+    console.log("MoolahVaultFactory implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/moolah-vault/MoolahVaultFactory.sol
+++ b/src/moolah-vault/MoolahVaultFactory.sol
@@ -21,7 +21,7 @@ contract MoolahVaultFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeab
   /// @inheritdoc IMoolahVaultFactory
   address public immutable MOOLAH;
 
-  address public constant MOOLAH_VAULT_IMPL_18 = 0x8F9475F2F5fEcccce21A14971DdE47498C2e51C3;
+  address public constant MOOLAH_VAULT_IMPL_18 = 0x2F1e420ea6D11d52707C1C45a52B548f62ecD735;
 
   address public vaultAdmin;
 


### PR DESCRIPTION
## Summary

Bump `MoolahVaultFactory.MOOLAH_VAULT_IMPL_18` from `0x8F94…51C3` to the newly deployed vault implementation `0x2F1e420ea6D11d52707C1C45a52B548f62ecD735`, which adds `setName` / `setSymbol` setters and merges `addWhiteList` / `removeWhiteList` into a single `setWhiteList(address, bool)`. Also adds `script/deploy_moolahVaultFactory_impl.sol` so the existing factory proxy can be upgraded to pick up the new constant.

## Change type

- [x] Upgrade (existing proxy) — factory proxy needs to be upgraded to the new impl
- [x] Configuration change — constant address bump
- [x] Migration / deploy script

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| MoolahVaultFactory | src/moolah-vault/MoolahVaultFactory.sol | modified |
| MoolahVaultFactoryImplDeploy | script/deploy_moolahVaultFactory_impl.sol | new (deploy script) |

## Interface changes

None. Only an inlined ` public constant ` value changed; the ABI selector for `MOOLAH_VAULT_IMPL_18()` is identical, only the returned address changes.

## Storage layout

Unchanged. The modified field is `constant` (inlined into bytecode, not in storage). `forge inspect MoolahVaultFactory storage` confirms the layout is still:

| Slot | Name | Type |
|------|------|------|
| 0 | `vaultAdmin` | `address` |
| 1 | `isMoolahVault` | `mapping(address => bool)` |

`AccessControl` / `UUPS` use ERC-7201 namespaced storage, unaffected.

## Access control

Unchanged. Factory upgrade is still gated by `DEFAULT_ADMIN_ROLE` via `_authorizeUpgrade`.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | None | Only a `constant` changed; no slot occupied. |
| Fund safety | None | No fund-handling logic touched. Already-deployed vaults are independent ERC1967 proxies and are not affected; only **future** `createMoolahVault` calls will use the new vault impl. |
| Access control | None | No role/modifier changes. |
| External call safety | None | No external-call paths added or modified. |

## Deployment

- Chain: BSC mainnet
- Deploy command:

\`\`\`bash
forge script script/deploy_moolahVaultFactory_impl.sol:MoolahVaultFactoryImplDeploy \\
  --rpc-url \$BSC_RPC --private-key \$PRIVATE_KEY --broadcast --verify -vvv --via-ir
\`\`\`

- Post-deploy: factory proxy admin (`DEFAULT_ADMIN_ROLE`) must call `upgradeToAndCall` / `upgradeTo` on the factory proxy to point at the newly deployed impl.
- No new env vars required.

## Test plan

- [x] \`forge test --mc MoolahVaultFactoryTest\` passes
- [ ] On a BSC fork, deploy the new factory impl, upgrade the factory proxy, then call \`createMoolahVault(...)\` and verify the resulting vault proxy's implementation slot equals \`0x2F1e420ea6D11d52707C1C45a52B548f62ecD735\`
- [ ] Verify \`MOOLAH_VAULT_IMPL_18()\` on the upgraded factory returns the new address
- [ ] Spot-check: existing vault proxies still respond unchanged (their impl pointers are independent of the factory)

Generated with Claude Code