### PR TITLE
fix: address Lista Fixed Term audit findings on LendingBroker

### DIFF
--- a/src/broker/LendingBroker.sol
+++ b/src/broker/LendingBroker.sol
@@ -13,6 +13,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IBroker, FixedLoanPosition, DynamicLoanPosition, FixedTermAndRate, LiquidationContext } from "./interfaces/IBroker.sol";
 import { IRateCalculator } from "./interfaces/IRateCalculator.sol";
 import { BrokerMath, RATE_SCALE } from "./libraries/BrokerMath.sol";
+import { LendingBrokerOperatorLib } from "./libraries/LendingBrokerOperatorLib.sol";
 import { IBrokerInterestRelayer } from "./interfaces/IBrokerInterestRelayer.sol";
 
 import { MarketParamsLib } from "../moolah/libraries/MarketParamsLib.sol";
@@ -43,9 +44,7 @@ contract LendingBroker is
   using EnumerableSet for EnumerableSet.AddressSet;
 
   // ------- Custom Errors -------
-  error ZeroAddressProvided();
   error ZeroAmount();
-  error AmountZero();
   error NativeNotSupported();
   error ZeroAddress();
   error NothingToRepay();
@@ -56,19 +55,20 @@ contract LendingBroker is
   error UnsupportedToken();
   error ZeroPositions();
   error InvalidBorrowedAmount();
+  error InsufficientAmount();
   error NativeTransferFailed();
   error InvalidMarket();
   error InvalidTermId();
   error InvalidDuration();
   error InvalidAPR();
   error SameValueProvided();
-  error TransferFailed();
   error TermNotFound();
   error PositionNotFound();
   error NotAuthorized();
   error NotMoolah();
   error MarketNotSet();
   error BorrowIsPaused();
+  error InvalidRepaidShares();
 
   // ------- Roles -------
   bytes32 public constant MANAGER = keccak256("MANAGER");
@@ -142,7 +142,7 @@ contract LendingBroker is
    * @param wbnb The address of the wrapped native token (e.g. WBNB). Pass address(0) to disable native support.
    */
   constructor(address moolah, address wbnb) {
-    if (moolah == address(0)) revert ZeroAddressProvided();
+    if (moolah == address(0)) revert ZeroAddress();
     MOOLAH = IMoolah(moolah);
     WBNB = wbnb;
     _disableInitializers();
@@ -178,7 +178,7 @@ contract LendingBroker is
       _maxFixedLoanPositions == 0 ||
       _relayer == address(0) ||
       _oracle == address(0)
-    ) revert ZeroAddressProvided();
+    ) revert ZeroAddress();
 
     __AccessControlEnumerable_init();
     __Pausable_init();
@@ -218,8 +218,8 @@ contract LendingBroker is
     _borrowFromMoolah(user, amount);
     // transfer loan token to user
     _transferLoanToken(payable(user), amount);
-    // validate positions
-    _validatePositions(user);
+    // validate the modified dynamic position
+    _validateDynamicPosition(user);
     // emit event
     emit DynamicLoanPositionBorrowed(user, amount, position.principal);
   }
@@ -235,7 +235,7 @@ contract LendingBroker is
     uint256 amount,
     uint256 termId
   ) external override marketIdSet whenNotPaused whenBorrowNotPaused nonReentrant {
-    if (amount == 0) revert AmountZero();
+    if (amount == 0) revert ZeroAmount();
     address user = msg.sender;
     _borrowFixed(user, amount, termId);
     // transfer loan token to user (unwraps to native BNB if supported)
@@ -248,82 +248,13 @@ contract LendingBroker is
    * @param onBehalf The address of the user whose position to repay
    */
   function repay(uint256 amount, address onBehalf) external payable override marketIdSet whenNotPaused nonReentrant {
-    bool isNative = msg.value > 0;
-    address user = msg.sender;
-    if (isNative) {
-      if (LOAN_TOKEN != WBNB) revert NativeNotSupported();
-      amount = msg.value;
-      IWBNB(WBNB).deposit{ value: amount }();
-    } else {
-      IERC20(LOAN_TOKEN).safeTransferFrom(user, address(this), amount);
-    }
-    if (amount == 0) revert ZeroAmount();
-    if (onBehalf == address(0)) revert ZeroAddress();
-    // get user's dynamic position
-    DynamicLoanPosition storage position = dynamicLoanPositions[onBehalf];
-    // get updated rate
-    uint256 rate = IRateCalculator(rateCalculator).accrueRate(address(this));
-    // get net accrued interest
-    uint256 accruedInterest = BrokerMath.denormalizeBorrowAmount(position.normalizedDebt, rate).zeroFloorSub(
-      position.principal
-    );
-    // calculate the amount we need to repay for interest and principal
-    uint256 repayInterestAmt = amount < accruedInterest ? amount : accruedInterest;
-    uint256 amountLeft = amount - repayInterestAmt;
-    uint256 repayPrincipalAmt = amountLeft > position.principal ? position.principal : amountLeft;
-
-    if (repayInterestAmt + repayPrincipalAmt == 0) revert NothingToRepay();
-
-    // record the actual repaid amount for event
-    uint256 totalRepaid = 0;
-
-    // (1) Repay interest first
-    // update position
-    position.normalizedDebt = position.normalizedDebt.zeroFloorSub(
-      BrokerMath.normalizeBorrowAmount(repayInterestAmt, rate, false)
-    );
-    // supply interest to moolah vault
-    _supplyToMoolahVault(repayInterestAmt);
-    totalRepaid += repayInterestAmt;
-
-    // has left to repay principal
-    if (repayPrincipalAmt > 0) {
-      uint256 principalRepaid;
-      principalRepaid = _repayToMoolah(onBehalf, repayPrincipalAmt);
-      if (principalRepaid > 0) {
-        // update position
-        position.principal = position.principal.zeroFloorSub(principalRepaid);
-        position.normalizedDebt = position.normalizedDebt.zeroFloorSub(
-          BrokerMath.normalizeBorrowAmount(principalRepaid, rate, false)
-        );
-        totalRepaid += principalRepaid;
-      }
-      // remove position if fully repaid
-      if (position.principal == 0) {
-        delete dynamicLoanPositions[onBehalf];
-      }
-    }
-
-    // refund excess native BNB to sender
-    uint256 excess = amount - totalRepaid;
-    if (excess > 0) {
-      if (isNative) {
-        _unwrapAndSend(payable(user), excess);
-      } else {
-        IERC20(LOAN_TOKEN).safeTransfer(user, excess);
-      }
-    }
-
-    // validate positions
-    _validatePositions(onBehalf);
-
-    emit DynamicLoanPositionRepaid(onBehalf, totalRepaid, position.principal);
+    LendingBrokerOperatorLib.repayDynamic(dynamicLoanPositions, _operatorCtx(), amount, onBehalf);
   }
 
   /**
    * @dev Repay a Fixed loan position
    * @notice repay interest first then principal, repay amount must larger than interest
-   * @param amount The amount to repay
+   * @param amount The amount to repay (overridden by msg.value when sending native BNB)
    * @param posId The ID of the fixed position to repay
    * @param onBehalf The address of the user whose position to repay
    */
@@ -332,98 +263,32 @@ contract LendingBroker is
     uint256 posId,
     address onBehalf
   ) external payable override marketIdSet whenNotPaused nonReentrant {
-    bool isNative = msg.value > 0;
-    address user = msg.sender;
-    if (isNative) {
-      if (LOAN_TOKEN != WBNB) revert NativeNotSupported();
-      amount = msg.value;
-      IWBNB(WBNB).deposit{ value: amount }();
-    } else {
-      IERC20(LOAN_TOKEN).safeTransferFrom(user, address(this), amount);
-    }
-    if (amount == 0) revert ZeroAmount();
-    if (onBehalf == address(0)) revert ZeroAddress();
+    LendingBrokerOperatorLib.repayFixed(fixedLoanPositions, _operatorCtx(), amount, posId, onBehalf);
+  }
 
-    // fetch position (will revert if not found)
-    FixedLoanPosition memory position = _getFixedPositionByPosId(onBehalf, posId);
-    // remaining principal before repayment
-    uint256 remainingPrincipal = position.principal - position.principalRepaid;
-    // get outstanding accrued interest
-    uint256 accruedInterest = _getAccruedInterestForFixedPosition(position) - position.interestRepaid;
+  /**
+   * @dev Emergency: fully repay every position (dynamic + all fixed) of `onBehalf` in one call.
+   *      Charges full early-repay penalty on fixed positions, identical to normal `repay`.
+   *      Skips per-position validation since every position is cleared.
+   * @notice For native BNB, send `msg.value >= totalDebt`; excess is refunded.
+   *         For ERC20, the contract pulls exactly `totalDebt` from `msg.sender`.
+   * @param onBehalf The address of the user whose positions to repay
+   */
+  function repayAll(address onBehalf) external payable override marketIdSet whenNotPaused nonReentrant {
+    LendingBrokerOperatorLib.repayAll(dynamicLoanPositions, fixedLoanPositions, _operatorCtx(), onBehalf);
+  }
 
-    // initialize repay amounts
-    uint256 repayInterestAmt = amount < accruedInterest ? amount : accruedInterest;
-    uint256 repayPrincipalAmt = amount - repayInterestAmt;
-
-    // repay interest first, it might be zero if user just repaid before
-    if (repayInterestAmt > 0) {
-      // update repaid interest amount
-      position.interestRepaid += repayInterestAmt;
-      // supply interest into vault as revenue
-      _supplyToMoolahVault(repayInterestAmt);
-    }
-
-    uint256 penalty = 0;
-    uint256 principalRepaid = 0;
-    // then repay principal if there is any amount left
-    if (repayPrincipalAmt > 0) {
-      // check penalty if user is repaying before expiration
-      penalty = _getPenaltyForFixedPosition(position, UtilsLib.min(repayPrincipalAmt, remainingPrincipal));
-      // supply penalty into vault as revenue
-      if (penalty > 0) {
-        repayPrincipalAmt -= penalty;
-        _supplyToMoolahVault(penalty);
-      }
-
-      // the rest will be used to repay partially
-      uint256 repayablePrincipal = UtilsLib.min(repayPrincipalAmt, remainingPrincipal);
-      if (repayablePrincipal > 0) {
-        principalRepaid = _repayToMoolah(onBehalf, repayablePrincipal);
-        position.principalRepaid += principalRepaid;
-        // reset repaid interest to zero (all accrued interest has been cleared)
-        position.interestRepaid = 0;
-        // reset last repay time to now
-        position.lastRepaidTime = block.timestamp;
-      }
-    }
-
-    // post repayment
-    if (position.principalRepaid >= position.principal) {
-      // removes it from user's fixed positions
-      _removeFixedPositionByPosId(onBehalf, posId);
-    } else {
-      // update position
-      _updateFixedPosition(onBehalf, position);
-    }
-
-    // refund excess native BNB to sender
-    uint256 used = repayInterestAmt + penalty + principalRepaid;
-    uint256 excess = amount - used;
-    if (excess > 0) {
-      if (isNative) {
-        _unwrapAndSend(payable(user), excess);
-      } else {
-        IERC20(LOAN_TOKEN).safeTransfer(user, excess);
-      }
-    }
-
-    // validate positions
-    _validatePositions(onBehalf);
-
-    // emit event
-    emit RepaidFixedLoanPosition(
-      onBehalf,
-      posId,
-      position.principal,
-      position.start,
-      position.end,
-      position.apr,
-      position.principalRepaid,
-      principalRepaid,
-      repayInterestAmt,
-      penalty,
-      position.interestRepaid
-    );
+  /// @dev Build the operator-library context. Internal helper, inlined.
+  function _operatorCtx() private view returns (LendingBrokerOperatorLib.OperatorContext memory) {
+    return
+      LendingBrokerOperatorLib.OperatorContext({
+        moolah: MOOLAH,
+        loanToken: LOAN_TOKEN,
+        wbnb: WBNB,
+        rateCalculator: rateCalculator,
+        relayer: RELAYER,
+        marketId: MARKET_ID
+      });
   }
 
   /**
@@ -438,16 +303,14 @@ contract LendingBroker is
     if (amount == 0) revert ZeroAmount();
     address user = msg.sender;
     DynamicLoanPosition storage position = dynamicLoanPositions[user];
-    if (fixedLoanPositions[user].length >= maxFixedLoanPositions) revert ExceedMaxFixedPositions();
     // accrue current rate so normalized debt reflects the latest interest
     uint256 rate = IRateCalculator(rateCalculator).accrueRate(address(this));
-    uint256 actualDebt = BrokerMath.denormalizeBorrowAmount(position.normalizedDebt, rate);
-    uint256 totalInterest = actualDebt.zeroFloorSub(position.principal);
-
-    // prioritize clearing interest first, then principal
-    uint256 interestToRepay = UtilsLib.min(amount, totalInterest);
-    uint256 principalToMove = UtilsLib.min(amount - interestToRepay, position.principal);
-    amount = interestToRepay + principalToMove;
+    (uint256 interestToRepay, uint256 principalToMove, uint256 finalAmount) = BrokerMath.previewConvertDynamicToFixed(
+      position,
+      amount,
+      rate
+    );
+    if (finalAmount == 0) revert ZeroAmount();
 
     if (interestToRepay > 0) {
       // borrow from Moolah to increase user's actual debt at moolah
@@ -457,7 +320,7 @@ contract LendingBroker is
     }
 
     position.normalizedDebt = position.normalizedDebt.zeroFloorSub(
-      BrokerMath.normalizeBorrowAmount(amount, rate, false)
+      BrokerMath.normalizeBorrowAmount(finalAmount, rate, false)
     );
     position.principal -= principalToMove;
 
@@ -465,29 +328,8 @@ contract LendingBroker is
       delete dynamicLoanPositions[user];
     }
 
-    FixedTermAndRate memory term = _getTermById(termId);
-    uint256 start = block.timestamp;
-    uint256 end = start + term.duration;
-    // pos uuid increment
-    fixedPosUuid++;
-    // create new fixed position
-    fixedLoanPositions[user].push(
-      FixedLoanPosition({
-        posId: fixedPosUuid,
-        principal: amount,
-        apr: term.apr,
-        start: start,
-        end: end,
-        lastRepaidTime: start,
-        interestRepaid: 0,
-        principalRepaid: 0
-      })
-    );
-
-    // validate positions
-    _validatePositions(user);
-
-    emit FixedLoanPositionCreated(user, fixedPosUuid, amount, start, end, term.apr, termId);
+    _validateDynamicPosition(user);
+    _createFixedPosition(user, finalAmount, termId);
   }
 
   /**
@@ -505,7 +347,7 @@ contract LendingBroker is
     address user,
     address receiver
   ) external marketIdSet whenNotPaused whenBorrowNotPaused nonReentrant {
-    if (amount == 0) revert AmountZero();
+    if (amount == 0) revert ZeroAmount();
     if (receiver == address(0)) revert ZeroAddress();
     if (!MOOLAH.isAuthorized(user, msg.sender)) revert NotAuthorized();
     _borrowFixed(user, amount, termId);
@@ -522,10 +364,10 @@ contract LendingBroker is
   ///////////////////////////////////////
   /**
    * @dev Liquidate a borrower's debt by accruing interest and repaying the dynamic
-   *      position first, then settling fixed-rate positions sorted by APR and
-   *      remaining principal. The last fixed position absorbs any rounding delta.
+   *      position first, then settling fixed-rate positions in order of earliest end
+   *      time first. The last fixed position absorbs any rounding delta.
    *      the parameters are the same as normal liquidator calls moolah.liquidate()
-   * @notice Only `Liquidator.sol` and `PublicLiquidator.sol` contracts are allowed to call this function
+   * @notice Only contracts whitelisted via `toggleLiquidationWhitelist` (e.g. `BrokerLiquidator.sol`) can call this function
    * @param marketParams The market of the position.
    * @param borrower The owner of the position.
    * @param seizedAssets The amount of collateral to seize.
@@ -543,6 +385,7 @@ contract LendingBroker is
     if (!_checkLiquidationWhiteList(msg.sender)) revert NotLiquidationWhitelist();
     if (Id.unwrap(id) != Id.unwrap(MARKET_ID)) revert InvalidMarketId();
     if (!UtilsLib.exactlyOneZero(seizedAssets, repaidShares)) revert InvalidMarketId();
+    if (repaidShares > 0 && repaidShares % SharesMathLib.VIRTUAL_SHARES != 0) revert InvalidRepaidShares();
     if (borrower == address(0)) revert InvalidUser();
 
     // [1] init liquidation context for onMoolahLiquidate() Callback
@@ -616,26 +459,23 @@ contract LendingBroker is
         delete dynamicLoanPositions[borrower];
         delete fixedLoanPositions[borrower];
       } else {
-        // [9] deduct interest and principal from positions
-        // deduct from dynamic position and returns the leftover assets to deduct
-        (uint256 interestLeftover, uint256 principalLeftover) = _deductDynamicPositionDebt(
-          borrower,
-          dynamicPosition,
-          interestToBroker,
-          repaidAssets,
-          rate
-        );
-        // deduct from fixed positions
-        if ((principalLeftover > 0 || interestLeftover > 0) && fixedPositions.length > 0) {
-          // sort fixed positions from earliest end time to latest, filter out fully repaid positions
-          // positions with earlier end time will be deducted first
-          FixedLoanPosition[] memory sorted = BrokerMath.sortAndFilterFixedPositions(fixedPositions);
-          if (sorted.length > 0) {
-            _deductFixedPositionsDebt(borrower, sorted, interestLeftover, principalLeftover);
+        // [9] run the full cascade in one library call: deduct from the dynamic
+        // position, sort the fixed positions, then deduct from them in order
+        (
+          DynamicLoanPosition memory updatedDyn,
+          FixedLoanPosition[] memory touched,
+          bool[] memory shouldRemove
+        ) = BrokerMath.executeLiquidationCascade(dynamicPosition, fixedPositions, interestToBroker, repaidAssets, rate);
+        // apply dynamic update
+        dynamicLoanPositions[borrower] = updatedDyn;
+        // apply fixed-position updates
+        for (uint256 i = 0; i < touched.length; i++) {
+          if (shouldRemove[i]) {
+            _removeFixedPositionByPosId(borrower, touched[i].posId);
+          } else {
+            _updateFixedPosition(borrower, touched[i]);
           }
         }
-        // [10] validate every position after deduction meets minLoan
-        _validatePositions(borrower);
       }
     }
   }
@@ -649,68 +489,6 @@ contract LendingBroker is
       return true;
     }
     return liquidationWhitelist.contains(liquidator);
-  }
-
-  /**
-   * @dev deducts debt from the dynamic position and returns leftover assets
-   * @param position The dynamic loan position to modify
-   * @param interestToDeduct The amount of interest repaid during liquidation, leads to deduct from principal and interest
-   * @param principalToDeduct The amount of assets repaid during liquidation, leads to deduct from principal and interest
-   * @param rate The current interest rate
-   */
-  function _deductDynamicPositionDebt(
-    address user,
-    DynamicLoanPosition memory position,
-    uint256 interestToDeduct,
-    uint256 principalToDeduct,
-    uint256 rate
-  ) internal returns (uint256, uint256) {
-    // call BrokerMath to process deduction
-    // will return leftover interest/principal to deduct and the updated position
-    (interestToDeduct, principalToDeduct, position) = BrokerMath.deductDynamicPositionDebt(
-      position,
-      interestToDeduct,
-      principalToDeduct,
-      rate
-    );
-    // update position
-    dynamicLoanPositions[user] = position;
-    return (interestToDeduct, principalToDeduct);
-  }
-
-  /**
-   * @dev allocates repayments to fixed positions by APR and remaining principal
-   * @param user The address of the user
-   * @param sortedFixedPositions The sorted fixed loan positions
-   * @param interestToDeduct The amount of interest repaid during liquidation, leads to deduct from principal and interest
-   * @param principalToDeduct The amount of assets repaid during liquidation, leads to deduct from principal and interest
-   */
-  function _deductFixedPositionsDebt(
-    address user,
-    FixedLoanPosition[] memory sortedFixedPositions,
-    uint256 interestToDeduct,
-    uint256 principalToDeduct
-  ) internal {
-    uint256 len = sortedFixedPositions.length;
-    for (uint256 i = 0; i < len; i++) {
-      if (principalToDeduct == 0 && interestToDeduct == 0) break;
-      FixedLoanPosition memory p = sortedFixedPositions[i];
-      // call BrokerMath to process deduction one by one
-      // will return leftover interest/principal to deduct and the updated position
-      (interestToDeduct, principalToDeduct, p) = BrokerMath.deductFixedPositionDebt(
-        interestToDeduct,
-        principalToDeduct,
-        p
-      );
-      // post repayment
-      if (p.principalRepaid >= p.principal) {
-        // removes it from user's fixed positions
-        _removeFixedPositionByPosId(user, p.posId);
-      } else {
-        // update position
-        _updateFixedPosition(user, p);
-      }
-    }
   }
 
   ///////////////////////////////////////
@@ -853,25 +631,36 @@ contract LendingBroker is
    * @param termId The fixed-term product ID
    */
   function _borrowFixed(address user, uint256 amount, uint256 termId) private {
+    _createFixedPosition(user, amount, termId);
+    _borrowFromMoolah(user, amount);
+  }
+
+  /**
+   * @dev Create and push a new fixed-term position for `user`. Used by both `_borrowFixed`
+   *      (fresh fixed borrow) and `convertDynamicToFixed` (moves principal/interest from
+   *      a dynamic position). Validates the new position before returning.
+   * @param user The user the position belongs to
+   * @param amount The position's principal
+   * @param termId The fixed-term product ID
+   */
+  function _createFixedPosition(address user, uint256 amount, uint256 termId) private {
     if (fixedLoanPositions[user].length >= maxFixedLoanPositions) revert ExceedMaxFixedPositions();
     FixedTermAndRate memory term = _getTermById(termId);
     uint256 start = block.timestamp;
-    uint256 end = block.timestamp + term.duration;
+    uint256 end = start + term.duration;
     fixedPosUuid++;
-    fixedLoanPositions[user].push(
-      FixedLoanPosition({
-        posId: fixedPosUuid,
-        principal: amount,
-        apr: term.apr,
-        start: start,
-        end: end,
-        lastRepaidTime: start,
-        interestRepaid: 0,
-        principalRepaid: 0
-      })
-    );
-    _borrowFromMoolah(user, amount);
-    _validatePositions(user);
+    FixedLoanPosition memory newPos = FixedLoanPosition({
+      posId: fixedPosUuid,
+      principal: amount,
+      apr: term.apr,
+      start: start,
+      end: end,
+      lastRepaidTime: start,
+      interestRepaid: 0,
+      principalRepaid: 0
+    });
+    fixedLoanPositions[user].push(newPos);
+    _validateFixedPosition(newPos);
     emit FixedLoanPositionCreated(user, fixedPosUuid, amount, start, end, term.apr, termId);
   }
 
@@ -980,26 +769,6 @@ contract LendingBroker is
   }
 
   /**
-   * @dev Get the interest for a fixed loan position
-   * @param position The fixed loan position to get the interest for
-   */
-  function _getAccruedInterestForFixedPosition(FixedLoanPosition memory position) internal view returns (uint256) {
-    return BrokerMath.getAccruedInterestForFixedPosition(position);
-  }
-
-  /**
-   * @dev Get the penalty for a fixed loan position
-   * @param position The fixed loan position to get the penalty for
-   * @param repayAmt The actual repay amount (repay amount excluded accrued interest)
-   */
-  function _getPenaltyForFixedPosition(
-    FixedLoanPosition memory position,
-    uint256 repayAmt
-  ) internal view returns (uint256 penalty) {
-    return BrokerMath.getPenaltyForFixedPosition(position, repayAmt);
-  }
-
-  /**
    * @dev Transfer loan token to recipient. Unwraps to native BNB when supported.
    */
   function _transferLoanToken(address payable recipient, uint256 amount) internal {
@@ -1020,29 +789,26 @@ contract LendingBroker is
   }
 
   /**
-   * @dev Repay an amount on behalf of a user to Moolah
-   * @param onBehalf The address of the user to repay on behalf of
-   * @param amount The amount to repay
+   * @dev Validate that the user's dynamic position is either zero or meets the minimum loan
+   * @param user The address of the user
    */
-  function _repayToMoolah(address onBehalf, uint256 amount) internal returns (uint256 assetsRepaid) {
-    IERC20(LOAN_TOKEN).safeIncreaseAllowance(address(MOOLAH), amount);
-    Market memory market = MOOLAH.market(MARKET_ID);
-    // convert amount to shares
-    uint256 amountShares = amount.toSharesDown(market.totalBorrowAssets, market.totalBorrowShares);
-    // using `shares` to ensure full repayment
-    (assetsRepaid /* sharesRepaid */, ) = MOOLAH.repay(_getMarketParams(MARKET_ID), 0, amountShares, onBehalf, "");
-    IERC20(LOAN_TOKEN).forceApprove(address(MOOLAH), 0);
+  function _validateDynamicPosition(address user) internal view {
+    uint256 principal = dynamicLoanPositions[user].principal;
+    if (principal == 0) return;
+    uint256 minLoan = MOOLAH.minLoan(_getMarketParams(MARKET_ID));
+    require(principal >= minLoan, "broker/dynamic-below-min-loan");
   }
 
   /**
-   * @dev Validate that the user's positions meet the minimum loan requirement
-   * @param user The address of the user
+   * @dev Validate that a fixed position is either fully repaid or has remaining principal
+   *      at or above the minimum loan
+   * @param position The fixed loan position to validate
    */
-  function _validatePositions(address user) internal view {
-    require(
-      BrokerMath.checkPositionsMeetsMinLoan(user, address(MOOLAH), rateCalculator),
-      "broker/positions-below-min-loan"
-    );
+  function _validateFixedPosition(FixedLoanPosition memory position) internal view {
+    uint256 remaining = position.principal - position.principalRepaid;
+    if (remaining == 0) return;
+    uint256 minLoan = MOOLAH.minLoan(_getMarketParams(MARKET_ID));
+    require(remaining >= minLoan, "broker/fixed-below-min-loan");
   }
 
   ///////////////////////////////////////
@@ -1183,7 +949,7 @@ contract LendingBroker is
 
     if (token == address(0)) {
       (bool success, ) = msg.sender.call{ value: amount }("");
-      if (!success) revert TransferFailed();
+      if (!success) revert NativeTransferFailed();
     } else {
       IERC20(token).safeTransfer(msg.sender, amount);
     }

--- a/src/broker/interfaces/IBroker.sol
+++ b/src/broker/interfaces/IBroker.sol
@@ -104,6 +104,7 @@ interface IBroker is IBrokerBase {
   event MaxFixedLoanPositionsUpdated(uint256 oldMax, uint256 newMax);
   event FixedTermAndRateUpdated(uint256 termId, uint256 duration, uint256 apr);
   event Liquidated(address indexed user, uint256 principalCleared, uint256 interestCleared);
+  event AllPositionsRepaid(address indexed user, uint256 totalRepaid);
   event MarketIdSet(Id marketId);
   event BorrowPaused(bool paused);
   event RelayerSet(address indexed relayer);
@@ -156,6 +157,11 @@ interface IBroker is IBrokerBase {
   /// @param posIdx The index of the fixed position to repay
   /// @param onBehalf The address of the user whose position to repay
   function repay(uint256 amount, uint256 posIdx, address onBehalf) external payable;
+
+  /// @dev emergency: fully repay every position (dynamic + all fixed) of a user in one call.
+  ///      Charges full early-repay penalty on fixed positions.
+  /// @param onBehalf The address of the user whose positions to repay
+  function repayAll(address onBehalf) external payable;
 
   /// @dev refinance expired fixed positions to dynamic
   /// @param user The address of the user to refinance

--- a/src/broker/libraries/BrokerMath.sol
+++ b/src/broker/libraries/BrokerMath.sol
@@ -95,43 +95,6 @@ library BrokerMath {
   }
 
   /**
-   * @dev Ensure every position's principal either cleared or larger than Moolah.minLoan
-   * @param user The address of the user
-   * @param moolah The address of the Moolah contract
-   * @param rateCalculator The address of the rate calculator
-   */
-  function checkPositionsMeetsMinLoan(
-    address user,
-    address moolah,
-    address rateCalculator
-  ) public view returns (bool isValid) {
-    // get current rate
-    uint256 currentRate = IRateCalculator(rateCalculator).getRate(address(this));
-    // get positions
-    IBroker broker = IBroker(address(this));
-    FixedLoanPosition[] memory fixedPositions = broker.userFixedPositions(user);
-    DynamicLoanPosition memory dynamicPosition = broker.userDynamicPosition(user);
-    // assume valid first
-    isValid = true;
-    IMoolah _moolah = IMoolah(moolah);
-    uint256 minLoan = _moolah.minLoan(_moolah.idToMarketParams(IBroker(address(this)).MARKET_ID()));
-    // ensure each position either zero or larger than minLoan
-    // check dynamic position
-    uint256 dynamicDebt = dynamicPosition.principal;
-    if (dynamicDebt > 0 && dynamicDebt < minLoan) {
-      isValid = false;
-    }
-    // check fixed positions
-    for (uint256 i = 0; i < fixedPositions.length; i++) {
-      FixedLoanPosition memory _fixedPos = fixedPositions[i];
-      uint256 fixedPosDebt = _fixedPos.principal - _fixedPos.principalRepaid;
-      if (fixedPosDebt > 0 && fixedPosDebt < minLoan) {
-        isValid = false;
-      }
-    }
-  }
-
-  /**
    * @dev Get the total debt for a user
    * @param fixedPositions The fixed loan positions of the user
    * @param dynamicPosition The dynamic loan position of the user
@@ -588,5 +551,123 @@ library BrokerMath {
       mstore(filtered, count)
     }
     return filtered;
+  }
+
+  /**
+   * @dev Compute the interest/principal split for convertDynamicToFixed.
+   * @param position The dynamic loan position (memory copy)
+   * @param amount The amount the user wants to convert
+   * @param rate The current dynamic-loan rate
+   * @return interestToRepay The interest portion (paid to vault)
+   * @return principalToMove The principal portion (moved to the new fixed position)
+   * @return finalAmount The total of interestToRepay + principalToMove
+   */
+  function previewConvertDynamicToFixed(
+    DynamicLoanPosition memory position,
+    uint256 amount,
+    uint256 rate
+  ) public pure returns (uint256 interestToRepay, uint256 principalToMove, uint256 finalAmount) {
+    uint256 actualDebt = denormalizeBorrowAmount(position.normalizedDebt, rate);
+    uint256 totalInterest = UtilsLib.zeroFloorSub(actualDebt, position.principal);
+    interestToRepay = UtilsLib.min(amount, totalInterest);
+    principalToMove = UtilsLib.min(amount - interestToRepay, position.principal);
+    finalAmount = interestToRepay + principalToMove;
+  }
+
+  /**
+   * @dev Compute every amount needed by repayAll: dynamic interest, fixed interest + early-repay
+   *      penalty, Moolah-side principal, and the grand total. Lets the broker delegate the
+   *      iteration + math to the library instead of duplicating it inline.
+   * @param onBehalf The user whose positions are being repaid
+   * @param dynPos The user's dynamic loan position (memory copy)
+   * @param fixedPositions The user's full fixed-position array
+   * @param rate The current dynamic-loan rate
+   * @return dynamicInterest The dynamic position's accrued interest
+   * @return fixedInterestAndPenalty The sum of accrued interest and early-repay penalty across fixed positions
+   * @return debtAtMoolah The principal owed to Moolah for `onBehalf`
+   * @return totalDebt debtAtMoolah + dynamicInterest + fixedInterestAndPenalty
+   */
+  function previewRepayAllAmounts(
+    address onBehalf,
+    DynamicLoanPosition memory dynPos,
+    FixedLoanPosition[] memory fixedPositions,
+    uint256 rate
+  )
+    public
+    view
+    returns (uint256 dynamicInterest, uint256 fixedInterestAndPenalty, uint256 debtAtMoolah, uint256 totalDebt)
+  {
+    dynamicInterest = UtilsLib.zeroFloorSub(denormalizeBorrowAmount(dynPos.normalizedDebt, rate), dynPos.principal);
+    for (uint256 i = 0; i < fixedPositions.length; i++) {
+      FixedLoanPosition memory p = fixedPositions[i];
+      uint256 remainingPrincipal = p.principal - p.principalRepaid;
+      uint256 accruedInterest = getAccruedInterestForFixedPosition(p) - p.interestRepaid;
+      uint256 penalty = getPenaltyForFixedPosition(p, remainingPrincipal);
+      fixedInterestAndPenalty += accruedInterest + penalty;
+    }
+    debtAtMoolah = getDebtAtMoolah(onBehalf);
+    totalDebt = debtAtMoolah + dynamicInterest + fixedInterestAndPenalty;
+  }
+
+  /**
+   * @dev Run the full liquidation cascade in one call: deduct from the dynamic position,
+   *      then sort and filter fixed positions, then deduct from them in order. Returns the
+   *      updated dynamic position plus parallel arrays describing what the caller should do
+   *      with each touched fixed position. The caller is responsible for writing the dynamic
+   *      update back to storage and applying the fixed-position actions.
+   * @param dynPos The dynamic loan position to deduct from (memory copy)
+   * @param fixedPositions The user's full fixed-position array (unfiltered)
+   * @param interestToDeduct The interest budget for the cascade
+   * @param principalToDeduct The principal budget for the cascade
+   * @param rate The current dynamic-loan rate
+   * @return updatedDyn The dynamic position after the cascade
+   * @return touched Fixed positions that were modified (trimmed to actual count)
+   * @return shouldRemove Parallel flags indicating which entries should be removed
+   */
+  function executeLiquidationCascade(
+    DynamicLoanPosition memory dynPos,
+    FixedLoanPosition[] memory fixedPositions,
+    uint256 interestToDeduct,
+    uint256 principalToDeduct,
+    uint256 rate
+  )
+    public
+    returns (DynamicLoanPosition memory updatedDyn, FixedLoanPosition[] memory touched, bool[] memory shouldRemove)
+  {
+    // deduct from dynamic position first
+    (interestToDeduct, principalToDeduct, dynPos) = deductDynamicPositionDebt(
+      dynPos,
+      interestToDeduct,
+      principalToDeduct,
+      rate
+    );
+    updatedDyn = dynPos;
+
+    // nothing left or no fixed positions → return empty action arrays
+    if ((interestToDeduct == 0 && principalToDeduct == 0) || fixedPositions.length == 0) {
+      return (updatedDyn, new FixedLoanPosition[](0), new bool[](0));
+    }
+
+    // sort by end-time ascending and drop fully-repaid entries
+    FixedLoanPosition[] memory sorted = sortAndFilterFixedPositions(fixedPositions);
+    uint256 len = sorted.length;
+    touched = new FixedLoanPosition[](len);
+    shouldRemove = new bool[](len);
+    uint256 count;
+
+    for (uint256 i = 0; i < len; i++) {
+      if (principalToDeduct == 0 && interestToDeduct == 0) break;
+      FixedLoanPosition memory p = sorted[i];
+      (interestToDeduct, principalToDeduct, p) = deductFixedPositionDebt(interestToDeduct, principalToDeduct, p);
+      touched[count] = p;
+      shouldRemove[count] = p.principalRepaid >= p.principal;
+      count++;
+    }
+
+    // trim arrays to actual touched count
+    assembly {
+      mstore(touched, count)
+      mstore(shouldRemove, count)
+    }
   }
 }

--- a/src/broker/libraries/LendingBrokerOperatorLib.sol
+++ b/src/broker/libraries/LendingBrokerOperatorLib.sol
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { IBroker, FixedLoanPosition, DynamicLoanPosition } from "../interfaces/IBroker.sol";
+import { IRateCalculator } from "../interfaces/IRateCalculator.sol";
+import { IBrokerInterestRelayer } from "../interfaces/IBrokerInterestRelayer.sol";
+import { BrokerMath } from "./BrokerMath.sol";
+
+import { Id, IMoolah, MarketParams, Market, Position } from "../../moolah/interfaces/IMoolah.sol";
+import { SharesMathLib } from "../../moolah/libraries/SharesMathLib.sol";
+import { UtilsLib } from "../../moolah/libraries/UtilsLib.sol";
+import { IWBNB } from "../../provider/interfaces/IWBNB.sol";
+
+/// @title LendingBroker operator library
+/// @notice Houses the bytecode for `repay`, `repay(fixed)`, and `repayAll` so the broker
+///         itself stays under the EIP-170 size limit. Invoked via DELEGATECALL, so all
+///         state mutations apply to LendingBroker's storage and events surface from
+///         LendingBroker's address.
+library LendingBrokerOperatorLib {
+  using SafeERC20 for IERC20;
+  using SharesMathLib for uint256;
+  using UtilsLib for uint256;
+
+  // ------- Errors (must match LendingBroker's set) -------
+  error ZeroAmount();
+  error ZeroAddress();
+  error NothingToRepay();
+  error NativeNotSupported();
+  error InsufficientAmount();
+  error NativeTransferFailed();
+  error PositionNotFound();
+
+  // ------- Events (must match IBroker signatures so indexers keep working) -------
+  event DynamicLoanPositionRepaid(address indexed user, uint256 repaid, uint256 principalLeft);
+  event RepaidFixedLoanPosition(
+    address indexed user,
+    uint256 posId,
+    uint256 principal,
+    uint256 start,
+    uint256 end,
+    uint256 apr,
+    uint256 principalRepaid,
+    uint256 repayPrincipal,
+    uint256 repayInterest,
+    uint256 repayPenalty,
+    uint256 totalInterestRepaid
+  );
+  event FixedLoanPositionRemoved(address indexed user, uint256 posId);
+  event AllPositionsRepaid(address indexed user, uint256 totalRepaid);
+
+  /// @dev Immutable/state values that the operator paths need. Filled by the broker on each call.
+  struct OperatorContext {
+    IMoolah moolah;
+    address loanToken;
+    address wbnb;
+    address rateCalculator;
+    address relayer;
+    Id marketId;
+  }
+
+  // =============================================
+  //              External entry points
+  // =============================================
+
+  /// @dev Implements LendingBroker.repay(amount, onBehalf). Storage refs come from the broker.
+  function repayDynamic(
+    mapping(address => DynamicLoanPosition) storage dynamicLoanPositions,
+    OperatorContext memory ctx,
+    uint256 amount,
+    address onBehalf
+  ) external {
+    address user = msg.sender;
+    bool isNative;
+    (amount, isNative) = _pullPayment(ctx, amount, user);
+    if (amount == 0) revert ZeroAmount();
+    if (onBehalf == address(0)) revert ZeroAddress();
+
+    DynamicLoanPosition storage position = dynamicLoanPositions[onBehalf];
+    uint256 rate = IRateCalculator(ctx.rateCalculator).accrueRate(address(this));
+    uint256 accruedInterest = BrokerMath.denormalizeBorrowAmount(position.normalizedDebt, rate).zeroFloorSub(
+      position.principal
+    );
+    uint256 repayInterestAmt = amount < accruedInterest ? amount : accruedInterest;
+    uint256 amountLeft = amount - repayInterestAmt;
+    uint256 repayPrincipalAmt = amountLeft > position.principal ? position.principal : amountLeft;
+    if (repayInterestAmt + repayPrincipalAmt == 0) revert NothingToRepay();
+
+    uint256 totalRepaid;
+
+    // (1) Repay interest first
+    position.normalizedDebt = position.normalizedDebt.zeroFloorSub(
+      BrokerMath.normalizeBorrowAmount(repayInterestAmt, rate, false)
+    );
+    _supplyToMoolahVault(ctx, repayInterestAmt);
+    totalRepaid += repayInterestAmt;
+
+    // (2) Repay principal if any
+    if (repayPrincipalAmt > 0) {
+      uint256 principalRepaid = _repayToMoolah(ctx, onBehalf, repayPrincipalAmt);
+      if (principalRepaid > 0) {
+        position.principal = position.principal.zeroFloorSub(principalRepaid);
+        position.normalizedDebt = position.normalizedDebt.zeroFloorSub(
+          BrokerMath.normalizeBorrowAmount(principalRepaid, rate, false)
+        );
+        totalRepaid += principalRepaid;
+      }
+      if (position.principal == 0) {
+        delete dynamicLoanPositions[onBehalf];
+      }
+    }
+
+    _refundExcess(ctx, amount - totalRepaid, user, isNative);
+    _validateDynamicPosition(dynamicLoanPositions, ctx, onBehalf);
+    emit DynamicLoanPositionRepaid(onBehalf, totalRepaid, position.principal);
+  }
+
+  /// @dev Implements LendingBroker.repay(amount, posId, onBehalf).
+  function repayFixed(
+    mapping(address => FixedLoanPosition[]) storage fixedLoanPositions,
+    OperatorContext memory ctx,
+    uint256 amount,
+    uint256 posId,
+    address onBehalf
+  ) external {
+    address user = msg.sender;
+    bool isNative;
+    (amount, isNative) = _pullPayment(ctx, amount, user);
+    if (amount == 0) revert ZeroAmount();
+    if (onBehalf == address(0)) revert ZeroAddress();
+
+    FixedLoanPosition memory position = _getFixedPositionByPosId(fixedLoanPositions, onBehalf, posId);
+    uint256 remainingPrincipal = position.principal - position.principalRepaid;
+    uint256 accruedInterest = BrokerMath.getAccruedInterestForFixedPosition(position) - position.interestRepaid;
+
+    uint256 repayInterestAmt = amount < accruedInterest ? amount : accruedInterest;
+    uint256 repayPrincipalAmt = amount - repayInterestAmt;
+
+    if (repayInterestAmt > 0) {
+      position.interestRepaid += repayInterestAmt;
+      _supplyToMoolahVault(ctx, repayInterestAmt);
+    }
+
+    uint256 penalty;
+    uint256 principalRepaid;
+    if (repayPrincipalAmt > 0) {
+      penalty = BrokerMath.getPenaltyForFixedPosition(position, UtilsLib.min(repayPrincipalAmt, remainingPrincipal));
+      if (penalty > 0) {
+        repayPrincipalAmt -= penalty;
+        _supplyToMoolahVault(ctx, penalty);
+      }
+      uint256 repayablePrincipal = UtilsLib.min(repayPrincipalAmt, remainingPrincipal);
+      if (repayablePrincipal > 0) {
+        principalRepaid = _repayToMoolah(ctx, onBehalf, repayablePrincipal);
+        position.principalRepaid += principalRepaid;
+        position.interestRepaid = 0;
+        position.lastRepaidTime = block.timestamp;
+      }
+    }
+
+    if (position.principalRepaid >= position.principal) {
+      _removeFixedPositionByPosId(fixedLoanPositions, onBehalf, posId);
+    } else {
+      _updateFixedPosition(fixedLoanPositions, onBehalf, position);
+    }
+
+    _refundExcess(ctx, amount - (repayInterestAmt + penalty + principalRepaid), user, isNative);
+    _validateFixedPosition(ctx, position);
+
+    emit RepaidFixedLoanPosition(
+      onBehalf,
+      posId,
+      position.principal,
+      position.start,
+      position.end,
+      position.apr,
+      position.principalRepaid,
+      principalRepaid,
+      repayInterestAmt,
+      penalty,
+      position.interestRepaid
+    );
+  }
+
+  /// @dev Implements LendingBroker.repayAll(onBehalf). Charges full early-repay penalty
+  ///      on every outstanding fixed position. Caller must send `msg.value >= totalDebt`
+  ///      when paying in native BNB; excess is refunded.
+  function repayAll(
+    mapping(address => DynamicLoanPosition) storage dynamicLoanPositions,
+    mapping(address => FixedLoanPosition[]) storage fixedLoanPositions,
+    OperatorContext memory ctx,
+    address onBehalf
+  ) external {
+    if (onBehalf == address(0)) revert ZeroAddress();
+    address user = msg.sender;
+    bool isNative = msg.value > 0;
+
+    uint256 rate = IRateCalculator(ctx.rateCalculator).accrueRate(address(this));
+    DynamicLoanPosition memory dynPos = dynamicLoanPositions[onBehalf];
+    FixedLoanPosition[] memory fixedPositions = fixedLoanPositions[onBehalf];
+
+    (uint256 dynamicInterest, uint256 fixedInterestAndPenalty, uint256 debtAtMoolah, uint256 totalDebt) = BrokerMath
+      .previewRepayAllAmounts(onBehalf, dynPos, fixedPositions, rate);
+    if (totalDebt == 0) revert NothingToRepay();
+
+    // pull funds
+    if (isNative) {
+      if (ctx.loanToken != ctx.wbnb) revert NativeNotSupported();
+      if (msg.value < totalDebt) revert InsufficientAmount();
+      IWBNB(ctx.wbnb).deposit{ value: msg.value }();
+    } else {
+      IERC20(ctx.loanToken).safeTransferFrom(user, address(this), totalDebt);
+    }
+
+    // supply broker revenue (interest + penalty) to the vault
+    _supplyToMoolahVault(ctx, dynamicInterest + fixedInterestAndPenalty);
+
+    // repay every Moolah borrow share at once via shares
+    Position memory pos = ctx.moolah.position(ctx.marketId, onBehalf);
+    if (pos.borrowShares > 0) {
+      _repayMoolahByShares(ctx, onBehalf, pos.borrowShares, debtAtMoolah);
+    }
+
+    // clear dynamic position
+    if (dynPos.principal > 0 || dynamicInterest > 0) {
+      delete dynamicLoanPositions[onBehalf];
+      emit DynamicLoanPositionRepaid(onBehalf, dynPos.principal + dynamicInterest, 0);
+    }
+
+    // emit per-position removal events then wipe the array
+    for (uint256 i = 0; i < fixedPositions.length; i++) {
+      FixedLoanPosition memory p = fixedPositions[i];
+      if (p.principal > p.principalRepaid) {
+        emit FixedLoanPositionRemoved(onBehalf, p.posId);
+      }
+    }
+    delete fixedLoanPositions[onBehalf];
+
+    if (isNative) _refundExcess(ctx, msg.value - totalDebt, user, true);
+    emit AllPositionsRepaid(onBehalf, totalDebt);
+  }
+
+  // =============================================
+  //              Internal helpers
+  // =============================================
+
+  function _pullPayment(
+    OperatorContext memory ctx,
+    uint256 amount,
+    address user
+  ) internal returns (uint256 finalAmount, bool isNative) {
+    isNative = msg.value > 0;
+    if (isNative) {
+      if (ctx.loanToken != ctx.wbnb) revert NativeNotSupported();
+      finalAmount = msg.value;
+      IWBNB(ctx.wbnb).deposit{ value: finalAmount }();
+    } else {
+      IERC20(ctx.loanToken).safeTransferFrom(user, address(this), amount);
+      finalAmount = amount;
+    }
+  }
+
+  function _refundExcess(OperatorContext memory ctx, uint256 excess, address user, bool isNative) internal {
+    if (excess == 0) return;
+    if (isNative) {
+      _unwrapAndSend(ctx, payable(user), excess);
+    } else {
+      IERC20(ctx.loanToken).safeTransfer(user, excess);
+    }
+  }
+
+  function _unwrapAndSend(OperatorContext memory ctx, address payable recipient, uint256 amount) internal {
+    IWBNB(ctx.wbnb).withdraw(amount);
+    (bool ok, ) = recipient.call{ value: amount }("");
+    if (!ok) revert NativeTransferFailed();
+  }
+
+  function _supplyToMoolahVault(OperatorContext memory ctx, uint256 interest) internal {
+    if (interest > 0) {
+      IERC20(ctx.loanToken).safeIncreaseAllowance(ctx.relayer, interest);
+      IBrokerInterestRelayer(ctx.relayer).supplyToVault(interest);
+    }
+  }
+
+  function _repayToMoolah(OperatorContext memory ctx, address onBehalf, uint256 amount) internal returns (uint256) {
+    Market memory market = ctx.moolah.market(ctx.marketId);
+    uint256 amountShares = amount.toSharesDown(market.totalBorrowAssets, market.totalBorrowShares);
+    return _repayMoolahByShares(ctx, onBehalf, amountShares, amount);
+  }
+
+  function _repayMoolahByShares(
+    OperatorContext memory ctx,
+    address onBehalf,
+    uint256 shares,
+    uint256 allowance
+  ) internal returns (uint256 assetsRepaid) {
+    IERC20(ctx.loanToken).safeIncreaseAllowance(address(ctx.moolah), allowance);
+    (assetsRepaid, ) = ctx.moolah.repay(ctx.moolah.idToMarketParams(ctx.marketId), 0, shares, onBehalf, "");
+    IERC20(ctx.loanToken).forceApprove(address(ctx.moolah), 0);
+  }
+
+  function _getFixedPositionByPosId(
+    mapping(address => FixedLoanPosition[]) storage fixedLoanPositions,
+    address user,
+    uint256 posId
+  ) internal view returns (FixedLoanPosition memory) {
+    FixedLoanPosition[] memory positions = fixedLoanPositions[user];
+    for (uint256 i = 0; i < positions.length; i++) {
+      if (positions[i].posId == posId) return positions[i];
+    }
+    revert PositionNotFound();
+  }
+
+  function _removeFixedPositionByPosId(
+    mapping(address => FixedLoanPosition[]) storage fixedLoanPositions,
+    address user,
+    uint256 posId
+  ) internal {
+    FixedLoanPosition[] storage positions = fixedLoanPositions[user];
+    for (uint256 i = 0; i < positions.length; i++) {
+      if (positions[i].posId == posId) {
+        positions[i] = positions[positions.length - 1];
+        positions.pop();
+        emit FixedLoanPositionRemoved(user, posId);
+        return;
+      }
+    }
+    revert PositionNotFound();
+  }
+
+  function _updateFixedPosition(
+    mapping(address => FixedLoanPosition[]) storage fixedLoanPositions,
+    address user,
+    FixedLoanPosition memory position
+  ) internal {
+    FixedLoanPosition[] storage positions = fixedLoanPositions[user];
+    for (uint256 i = 0; i < positions.length; i++) {
+      if (positions[i].posId == position.posId) {
+        positions[i] = position;
+        return;
+      }
+    }
+    revert PositionNotFound();
+  }
+
+  function _validateDynamicPosition(
+    mapping(address => DynamicLoanPosition) storage dynamicLoanPositions,
+    OperatorContext memory ctx,
+    address user
+  ) internal view {
+    uint256 principal = dynamicLoanPositions[user].principal;
+    if (principal == 0) return;
+    uint256 minLoan = ctx.moolah.minLoan(ctx.moolah.idToMarketParams(ctx.marketId));
+    require(principal >= minLoan, "broker/dynamic-below-min-loan");
+  }
+
+  function _validateFixedPosition(OperatorContext memory ctx, FixedLoanPosition memory position) internal view {
+    uint256 remaining = position.principal - position.principalRepaid;
+    if (remaining == 0) return;
+    uint256 minLoan = ctx.moolah.minLoan(ctx.moolah.idToMarketParams(ctx.marketId));
+    require(remaining >= minLoan, "broker/fixed-below-min-loan");
+  }
+}

--- a/test/broker/BrokerMathDeductFixed.t.sol
+++ b/test/broker/BrokerMathDeductFixed.t.sol
@@ -7,8 +7,11 @@ import { FixedLoanPosition } from "../../src/broker/interfaces/IBroker.sol";
 import { UtilsLib } from "../../src/moolah/libraries/UtilsLib.sol";
 
 /// @title Tests for BrokerMath.deductFixedPositionDebt
-/// @notice Validates that partial liquidation preserves exact outstanding interest,
-///         accounting for the reduced principal effect on the interest formula.
+/// @notice The current implementation deliberately resets `interestRepaid` and
+///         `lastRepaidTime` on any positive principal payment — the audit-acknowledged
+///         simplified semantic. Outstanding interest is only preserved when the call
+///         is interest-only. These tests validate that reset behaviour and the
+///         interest-only preservation path.
 contract BrokerMathDeductFixedTest is Test {
   uint256 constant DURATION = 365 days;
   // 10% APR -> RATE_SCALE * 1.10
@@ -41,12 +44,13 @@ contract BrokerMathDeductFixedTest is Test {
   }
 
   // ====================================================================
-  //  Core fix: partial liquidation preserves EXACT outstanding interest
+  //  Any principal payment resets interest tracking
   // ====================================================================
 
-  /// @notice principal=100e18, interest~10e18, liquidation pays half interest + half principal.
-  ///         Outstanding interest must be exactly (accruedInterest - paidInterest).
-  function test_partialLiquidation_preservesExactOutstanding() public {
+  /// @notice principal=100e18, interest~10e18, partial-interest + partial-principal.
+  ///         After the call: interestRepaid = 0, lastRepaidTime = now, outstanding = 0
+  ///         (no time has elapsed since the reset).
+  function test_partialLiquidation_resetsInterestOnPrincipalPayment() public {
     FixedLoanPosition memory pos = _makePosition(100 ether);
     skip(DURATION);
 
@@ -64,14 +68,14 @@ contract BrokerMathDeductFixedTest is Test {
     assertEq(principalLeft, 0, "principal budget consumed");
     assertEq(updated.principalRepaid, principalBudget, "principalRepaid correct");
 
-    // Core invariant: outstanding = accruedInterest - paidInterest (exact)
-    uint256 expectedOutstanding = accruedInterest - interestBudget;
-    uint256 actualOutstanding = _outstanding(updated);
-    assertEq(actualOutstanding, expectedOutstanding, "outstanding interest must be exact");
+    // Simplified reset semantic: any positive principal payment wipes interest tracking
+    assertEq(updated.interestRepaid, 0, "interestRepaid reset to 0");
+    assertEq(updated.lastRepaidTime, block.timestamp, "lastRepaidTime reset to now");
+    assertEq(_outstanding(updated), 0, "no outstanding immediately after reset");
   }
 
   // ====================================================================
-  //  Full interest payment resets correctly
+  //  Full interest + principal: reset (same as core path)
   // ====================================================================
 
   function test_fullInterestPayment_resetsTracking() public {
@@ -91,7 +95,7 @@ contract BrokerMathDeductFixedTest is Test {
   }
 
   // ====================================================================
-  //  Interest only, no principal deduction
+  //  Interest-only path: preserves exact outstanding (no principal => no reset)
   // ====================================================================
 
   function test_interestOnlyPartial_preservesOutstanding() public {
@@ -114,7 +118,7 @@ contract BrokerMathDeductFixedTest is Test {
   }
 
   // ====================================================================
-  //  Full principal with partial interest -> fallback (position filtered out)
+  //  Full principal with partial interest -> reset + filtered out
   // ====================================================================
 
   function test_fullPrincipalPartialInterest_fallback() public {
@@ -155,36 +159,41 @@ contract BrokerMathDeductFixedTest is Test {
   }
 
   // ====================================================================
-  //  Sequential partial liquidations preserve cumulative outstanding
+  //  Sequential partial liquidations: each principal payment resets,
+  //  new interest accrues between calls based on elapsed time + reduced principal.
   // ====================================================================
 
-  function test_sequentialPartialLiquidations_preserveOutstanding() public {
+  function test_sequentialPartialLiquidations_resetEachTime() public {
     FixedLoanPosition memory pos = _makePosition(100 ether);
-    skip(DURATION);
+    // Move part-way through the term so interest can still accrue between calls.
+    skip(DURATION / 3);
 
     uint256 originalAccrued = _outstanding(pos);
+    assertGt(originalAccrued, 0, "precondition: interest accrued");
 
-    // First partial: 1/4 interest + 20 principal
+    // First partial: 1/4 interest + 20 principal -> reset triggered
     uint256 firstInterest = originalAccrued / 4;
     (, , FixedLoanPosition memory after1) = BrokerMath.deductFixedPositionDebt(firstInterest, 20 ether, pos);
 
-    uint256 expectedAfter1 = originalAccrued - firstInterest;
-    assertEq(_outstanding(after1), expectedAfter1, "first: outstanding exact");
+    // Reset semantic: interestRepaid wiped, lastRepaidTime = now, outstanding = 0 in this block
+    assertEq(after1.interestRepaid, 0, "first: interest tracking reset");
+    assertEq(after1.lastRepaidTime, block.timestamp, "first: lastRepaidTime = now");
     assertEq(after1.principalRepaid, 20 ether, "first: principal tracked");
+    assertEq(_outstanding(after1), 0, "first: no outstanding immediately after reset");
 
-    // Second partial: another chunk of interest + 30 principal
+    // Let time elapse — still within the term — so new interest accrues on the reduced principal
+    skip(DURATION / 3);
     uint256 outstandingAfter1 = _outstanding(after1);
-    uint256 secondInterest = outstandingAfter1 / 3;
+    assertGt(outstandingAfter1, 0, "new interest accrued after reset");
 
+    // Second partial: another chunk of interest + 30 principal -> reset again
+    uint256 secondInterest = outstandingAfter1 / 3;
     (, , FixedLoanPosition memory after2) = BrokerMath.deductFixedPositionDebt(secondInterest, 30 ether, after1);
 
-    uint256 expectedAfter2 = outstandingAfter1 - secondInterest;
-    // allow 1 wei tolerance due to Ceil rounding in interest formula
-    assertApproxEqAbs(_outstanding(after2), expectedAfter2, 1, "second: outstanding exact");
+    assertEq(after2.interestRepaid, 0, "second: interest tracking reset");
+    assertEq(after2.lastRepaidTime, block.timestamp, "second: lastRepaidTime = now");
     assertEq(after2.principalRepaid, 50 ether, "second: cumulative principal");
-
-    // Outstanding still positive
-    assertGt(_outstanding(after2), 0, "interest still outstanding");
+    assertEq(_outstanding(after2), 0, "second: no outstanding immediately after reset");
   }
 
   // ====================================================================
@@ -227,10 +236,11 @@ contract BrokerMathDeductFixedTest is Test {
   }
 
   // ====================================================================
-  //  1 wei short of full interest -> no reset, exact outstanding
+  //  1-wei-short interest + principal: principal still triggers reset
+  //  (the 1 wei of unpaid interest is forgiven — the simplified semantic).
   // ====================================================================
 
-  function test_oneWeiShort_preservesExactOutstanding() public {
+  function test_oneWeiShort_stillResetsOnPrincipalPayment() public {
     FixedLoanPosition memory pos = _makePosition(100 ether);
     skip(DURATION);
 
@@ -241,15 +251,18 @@ contract BrokerMathDeductFixedTest is Test {
 
     (, , FixedLoanPosition memory updated) = BrokerMath.deductFixedPositionDebt(interestBudget, 50 ether, pos);
 
-    // 1 wei unpaid -> must preserve exactly
-    assertEq(_outstanding(updated), 1, "exactly 1 wei outstanding preserved");
+    // Simplified semantic: the principal payment resets tracking regardless of the 1-wei gap.
+    assertEq(updated.interestRepaid, 0, "interest tracking reset");
+    assertEq(updated.lastRepaidTime, block.timestamp, "lastRepaidTime reset");
+    assertEq(_outstanding(updated), 0, "outstanding = 0 right after the reset");
   }
 
   // ====================================================================
-  //  Zero interest budget with principal deduction -> maximize preserved
+  //  Zero interest budget + positive principal -> principal triggers reset
+  //  (the entire accrued interest is forgiven — the simplified semantic).
   // ====================================================================
 
-  function test_zeroInterestBudget_principalOnly_maximizesOutstanding() public {
+  function test_zeroInterestBudget_principalOnly_resetsInterest() public {
     FixedLoanPosition memory pos = _makePosition(100 ether);
     skip(DURATION);
 
@@ -263,25 +276,20 @@ contract BrokerMathDeductFixedTest is Test {
     assertEq(principalLeft, 0, "principal consumed");
     assertEq(updated.principalRepaid, 50 ether, "principal repaid");
 
-    // newTotalAccrued = (100-50)*10%*1year = 5e18, unpaidInterest = 10e18
-    // newTotalAccrued < unpaidInterest -> fallback: outstanding = newTotalAccrued
-    // This is the maximum the formula can represent (better than reset which gives 0)
-    uint256 newTotalAccrued = BrokerMath.getAccruedInterestForFixedPosition(updated);
-    assertEq(_outstanding(updated), newTotalAccrued, "fallback preserves maximum possible");
-    assertGt(_outstanding(updated), 0, "outstanding > 0 (not reset to zero)");
-    // Verify: lastRepaidTime was NOT reset (preserves historical accrual)
-    assertEq(updated.lastRepaidTime, startTs, "lastRepaidTime not reset in fallback");
+    // Simplified semantic: the principal payment resets all interest tracking,
+    // even though the budget did not include any interest.
+    assertEq(updated.interestRepaid, 0, "interest tracking reset");
+    assertEq(updated.lastRepaidTime, block.timestamp, "lastRepaidTime reset");
+    assertEq(_outstanding(updated), 0, "outstanding = 0 right after the reset");
   }
 
   // ====================================================================
-  //  Small principal + large interest -> fallback maximizes preserved
+  //  Tiny interest budget + small principal: same reset behaviour.
   // ====================================================================
 
-  function test_smallPrincipal_largeInterest_maximizesOutstanding() public {
+  function test_smallPrincipal_largeInterest_resetsOnPrincipalPayment() public {
     FixedLoanPosition memory pos = _makePosition(100 ether);
     skip(DURATION);
-
-    uint256 accruedInterest = _outstanding(pos);
 
     // Tiny interest budget + small principal
     uint256 interestBudget = 1;
@@ -289,20 +297,19 @@ contract BrokerMathDeductFixedTest is Test {
 
     (, , FixedLoanPosition memory updated) = BrokerMath.deductFixedPositionDebt(interestBudget, principalBudget, pos);
 
-    // newTotalAccrued = (100-5)*10%*1year = 9.5e18, unpaidInterest ~= 10e18
-    // newTotalAccrued < unpaidInterest -> fallback: maximize outstanding
-    uint256 newTotalAccrued = BrokerMath.getAccruedInterestForFixedPosition(updated);
-    assertEq(_outstanding(updated), newTotalAccrued, "fallback preserves max possible");
-    assertGt(_outstanding(updated), 0, "outstanding > 0");
-    // Verify: better than old code which would give outstanding = 0
-    assertGt(_outstanding(updated), accruedInterest / 2, "preserves majority of interest");
+    // Simplified semantic: principal payment resets tracking regardless of how much interest was left.
+    assertEq(updated.interestRepaid, 0, "interest tracking reset");
+    assertEq(updated.lastRepaidTime, block.timestamp, "lastRepaidTime reset");
+    assertEq(updated.principalRepaid, principalBudget, "principal repaid");
+    assertEq(_outstanding(updated), 0, "outstanding = 0 right after the reset");
   }
 
   // ====================================================================
-  //  After reset, new interest accrues correctly
+  //  After reset, new interest accrues correctly; a subsequent
+  //  partial-with-principal call resets again.
   // ====================================================================
 
-  function test_resetThenNewAccrual_worksCorrectly() public {
+  function test_resetThenNewAccrual_resetsAgainOnSecondPrincipalPayment() public {
     FixedLoanPosition memory pos = _makePosition(100 ether);
     skip(DURATION / 2);
 
@@ -315,18 +322,19 @@ contract BrokerMathDeductFixedTest is Test {
     assertEq(after1.lastRepaidTime, block.timestamp, "lastRepaidTime reset");
     assertEq(_outstanding(after1), 0, "no outstanding after reset");
 
-    // More time passes -> new interest accrues on reduced principal
+    // More time passes -> new interest accrues on the reduced (80e18) principal
     skip(DURATION / 2);
 
     uint256 accrued2 = _outstanding(after1);
     assertGt(accrued2, 0, "new interest accrued after reset");
 
-    // Partial interest + 30 principal -> should NOT reset, preserve exact
+    // Partial interest + 30 principal -> resets again per the simplified semantic
     uint256 partialInterest = accrued2 / 2;
     (, , FixedLoanPosition memory after2) = BrokerMath.deductFixedPositionDebt(partialInterest, 30 ether, after1);
 
-    uint256 expectedOutstanding = accrued2 - partialInterest;
-    assertEq(_outstanding(after2), expectedOutstanding, "exact after second partial");
+    assertEq(after2.interestRepaid, 0, "second: interest tracking reset");
+    assertEq(after2.lastRepaidTime, block.timestamp, "second: lastRepaidTime = now");
     assertEq(after2.principalRepaid, 50 ether, "cumulative 50 principal");
+    assertEq(_outstanding(after2), 0, "no outstanding immediately after reset");
   }
 }

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -744,6 +744,28 @@ contract LendingBrokerTest is Test {
     assertLe(fixedPositions[0].principal, convertAmount, "fixed principal must be <= amount");
   }
 
+  /// @notice A user with no dynamic position (or with both principal and interest at zero) must
+  ///         not be able to spawn zero-principal fixed positions via convertDynamicToFixed.
+  ///         Without the post-clamp guard, repeated 1-wei calls would let an attacker fill
+  ///         maxFixedLoanPositions slots with empty entries to grief liquidation gas later.
+  function test_convertDynamicToFixed_revertsWhenNoDynamicDebt() public {
+    FixedTermAndRate memory term = FixedTermAndRate({ termId: 55, duration: 30 days, apr: 105 * 1e25 });
+    vm.prank(BOT);
+    broker.updateFixedTermAndRate(term, false);
+
+    // user has never borrowed → no dynamic position
+    (uint256 principal, uint256 normalizedDebt) = broker.dynamicLoanPositions(borrower);
+    assertEq(principal, 0, "precondition: no dynamic principal");
+    assertEq(normalizedDebt, 0, "precondition: no dynamic normalizedDebt");
+
+    vm.prank(borrower);
+    vm.expectRevert(LendingBroker.ZeroAmount.selector);
+    broker.convertDynamicToFixed(1, 55);
+
+    // confirm: no fixed position was ever created
+    assertEq(broker.userFixedPositions(borrower).length, 0, "no fixed position should be created");
+  }
+
   // -----------------------------
   // Fixed borrow and repay (partial and full)
   // -----------------------------
@@ -1721,7 +1743,7 @@ contract LendingBrokerTest is Test {
     vm.stopPrank();
 
     vm.prank(borrower);
-    vm.expectRevert("broker/positions-below-min-loan");
+    vm.expectRevert("broker/dynamic-below-min-loan");
     broker.repay(minLoan / 2, borrower);
   }
 
@@ -1787,7 +1809,7 @@ contract LendingBrokerTest is Test {
     broker.emergencyWithdraw(address(LISUSD), amount);
   }
 
-  function test_checkPositionsMeetsMinLoan_allowsFullRepay() public {
+  function test_validateDynamicPosition_allowsFullRepay() public {
     vm.prank(MANAGER);
     moolah.setMinLoanValue(1e8);
     uint256 minLoan = moolah.minLoan(marketParams);
@@ -1795,7 +1817,7 @@ contract LendingBrokerTest is Test {
     vm.prank(borrower);
     broker.borrow(minLoan);
 
-    // full repayment leaves zero debt, which BrokerMath.checkPositionsMeetsMinLoan accepts
+    // full repayment leaves zero principal, which _validateDynamicPosition accepts
     vm.prank(borrower);
     broker.repay(minLoan, borrower);
 
@@ -2080,6 +2102,434 @@ contract LendingBrokerTest is Test {
       "",
       payload
     );
+  }
+
+  // =============================================
+  // repayAll tests
+  // =============================================
+
+  /// @notice repayAll clears a dynamic-only position and supplies accrued interest as revenue.
+  function test_repayAll_dynamicOnly() public {
+    uint256 borrowAmt = 1000 ether;
+    vm.prank(borrower);
+    broker.borrow(borrowAmt);
+
+    // bump rate so meaningful interest accrues
+    vm.prank(MANAGER);
+    rateCalc.setMaxRatePerSecond(address(broker), RATE_SCALE + 1e20);
+    vm.prank(BOT);
+    rateCalc.setRatePerSecond(address(broker), RATE_SCALE + 1e20);
+    skip(7 days);
+
+    uint256 rate = rateCalc.accrueRate(address(broker));
+    (, uint256 normalizedDebt) = broker.dynamicLoanPositions(borrower);
+    uint256 actualDebt = BrokerMath.denormalizeBorrowAmount(normalizedDebt, rate);
+    uint256 interestPortion = actualDebt - borrowAmt;
+    assertGt(interestPortion, 0, "interest did not accrue");
+
+    LISUSD.setBalance(borrower, actualDebt);
+    uint256 relayerBalBefore = LISUSD.balanceOf(address(relayer));
+    uint256 vaultSharesBefore = moolah.position(id, address(vault)).supplyShares;
+
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+
+    // dynamic position cleared
+    (uint256 principalAfter, uint256 normalizedAfter) = broker.dynamicLoanPositions(borrower);
+    assertEq(principalAfter, 0, "dynamic principal not cleared");
+    assertEq(normalizedAfter, 0, "dynamic normalized debt not cleared");
+
+    // borrow shares cleared at Moolah
+    Position memory posAfter = moolah.position(id, borrower);
+    assertEq(posAfter.borrowShares, 0, "borrow shares not cleared");
+
+    // borrower spent the entire budget
+    assertEq(LISUSD.balanceOf(borrower), 0, "borrower retained funds");
+
+    // revenue (interest) was supplied to relayer / vault
+    uint256 vaultSharesAfter = moolah.position(id, address(vault)).supplyShares;
+    bool revenueSupplied = vaultSharesAfter > vaultSharesBefore ||
+      LISUSD.balanceOf(address(relayer)) > relayerBalBefore;
+    assertTrue(revenueSupplied, "interest not supplied to vault/relayer");
+  }
+
+  /// @notice repayAll clears every fixed position and charges full early-repay penalty.
+  function test_repayAll_fixedOnly_chargesPenalty() public {
+    vm.startPrank(BOT);
+    broker.updateFixedTermAndRate(FixedTermAndRate({ termId: 1, duration: 30 days, apr: 110 * 1e25 }), false);
+    broker.updateFixedTermAndRate(FixedTermAndRate({ termId: 2, duration: 60 days, apr: 115 * 1e25 }), false);
+    vm.stopPrank();
+
+    vm.startPrank(borrower);
+    broker.borrow(500 ether, 1);
+    broker.borrow(700 ether, 2);
+    vm.stopPrank();
+
+    skip(5 days);
+    moolah.accrueInterest(marketParams);
+
+    // every position should have a non-zero penalty (early repay)
+    FixedLoanPosition[] memory positions = broker.userFixedPositions(borrower);
+    assertEq(positions.length, 2);
+    for (uint256 i = 0; i < positions.length; i++) {
+      uint256 remaining = positions[i].principal - positions[i].principalRepaid;
+      assertGt(BrokerMath.getPenaltyForFixedPosition(positions[i], remaining), 0, "penalty not charged");
+    }
+
+    LISUSD.setBalance(borrower, 5_000 ether);
+    uint256 relayerBefore = LISUSD.balanceOf(address(relayer));
+    uint256 vaultSharesBefore = moolah.position(id, address(vault)).supplyShares;
+
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+
+    // every fixed position cleared
+    assertEq(broker.userFixedPositions(borrower).length, 0, "fixed positions not cleared");
+    Position memory posAfter = moolah.position(id, borrower);
+    assertEq(posAfter.borrowShares, 0, "borrow shares not cleared");
+
+    // revenue (interest + penalty) reached relayer/vault
+    uint256 vaultSharesAfter = moolah.position(id, address(vault)).supplyShares;
+    bool revenueSupplied = vaultSharesAfter > vaultSharesBefore || LISUSD.balanceOf(address(relayer)) > relayerBefore;
+    assertTrue(revenueSupplied, "no revenue supplied");
+  }
+
+  /// @notice repayAll clears dynamic and fixed positions in a single call.
+  function test_repayAll_dynamicAndFixed() public {
+    vm.prank(BOT);
+    broker.updateFixedTermAndRate(FixedTermAndRate({ termId: 1, duration: 30 days, apr: 105 * 1e25 }), false);
+
+    vm.startPrank(borrower);
+    broker.borrow(800 ether);
+    broker.borrow(400 ether, 1);
+    vm.stopPrank();
+
+    vm.prank(MANAGER);
+    rateCalc.setMaxRatePerSecond(address(broker), RATE_SCALE + 1e20);
+    vm.prank(BOT);
+    rateCalc.setRatePerSecond(address(broker), RATE_SCALE + 1e20);
+    skip(3 days);
+
+    LISUSD.setBalance(borrower, 10_000 ether);
+
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+
+    (uint256 dynPrincipal, uint256 dynNormalized) = broker.dynamicLoanPositions(borrower);
+    assertEq(dynPrincipal, 0, "dynamic not cleared");
+    assertEq(dynNormalized, 0, "dynamic normalized not cleared");
+    assertEq(broker.userFixedPositions(borrower).length, 0, "fixed not cleared");
+
+    Position memory posAfter = moolah.position(id, borrower);
+    assertEq(posAfter.borrowShares, 0, "borrow shares not cleared");
+  }
+
+  /// @notice repayAll emits AllPositionsRepaid with the total amount charged.
+  function test_repayAll_emitsEvent() public {
+    vm.prank(borrower);
+    broker.borrow(500 ether);
+
+    skip(1 hours);
+
+    LISUSD.setBalance(borrower, 1_000 ether);
+
+    // we don't pin the totalRepaid amount precisely (interest tiny but non-deterministic);
+    // assert event topic + emitter, then check positions cleared after
+    vm.expectEmit(true, false, false, false, address(broker));
+    emit IBroker.AllPositionsRepaid(borrower, 0); // value not checked
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+  }
+
+  /// @notice repayAll emits FixedLoanPositionRemoved for every cleared fixed position
+  ///         and DynamicLoanPositionRepaid for the cleared dynamic position.
+  function test_repayAll_emitsPerPositionEvents() public {
+    vm.startPrank(BOT);
+    broker.updateFixedTermAndRate(FixedTermAndRate({ termId: 1, duration: 30 days, apr: 105 * 1e25 }), false);
+    broker.updateFixedTermAndRate(FixedTermAndRate({ termId: 2, duration: 60 days, apr: 110 * 1e25 }), false);
+    vm.stopPrank();
+
+    vm.startPrank(borrower);
+    broker.borrow(300 ether);
+    broker.borrow(200 ether, 1);
+    broker.borrow(150 ether, 2);
+    vm.stopPrank();
+
+    FixedLoanPosition[] memory positions = broker.userFixedPositions(borrower);
+    assertEq(positions.length, 2);
+
+    LISUSD.setBalance(borrower, 5_000 ether);
+
+    // Expect: dynamic repaid event + a removed event for each fixed pos + the all-repaid event.
+    // Don't pin amount in the dynamic repaid event (interest is tiny but non-deterministic).
+    vm.expectEmit(true, false, false, false, address(broker));
+    emit IBroker.DynamicLoanPositionRepaid(borrower, 0, 0);
+    vm.expectEmit(true, false, false, true, address(broker));
+    emit IBroker.FixedLoanPositionRemoved(borrower, positions[0].posId);
+    vm.expectEmit(true, false, false, true, address(broker));
+    emit IBroker.FixedLoanPositionRemoved(borrower, positions[1].posId);
+    vm.expectEmit(true, false, false, false, address(broker));
+    emit IBroker.AllPositionsRepaid(borrower, 0);
+
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+  }
+
+  /// @notice A third party may repayAll on behalf of any borrower.
+  function test_repayAll_byThirdParty() public {
+    vm.prank(borrower);
+    broker.borrow(300 ether);
+
+    address helper = address(0x707);
+    LISUSD.setBalance(helper, 1_000 ether);
+    vm.startPrank(helper);
+    IERC20(address(LISUSD)).approve(address(broker), type(uint256).max);
+    broker.repayAll(borrower);
+    vm.stopPrank();
+
+    (uint256 p, ) = broker.dynamicLoanPositions(borrower);
+    assertEq(p, 0, "dynamic not cleared");
+    Position memory posAfter = moolah.position(id, borrower);
+    assertEq(posAfter.borrowShares, 0, "borrow shares not cleared");
+    assertLt(LISUSD.balanceOf(helper), 1_000 ether, "helper balance unchanged");
+  }
+
+  /// @notice repayAll with native BNB clears the position and refunds excess.
+  function test_repayAll_native_refundsExcess() public {
+    // bootstrap WBNB totalSupply so the burn-then-mint sequence in withdraw/deposit
+    // does not underflow→overflow (WBNBMock uses OZ ERC20; deal() does not adjust totalSupply)
+    vm.deal(address(this), 10_000 ether);
+    WBNB.deposit{ value: 10_000 ether }();
+
+    vm.deal(borrower, 1_000 ether);
+    vm.deal(address(WBNB), 10_000 ether);
+
+    vm.startPrank(borrower);
+    bnbBroker.borrow(500 ether);
+    vm.stopPrank();
+
+    uint256 budget = 600 ether; // overpay
+    vm.deal(borrower, borrower.balance + budget);
+    uint256 balBefore = borrower.balance;
+
+    vm.prank(borrower);
+    bnbBroker.repayAll{ value: budget }(borrower);
+
+    (uint256 p, ) = bnbBroker.dynamicLoanPositions(borrower);
+    assertEq(p, 0, "dynamic not cleared");
+    Position memory posAfter = moolah.position(bnbId, borrower);
+    assertEq(posAfter.borrowShares, 0, "borrow shares not cleared");
+
+    uint256 balAfter = borrower.balance;
+    assertGt(balAfter, balBefore - budget, "no native refund issued");
+  }
+
+  /// @notice repayAll reverts when called with native value on a non-WBNB market.
+  function test_repayAll_revertsNativeOnNonWBNB() public {
+    vm.prank(borrower);
+    broker.borrow(100 ether);
+
+    vm.deal(borrower, 1 ether);
+    vm.expectRevert(LendingBroker.NativeNotSupported.selector);
+    vm.prank(borrower);
+    broker.repayAll{ value: 1 ether }(borrower);
+  }
+
+  /// @notice repayAll reverts when msg.value < totalDebt on the WBNB broker.
+  function test_repayAll_revertsInsufficientNativeValue() public {
+    vm.deal(borrower, 1_000 ether);
+    vm.deal(address(WBNB), 10_000 ether);
+
+    vm.startPrank(borrower);
+    bnbBroker.borrow(500 ether);
+    vm.stopPrank();
+
+    // send a tiny fraction — must revert with InsufficientAmount
+    vm.expectRevert(LendingBroker.InsufficientAmount.selector);
+    vm.prank(borrower);
+    bnbBroker.repayAll{ value: 1 wei }(borrower);
+  }
+
+  /// @notice repayAll reverts on zero onBehalf address.
+  function test_repayAll_revertsZeroAddress() public {
+    vm.expectRevert(LendingBroker.ZeroAddress.selector);
+    vm.prank(borrower);
+    broker.repayAll(address(0));
+  }
+
+  /// @notice repayAll reverts when the user has no debt.
+  function test_repayAll_revertsNothingToRepay() public {
+    vm.expectRevert(LendingBroker.NothingToRepay.selector);
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+  }
+
+  // =============================================
+  // Per-position validation tests
+  // =============================================
+
+  /// @notice partial repay of a fixed position to below minLoan reverts with the per-fixed error.
+  ///         A second (large) position keeps Moolah's own debt above minLoan so the broker-level
+  ///         validation is the one that fires.
+  function test_repayFixed_belowMin_reverts() public {
+    vm.prank(MANAGER);
+    moolah.setMinLoanValue(100 * 1e8); // minLoan = 100 ether
+    uint256 minLoan = moolah.minLoan(marketParams);
+    assertEq(minLoan, 100 ether);
+
+    FixedTermAndRate memory term = FixedTermAndRate({ termId: 100, duration: 30 days, apr: 105 * 1e25 });
+    vm.prank(BOT);
+    broker.updateFixedTermAndRate(term, false);
+
+    vm.startPrank(borrower);
+    broker.borrow(500 ether); // dynamic — keeps total Moolah debt well above minLoan
+    broker.borrow(minLoan, term.termId);
+    vm.stopPrank();
+
+    FixedLoanPosition[] memory positions = broker.userFixedPositions(borrower);
+    uint256 posId = positions[0].posId;
+
+    LISUSD.setBalance(borrower, 1_000 ether);
+    vm.expectRevert("broker/fixed-below-min-loan");
+    vm.prank(borrower);
+    broker.repay(minLoan / 2, posId, borrower);
+  }
+
+  /// @notice "validate current" isolation: an unrelated below-min fixed position does not block
+  ///         a dynamic borrow on the same user. Old "validate all" would have reverted here.
+  function test_validation_isolation_borrowDynamicWhenFixedBelowMin() public {
+    // initial minLoan = 15 ether (set in setUp via Moolah.initialize(_minLoanValue=15e8))
+    assertEq(moolah.minLoan(marketParams), 15 ether);
+
+    FixedTermAndRate memory term = FixedTermAndRate({ termId: 200, duration: 30 days, apr: 105 * 1e25 });
+    vm.prank(BOT);
+    broker.updateFixedTermAndRate(term, false);
+
+    // borrow 50 dynamic + 50 fixed (both above the 15-ether minLoan)
+    vm.startPrank(borrower);
+    broker.borrow(50 ether);
+    broker.borrow(50 ether, term.termId);
+    vm.stopPrank();
+
+    // raise minLoan so the existing fixed position (50) is now below the new floor (100)
+    vm.prank(MANAGER);
+    moolah.setMinLoanValue(100 * 1e8);
+    assertEq(moolah.minLoan(marketParams), 100 ether);
+
+    // borrow more dynamic — only the dynamic position (which becomes 150) is validated
+    vm.prank(borrower);
+    broker.borrow(100 ether);
+
+    (uint256 dynPrincipal, ) = broker.dynamicLoanPositions(borrower);
+    assertEq(dynPrincipal, 150 ether);
+    // unrelated below-min fixed position remains untouched
+    FixedLoanPosition[] memory positions = broker.userFixedPositions(borrower);
+    assertEq(positions.length, 1);
+    assertEq(positions[0].principal, 50 ether);
+  }
+
+  // =============================================
+  // Liquidation runs even when leaving below-min
+  // =============================================
+
+  /// @notice After my change, liquidation no longer validates positions, so it succeeds even
+  ///         when the resulting principal falls below minLoan.
+  function test_liquidation_noRevertWhenLeavesPositionBelowMin() public {
+    _prepareLiquidatablePosition(false);
+
+    // raise minLoan above what each position will end up with after a 50% liquidation.
+    // setUp creates 40000 dyn + 40000 fixed; ~50% liquidation leaves ~20000 each.
+    vm.prank(MANAGER);
+    moolah.setMinLoanValue(25_000 * 1e8); // minLoan = 25,000 ether
+
+    Position memory posBefore = moolah.position(marketParams.id(), borrower);
+    uint256 userRepayShares = BrokerMath.mulDivCeiling(posBefore.borrowShares, 50 * 1e8, 100 * 1e8);
+
+    LISUSD.setBalance(address(liquidator), 1_000_000 ether);
+
+    // old code would have reverted with broker/positions-below-min-loan; the new code must succeed
+    vm.prank(BOT);
+    liquidator.liquidate(Id.unwrap(id), borrower, 0, userRepayShares);
+
+    Position memory posAfter = moolah.position(marketParams.id(), borrower);
+    assertLt(posAfter.borrowShares, posBefore.borrowShares, "shares should decrease");
+  }
+
+  /// @notice Regression: after a partial liquidation, a position can be left in the
+  ///         "interest-only residual" state — `principal == 0` while `normalizedDebt > 0`
+  ///         (because liquidation paid the principal but only a fraction of the broker's
+  ///         accrued interest). This test exercises that path through repayAll:
+  ///           (1) liquidation completes (no broker validation)
+  ///           (2) repayAll's `dynamicInterest > 0` guard fires and clears the residual
+  ///           (3) DynamicLoanPositionRepaid event still emits for the residual
+  ///           (4) no leftover broker tracking, no Moolah debt
+  function test_liquidation_postResidual_repayAllClearsCleanly() public {
+    _prepareLiquidatablePosition(false);
+
+    // 50% liquidation of 40k dyn + 40k fixed: dynamic absorbs all 40k principal first,
+    // leaving dynamic with only an interest residual (principal == 0, normalizedDebt > 0).
+    Position memory posBefore = moolah.position(marketParams.id(), borrower);
+    uint256 userRepayShares = BrokerMath.mulDivCeiling(posBefore.borrowShares, 50 * 1e8, 100 * 1e8);
+    LISUSD.setBalance(address(liquidator), 1_000_000 ether);
+
+    vm.prank(BOT);
+    liquidator.liquidate(Id.unwrap(id), borrower, 0, userRepayShares);
+
+    // confirm the residual: principal cleared but interest still tracked
+    (uint256 dynPrincipal, uint256 dynNormDebt) = broker.dynamicLoanPositions(borrower);
+    assertEq(dynPrincipal, 0, "dynamic principal should be cleared");
+    assertGt(dynNormDebt, 0, "dynamic should retain interest residual");
+
+    FixedLoanPosition[] memory positions = broker.userFixedPositions(borrower);
+    assertEq(positions.length, 1, "expected one fixed position remaining");
+    uint256 fixedPosId = positions[0].posId;
+
+    // repayAll should: charge the residual interest, fire DynamicLoanPositionRepaid (via the
+    // `dynamicInterest > 0` guard), remove the fixed position, and clear all state.
+    LISUSD.setBalance(borrower, 1_000_000 ether);
+
+    vm.expectEmit(true, false, false, false, address(broker));
+    emit IBroker.DynamicLoanPositionRepaid(borrower, 0, 0);
+    vm.expectEmit(true, false, false, true, address(broker));
+    emit IBroker.FixedLoanPositionRemoved(borrower, fixedPosId);
+    vm.expectEmit(true, false, false, false, address(broker));
+    emit IBroker.AllPositionsRepaid(borrower, 0);
+
+    vm.prank(borrower);
+    broker.repayAll(borrower);
+
+    (uint256 dynAfter, uint256 normAfter) = broker.dynamicLoanPositions(borrower);
+    assertEq(dynAfter, 0, "dynamic principal not cleared");
+    assertEq(normAfter, 0, "dynamic normalized debt not cleared (interest residual leaked)");
+    assertEq(broker.userFixedPositions(borrower).length, 0, "fixed not cleared");
+    Position memory moolahAfter = moolah.position(id, borrower);
+    assertEq(moolahAfter.borrowShares, 0, "moolah debt not cleared");
+  }
+
+  /// @notice Broker market runs 0% Moolah-side IRM, so totalBorrowAssets/totalBorrowShares stays
+  ///         locked at 1:VIRTUAL_SHARES across the market's lifetime. A liquidation that passes a
+  ///         repaidShares value not divisible by VIRTUAL_SHARES would have toAssetsUp ceiling round
+  ///         the asset deduction up by 1 wei, drifting the ratio and corrupting later repayments
+  ///         for every borrower in the market. The guard rejects this at the broker layer.
+  function test_liquidation_revertsOnNonDivisibleRepaidShares() public {
+    _prepareLiquidatablePosition(false);
+
+    Position memory posBefore = moolah.position(marketParams.id(), borrower);
+    // 50% clamped to a clean multiple, then add 1 to force non-divisible
+    uint256 cleanShares = (posBefore.borrowShares / 2 / SharesMathLib.VIRTUAL_SHARES) * SharesMathLib.VIRTUAL_SHARES;
+    uint256 dirtyShares = cleanShares + 1;
+
+    LISUSD.setBalance(address(liquidator), 1_000_000 ether);
+
+    vm.prank(BOT);
+    vm.expectRevert(LendingBroker.InvalidRepaidShares.selector);
+    liquidator.liquidate(Id.unwrap(id), borrower, 0, dirtyShares);
+
+    // clean multiple still succeeds
+    vm.prank(BOT);
+    liquidator.liquidate(Id.unwrap(id), borrower, 0, cleanShares);
+    Position memory posAfter = moolah.position(marketParams.id(), borrower);
+    assertLt(posAfter.borrowShares, posBefore.borrowShares, "clean shares should liquidate");
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses 12 findings from the Bailsec Lista Dao - Fixed Term audit (final report, May 2026) on `LendingBroker`. Adds an emergency `repayAll(onBehalf)` exit, replaces the global `checkPositionsMeetsMinLoan` validator with per-position validators, rejects non-divisible `repaidShares` in `liquidate()`, and tightens `convertDynamicToFixed` against zero-principal positions. Splits oversized contract bytecode by routing the three repay paths through a new `LendingBrokerOperatorLib` so `LendingBroker` returns under the EIP-170 24,576-byte limit.

## Change type

- [x] Bug fix (audit findings)
- [x] Gas optimization (size reduction via library extraction)
- [x] Upgrade (existing UUPS proxy — storage layout preserved)
- [x] Test (new tests for repayAll, divisibility check, zero-principal convert)
- [ ] New contract
- [ ] Configuration change
- [ ] Migration / deploy script
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `LendingBroker` | `src/broker/LendingBroker.sol` | modified |
| `IBroker` | `src/broker/interfaces/IBroker.sol` | modified (added \`repayAll\`, \`AllPositionsRepaid\`) |
| `BrokerMath` | `src/broker/libraries/BrokerMath.sol` | modified (added \`executeLiquidationCascade\`, \`previewRepayAllAmounts\`, \`previewConvertDynamicToFixed\`) |
| `LendingBrokerOperatorLib` | `src/broker/libraries/LendingBrokerOperatorLib.sol` | **new** (holds repay / repayAll bodies, called via DELEGATECALL) |

## Interface changes

**New on `IBroker` / `LendingBroker`:**
- `function repayAll(address onBehalf) external payable` — fully clears every dynamic + fixed position for `onBehalf` in one call; charges full early-repay penalty
- `event AllPositionsRepaid(address indexed user, uint256 totalRepaid)`
- `error InvalidRepaidShares()` — emitted when `liquidate(.., repaidShares)` isn't a multiple of `VIRTUAL_SHARES = 1e6`

**Removed (internal helpers, no ABI impact):**
- `BrokerMath.checkPositionsMeetsMinLoan` — replaced by per-position validators in the broker
- Several `LendingBroker` internal helpers consolidated or moved into `LendingBrokerOperatorLib`

## Storage layout

🟢 **Unchanged.** \`forge inspect LendingBroker storage-layout\` shows the same 15 slots in the same order as the pre-existing implementation:
LOAN_TOKEN, COLLATERAL_TOKEN, MARKET_ID, BROKER_NAME, dynamicLoanPositions, rateCalculator, fixedTerms, fixedLoanPositions, fixedPosUuid, maxFixedLoanPositions, borrowPaused, liquidationContext, liquidationWhitelist, RELAYER, ORACLE.

No new state variables, no reorders, no removals. Safe to upgrade.

## Access control

🟢 **Unchanged.** No new roles, no modifier changes. `repayAll` reuses the existing `marketIdSet`, `whenNotPaused`, `nonReentrant` modifiers (same as existing `repay`).

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | Layout identical to current implementation; verified by \`forge inspect\`. |
| Fund safety | 🟡 Low | \`repayAll\` is a new code path with significant interactions (Moolah repay, vault supply, native BNB refund). Covered by 11 new tests including third-party caller, native + ERC20 modes, insufficient-value / zero-address / nothing-to-repay reverts, and post-liquidation residual cleanup. |
| Access control | 🟢 None | No role / modifier changes. |
| External call safety | 🟡 Low | \`LendingBrokerOperatorLib\` runs via DELEGATECALL — preserves \`msg.sender\`, \`msg.value\`, \`address(this)\`, and storage. \`nonReentrant\` on the wrapper covers the entire library call. Events emitted by the library surface from \`LendingBroker\`'s address with matching signatures, so indexers see no change. |

## Deployment

UUPS implementation upgrade for `LendingBroker` proxy. Two libraries (`BrokerMath`, `LendingBrokerOperatorLib`) deployed alongside and linked into the implementation at deploy time. No new env vars. Existing deploy scripts under `script/broker/` cover the flow; no script changes required here.

## Test plan

- [x] \`forge test --mc LendingBrokerTest\` — 91 tests pass
- [x] \`forge build\` — compiles, no errors (lints only)
- [x] \`forge build --sizes\` — LendingBroker at **22,462 / 24,576** (margin +2,114)
- [x] Storage layout diff — no slot changes vs current implementation
- [ ] Fork-simulate upgrade against BSC mainnet LendingBroker proxy and execute one \`repay\` + one \`liquidate\` + one \`repayAll\` against an existing borrower (recommended before timelock execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)