### PR TITLE
chore: add .github/audit-config.yml for @audit-agent

### DIFF
--- a/.github/audit-config.yml
+++ b/.github/audit-config.yml
@@ -1,14 +1,7 @@
-# Per-repo audit configuration for lista-dao/moolah.
-# Schema: modules/cloud-auditor/PLAN.md §17.7
-# Phase 9 cutover values per .planning/phases/09-production-cutover/09-CONTEXT.md D-09-01.
-
 audit_doc_paths:
   - docs/audits/*.pdf
 
 actor_allowlist:
-  # Source: @lista-dao/sc team members (4 as of 2026-05-21).
-  # Team handle in allowlist requires GH App members:read scope + Worker expansion
-  # logic — deferred to v2. Sync this list manually when team membership changes.
   - lawson-ccy
   - razww
   - qingyang-lista

--- a/.github/audit-config.yml
+++ b/.github/audit-config.yml
@@ -1,0 +1,29 @@
+# Per-repo audit configuration for lista-dao/moolah.
+# Schema: modules/cloud-auditor/PLAN.md §17.7
+# Phase 9 cutover values per .planning/phases/09-production-cutover/09-CONTEXT.md D-09-01.
+
+audit_doc_paths:
+  - docs/audits/*.pdf
+
+actor_allowlist:
+  # Source: @lista-dao/sc team members (4 as of 2026-05-21).
+  # Team handle in allowlist requires GH App members:read scope + Worker expansion
+  # logic — deferred to v2. Sync this list manually when team membership changes.
+  - lawson-ccy
+  - razww
+  - qingyang-lista
+  - ricklista
+
+escalation_reviewers:
+  - "@lista-dao/sc"
+
+telegram:
+  chat_id: -4110669414
+  send_pdf: true
+  caption_prefix: "[Moolah]"
+
+delivery:
+  also_post_to_slack: false
+
+focus_defaults:
+  skip: []


### PR DESCRIPTION
Adds per-repo audit configuration for @audit-agent.

actor_allowlist: 4 @lista-dao/sc team members
escalation_reviewers: @lista-dao/sc
telegram chat: -4110669414 [Moolah]

Config-only — not audited.