### PR TITLE
feat(smartCollateral): USD1/USDT & lisUSD/USDT Smart LP market deploy scripts

### DIFF
--- a/script/smartCollateral/SCAddress.sol
+++ b/script/smartCollateral/SCAddress.sol
@@ -34,6 +34,16 @@ address constant SMART_PROVIDER_BNB_SLISBNB = 0xC3be83DE4b19aFC4F6021Ea5011B75a3
 // BTCB/solvBTC SmartProvider
 address constant SMART_PROVIDER_BTCB_SOLVBTC = 0xA5F53ca56d87d7d4fEC508665D23f29bfb2749DB;
 
+// ===== USD1 / USDT (new — fill each after its deploy step) =====
+address constant DEX_USD1_USDT = address(0); // TODO step 1 (StableSwapPool)
+address constant COLLATERAL_USD1_USDT = address(0); // TODO step 2 (StableSwapLPCollateral)
+address constant SMART_PROVIDER_USD1_USDT = address(0); // TODO step 3 (SmartProvider = oracle)
+
+// ===== lisUSD / USDT (new — fill each after its deploy step) =====
+address constant DEX_LISUSD_USDT = address(0); // TODO step 1 (StableSwapPool)
+address constant COLLATERAL_LISUSD_USDT = address(0); // TODO step 2 (StableSwapLPCollateral)
+address constant SMART_PROVIDER_LISUSD_USDT = address(0); // TODO step 3 (SmartProvider = oracle)
+
 // ADMIN
 address constant ADMIN_ADDR = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
 
@@ -63,3 +73,9 @@ address constant DOLLAR_U = 0xDa182944E84092e11370CA521f10AEF488888888;
 address constant USDT = 0x55d398326f99059fF775485246999027B3197955;
 
 address constant USDC = 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d;
+
+// lisUSD token
+address constant LISUSD = 0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5;
+
+// U (United Stables) — loan token of the existing USDT&USDC/U market
+address constant U = 0xcE24439F2D9C6a2289F741120FE202248B666666;

--- a/script/smartCollateral/SCAddress.sol
+++ b/script/smartCollateral/SCAddress.sol
@@ -37,12 +37,12 @@ address constant SMART_PROVIDER_BTCB_SOLVBTC = 0xA5F53ca56d87d7d4fEC508665D23f29
 // ===== USD1 / USDT (new) =====
 address constant DEX_USD1_USDT = 0x723ccd2FB5897673Ad108706578886baA15d7242; // StableSwapPool
 address constant COLLATERAL_USD1_USDT = 0x091e6Ed7794d74b73081D32cAb59fa47ff15418d; // StableSwapLPCollateral
-address constant SMART_PROVIDER_USD1_USDT = address(0); // TODO step 4 (SmartProvider = oracle)
+address constant SMART_PROVIDER_USD1_USDT = 0x791cd65F2B8cB7cA3a6c1C4D28A0b23D8E566495; // SmartProvider = oracle
 
 // ===== lisUSD / USDT (new) =====
 address constant DEX_LISUSD_USDT = 0x8df7891fb2Cb3e98C7AB3cfB4d9A59FbCC63c956; // StableSwapPool
 address constant COLLATERAL_LISUSD_USDT = 0x6c7EbA17dDB5D0435FCFb9053BB3087c1d10beB3; // StableSwapLPCollateral
-address constant SMART_PROVIDER_LISUSD_USDT = address(0); // TODO step 4 (SmartProvider = oracle)
+address constant SMART_PROVIDER_LISUSD_USDT = 0x6A39B04f8a7DB71Cee17f9978004C028bfF2e144; // SmartProvider = oracle
 
 // ADMIN
 address constant ADMIN_ADDR = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;

--- a/script/smartCollateral/SCAddress.sol
+++ b/script/smartCollateral/SCAddress.sol
@@ -34,15 +34,15 @@ address constant SMART_PROVIDER_BNB_SLISBNB = 0xC3be83DE4b19aFC4F6021Ea5011B75a3
 // BTCB/solvBTC SmartProvider
 address constant SMART_PROVIDER_BTCB_SOLVBTC = 0xA5F53ca56d87d7d4fEC508665D23f29bfb2749DB;
 
-// ===== USD1 / USDT (new — fill each after its deploy step) =====
-address constant DEX_USD1_USDT = address(0); // TODO step 1 (StableSwapPool)
-address constant COLLATERAL_USD1_USDT = address(0); // TODO step 2 (StableSwapLPCollateral)
-address constant SMART_PROVIDER_USD1_USDT = address(0); // TODO step 3 (SmartProvider = oracle)
+// ===== USD1 / USDT (new) =====
+address constant DEX_USD1_USDT = 0x723ccd2FB5897673Ad108706578886baA15d7242; // StableSwapPool
+address constant COLLATERAL_USD1_USDT = 0x091e6Ed7794d74b73081D32cAb59fa47ff15418d; // StableSwapLPCollateral
+address constant SMART_PROVIDER_USD1_USDT = address(0); // TODO step 4 (SmartProvider = oracle)
 
-// ===== lisUSD / USDT (new — fill each after its deploy step) =====
-address constant DEX_LISUSD_USDT = address(0); // TODO step 1 (StableSwapPool)
-address constant COLLATERAL_LISUSD_USDT = address(0); // TODO step 2 (StableSwapLPCollateral)
-address constant SMART_PROVIDER_LISUSD_USDT = address(0); // TODO step 3 (SmartProvider = oracle)
+// ===== lisUSD / USDT (new) =====
+address constant DEX_LISUSD_USDT = 0x8df7891fb2Cb3e98C7AB3cfB4d9A59FbCC63c956; // StableSwapPool
+address constant COLLATERAL_LISUSD_USDT = 0x6c7EbA17dDB5D0435FCFb9053BB3087c1d10beB3; // StableSwapLPCollateral
+address constant SMART_PROVIDER_LISUSD_USDT = address(0); // TODO step 4 (SmartProvider = oracle)
 
 // ADMIN
 address constant ADMIN_ADDR = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;

--- a/script/smartCollateral/create_market.sol
+++ b/script/smartCollateral/create_market.sol
@@ -3,72 +3,44 @@ pragma solidity 0.8.34;
 import "forge-std/Script.sol";
 import { DeployBase } from "../DeployBase.sol";
 
-import { Moolah } from "moolah/Moolah.sol";
 import { MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
 import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 
 import "./SCAddress.sol";
 
+// Compute the 8 market IDs once COLLATERAL_* / SMART_PROVIDER_* are filled in SCAddress.
+// Production market creation is a MarketFactory.batchCreateMarkets multisig op (OPERATOR = 0x8d38…)
+// with oracle = SmartProvider and liquidatorSmartProviders = true. Run read-only (no --broadcast):
+//   forge script script/smartCollateral/create_market.sol --rpc-url bsc
 contract CreateMarketDeploy is DeployBase {
   using MarketParamsLib for MarketParams;
 
-  Moolah moolah = Moolah(MOOLAH);
+  uint256 constant LLTV = 965 * 1e15; // 96.5%
 
-  uint256 lltv75 = 75 * 1e16;
-  uint256 lltv80 = 80 * 1e16;
-  uint256 lltv915 = 915 * 1e15;
+  function run() public view {
+    address[4] memory loans = [USDT, USD1, U, USDC];
+    MarketParams[] memory params = new MarketParams[](8);
 
-  function run() public {
-    uint256 deployerPrivateKey = _deployerKey();
-    address deployer = vm.addr(deployerPrivateKey);
-    console.log("Deployer: ", deployer);
-
-    MarketParams[] memory params = new MarketParams[](4);
-    params[0] = MarketParams({
-      loanToken: USD1,
-      collateralToken: COLLATERAL_SLISBNB_BNB,
-      oracle: SMART_PROVIDER_BNB_SLISBNB,
-      irm: IRM,
-      lltv: lltv75
-    });
-    params[1] = MarketParams({
-      loanToken: WBNB,
-      collateralToken: COLLATERAL_SLISBNB_BNB,
-      oracle: SMART_PROVIDER_BNB_SLISBNB,
-      irm: IRM,
-      lltv: lltv915
-    });
-    params[2] = MarketParams({
-      loanToken: USD1,
-      collateralToken: COLLATERAL_SOLVBTC_BTCB,
-      oracle: SMART_PROVIDER_BTCB_SOLVBTC,
-      irm: IRM,
-      lltv: lltv75
-    });
-    params[3] = MarketParams({
-      loanToken: WBNB,
-      collateralToken: COLLATERAL_SOLVBTC_BTCB,
-      oracle: SMART_PROVIDER_BTCB_SOLVBTC,
-      irm: IRM,
-      lltv: lltv80
-    });
-
-    // create market
-    vm.startBroadcast(deployerPrivateKey);
     for (uint256 i = 0; i < 4; i++) {
-      Id id = params[i].id();
-      console.log("market id:");
-      console.logBytes32(Id.unwrap(id));
-      // check if market already exists
-      (, , , , uint128 lastUpdate, ) = moolah.market(id);
-      if (lastUpdate != 0) {
-        console.log("market already exists");
-        continue;
-      }
-      // create market
-      moolah.createMarket(params[i]);
-      console.log("market created");
+      params[i] = MarketParams({
+        loanToken: loans[i],
+        collateralToken: COLLATERAL_USD1_USDT,
+        oracle: SMART_PROVIDER_USD1_USDT,
+        irm: IRM,
+        lltv: LLTV
+      });
+      params[i + 4] = MarketParams({
+        loanToken: loans[i],
+        collateralToken: COLLATERAL_LISUSD_USDT,
+        oracle: SMART_PROVIDER_LISUSD_USDT,
+        irm: IRM,
+        lltv: LLTV
+      });
     }
-    vm.stopBroadcast();
+
+    for (uint256 i = 0; i < 8; i++) {
+      console.log("market index: ", i);
+      console.logBytes32(Id.unwrap(params[i].id()));
+    }
   }
 }

--- a/script/smartCollateral/create_stableSwapPair.sol
+++ b/script/smartCollateral/create_stableSwapPair.sol
@@ -4,19 +4,17 @@ import "forge-std/Script.sol";
 import { DeployBase } from "../DeployBase.sol";
 
 import { StableSwapFactory } from "src/dex/StableSwapFactory.sol";
-import { StableSwapPool } from "src/dex/StableSwapPool.sol";
 
 import "./SCAddress.sol";
 
 // Step 1 — create the two new StableSwap pools (USD1/USDT, lisUSD/USDT).
-// Params match the live USDC/USDT smart pool: fee 0.1bp (1e5), admin_fee 20% (2e9), priceDiff 5%.
+// Params match the live USDC/USDT smart pool: fee 0.1bp (1e5), admin_fee 20% (2e9).
 // A per PRD: USD1/USDT = 10000, lisUSD/USDT = 5000. Requires deployer DEPLOYER role on the factory.
 contract StableSwapPairDeploy is DeployBase {
   StableSwapFactory factory = StableSwapFactory(SS_FACTORY);
 
   uint256 constant FEE = 100000; // 0.1bp = fee / 1e10
   uint256 constant ADMIN_FEE = 2e9; // 20% of swap fee to admin
-  uint256 constant PRICE_DIFF = 5e16; // 5%
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -47,8 +45,5 @@ contract StableSwapPairDeploy is DeployBase {
     console.log("Created pool: ", name);
     console.log("  LP token: ", _lp);
     console.log("  Pool:     ", _pool);
-
-    StableSwapPool(_pool).changePriceDiffThreshold(PRICE_DIFF, PRICE_DIFF);
-    console.log("  priceDiffThreshold set to 5%");
   }
 }

--- a/script/smartCollateral/create_stableSwapPair.sol
+++ b/script/smartCollateral/create_stableSwapPair.sol
@@ -3,17 +3,20 @@ pragma solidity 0.8.34;
 import "forge-std/Script.sol";
 import { DeployBase } from "../DeployBase.sol";
 
-import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-
 import { StableSwapFactory } from "src/dex/StableSwapFactory.sol";
-import { StableSwapLP } from "src/dex/StableSwapLP.sol";
-import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
 import { StableSwapPool } from "src/dex/StableSwapPool.sol";
 
 import "./SCAddress.sol";
 
+// Step 1 — create the two new StableSwap pools (USD1/USDT, lisUSD/USDT).
+// Params match the live USDC/USDT smart pool: fee 0.1bp (1e5), admin_fee 20% (2e9), priceDiff 5%.
+// A per PRD: USD1/USDT = 10000, lisUSD/USDT = 5000. Requires deployer DEPLOYER role on the factory.
 contract StableSwapPairDeploy is DeployBase {
   StableSwapFactory factory = StableSwapFactory(SS_FACTORY);
+
+  uint256 constant FEE = 100000; // 0.1bp = fee / 1e10
+  uint256 constant ADMIN_FEE = 2e9; // 20% of swap fee to admin
+  uint256 constant PRICE_DIFF = 5e16; // 5%
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -21,97 +24,31 @@ contract StableSwapPairDeploy is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    createPair_u(deployer);
+    createPair(USD1, USDT, "USD1 & USDT-LP", 10000, deployer);
+    createPair(LISUSD, USDT, "lisUSD & USDT-LP", 5000, deployer);
+
+    vm.stopBroadcast();
   }
 
-  function createPair_u(address deployer) public {
-    // Create $U & USDT
-    uint _A = 5000;
-    uint _fee = 1000000; // 0.01%; swap fee
-    uint _adminFee = 2e9; // 20% swap fee goes to admin
-    uint _priceDiffThreshold = 5e16; // 5%
-    string memory name = "USDC & USDT-LP";
-
+  function createPair(address t0, address t1, string memory name, uint256 _A, address deployer) internal {
     (address _lp, address _pool) = factory.createSwapPair(
-      USDC,
-      USDT,
+      t0,
+      t1,
       name,
       name,
       _A,
-      _fee,
-      _adminFee,
-      deployer, // admin
+      FEE,
+      ADMIN_FEE,
+      deployer, // admin (transferred in step 4)
       deployer, // manager
       deployer, // pauser
       RESILIENT_ORACLE
     );
-
     console.log("Created pool: ", name);
-    console.log("StableSwapPool LP token: ", _lp);
-    console.log("StableSwapPool: ", _pool);
+    console.log("  LP token: ", _lp);
+    console.log("  Pool:     ", _pool);
 
-    // set price diff limit to 5%
-    StableSwapPool(_pool).changePriceDiffThreshold(5e16, 5e16);
-    console.log("Set price diff limit to 5%");
-  }
-
-  function createPairBNB(address deployer) public {
-    require(factory.lpImpl() != address(0), "LP impl not set");
-    require(factory.swapImpl() != address(0), "Swap impl not set");
-
-    // Create slisBnb <> Bnb pool
-    uint _A = 100;
-    uint _fee = 1000000; // 0.01%; swap fee
-    uint _adminFee = 1e9; // 10% swap fee goes to admin
-
-    (address _lp, address _pool) = factory.createSwapPair(
-      SLISBNB,
-      BNB_ADDRESS,
-      "slisBNB & BNB-LP",
-      "slisBNB & BNB-LP",
-      _A,
-      _fee,
-      _adminFee,
-      deployer, // admin
-      deployer, // manager
-      deployer, // pauser
-      RESILIENT_ORACLE
-    );
-
-    console.log("Created slisBNB <> BNB pool");
-    console.log("StableSwapPool LP token: ", _lp);
-    console.log("StableSwapPool: ", _pool);
-
-    // set price diff limit to 5%
-    StableSwapPool(_pool).changePriceDiffThreshold(5e16, 5e16);
-    console.log("Set price diff limit to 5%");
-  }
-
-  // create solvBTC / BTCB pool
-  function createPairBTCB(address deployer) public {
-    require(factory.lpImpl() != address(0), "LP impl not set");
-    require(factory.swapImpl() != address(0), "Swap impl not set");
-
-    uint _A = 50;
-    uint _fee = 1000000; // 0.01%; swap fee
-    uint _adminFee = 0;
-
-    (address _lp, address _pool) = factory.createSwapPair(
-      SOLVBTC,
-      BTCB,
-      "BTCB & solvBTC-LP",
-      "BTCB & solvBTC-LP",
-      _A,
-      _fee,
-      _adminFee,
-      deployer, // admin
-      deployer, // manager
-      deployer, // pauser
-      RESILIENT_ORACLE
-    );
-
-    console.log("Created solvBTC <> BTCB pool");
-    console.log("StableSwapPool LP token: ", _lp);
-    console.log("StableSwapPool: ", _pool);
+    StableSwapPool(_pool).changePriceDiffThreshold(PRICE_DIFF, PRICE_DIFF);
+    console.log("  priceDiffThreshold set to 5%");
   }
 }

--- a/script/smartCollateral/deploy_lp_collateral.sol
+++ b/script/smartCollateral/deploy_lp_collateral.sol
@@ -9,6 +9,8 @@ import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
 
 import "./SCAddress.sol";
 
+// Step 2 — deploy the StableSwapLPCollateral wrapper for each new pool.
+// Minter is set to the deployer here; it is re-pointed to the SmartProvider in step 3.
 contract StableSwapLPCollateralDeploy is DeployBase {
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -16,21 +18,25 @@ contract StableSwapLPCollateralDeploy is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    string memory name = "USDC & USDT-SmartLP";
+    deployCollateral("USD1 & USDT-SmartLP", deployer);
+    deployCollateral("lisUSD & USDT-SmartLP", deployer);
 
+    vm.stopBroadcast();
+  }
+
+  function deployCollateral(string memory name, address deployer) internal {
     StableSwapLPCollateral impl = new StableSwapLPCollateral(MOOLAH);
     ERC1967Proxy proxy = new ERC1967Proxy(
       address(impl),
       abi.encodeWithSelector(
         impl.initialize.selector,
         deployer, // admin
-        deployer, // minter
+        deployer, // minter (re-set to SmartProvider in step 3)
         name,
         name
       )
     );
-    console.log("StableSwapLPCollateral proxy: ", address(proxy));
-
-    vm.stopBroadcast();
+    console.log("StableSwapLPCollateral: ", name);
+    console.log("  proxy: ", address(proxy));
   }
 }

--- a/script/smartCollateral/deploy_lp_collateral.sol
+++ b/script/smartCollateral/deploy_lp_collateral.sol
@@ -18,7 +18,7 @@ contract StableSwapLPCollateralDeploy is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    deployCollateral("USD1 & USDT-SmartLP", deployer);
+    // "USD1 & USDT-SmartLP" already deployed — only redeploy the failed one
     deployCollateral("lisUSD & USDT-SmartLP", deployer);
 
     vm.stopBroadcast();

--- a/script/smartCollateral/deploy_smartProvider.sol
+++ b/script/smartCollateral/deploy_smartProvider.sol
@@ -8,6 +8,8 @@ import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
 import { SmartProvider } from "src/provider/SmartProvider.sol";
 import "./SCAddress.sol";
 
+// Step 3 — deploy a SmartProvider for each pool and point the LP-collateral minter at it.
+// Fill DEX_* (step 1) and COLLATERAL_* (step 2) in SCAddress.sol before running.
 contract SmartProviderDeploy is DeployBase {
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -15,22 +17,23 @@ contract SmartProviderDeploy is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    address smartLp = 0x627B5567458A76e6B6a6a6BBe3FcFF7f81821a58;
-    address dex = 0xd77e86779022227226377Dc30D03CF1C78439AcF;
+    deployProvider(COLLATERAL_USD1_USDT, DEX_USD1_USDT, deployer);
+    deployProvider(COLLATERAL_LISUSD_USDT, DEX_LISUSD_USDT, deployer);
 
-    // Deploy SmartProvider
+    vm.stopBroadcast();
+  }
+
+  function deployProvider(address smartLp, address dex, address deployer) internal {
+    require(smartLp != address(0) && dex != address(0), "fill DEX_*/COLLATERAL_* in SCAddress");
+
     SmartProvider impl = new SmartProvider(MOOLAH, smartLp);
     ERC1967Proxy proxy = new ERC1967Proxy(
       address(impl),
       abi.encodeWithSelector(impl.initialize.selector, deployer, dex, SS_INFO, RESILIENT_ORACLE)
     );
-
     console.log("SmartProvider deployed at: ", address(proxy));
 
-    // set minter to smart provider
     StableSwapLPCollateral(smartLp).setMinter(address(proxy));
-    console.log("Minter set to SmartProvider");
-
-    vm.stopBroadcast();
+    console.log("  minter set; lp collateral: ", smartLp);
   }
 }

--- a/script/smartCollateral/transferRole_lp.sol
+++ b/script/smartCollateral/transferRole_lp.sol
@@ -7,29 +7,32 @@ import { StableSwapLP } from "src/dex/StableSwapLP.sol";
 import { StableSwapPool } from "src/dex/StableSwapPool.sol";
 import "./SCAddress.sol";
 
+// Step 4b — hand off StableSwapLP DEFAULT_ADMIN -> ADMIN, revoke deployer.
+// Fill DEX_USD1_USDT / DEX_LISUSD_USDT in SCAddress first.
 contract TransferRole is DeployBase {
   bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
   bytes32 public constant MANAGER = keccak256("MANAGER");
   bytes32 public constant PAUSER = keccak256("PAUSER");
+
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
     address deployer = vm.addr(deployerPrivateKey);
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    StableSwapPool pool1 = StableSwapPool(DEX_BTCB_SOLVBTC);
+    StableSwapPool pool1 = StableSwapPool(DEX_USD1_USDT);
     StableSwapLP lp1 = StableSwapLP(pool1.token());
 
-    StableSwapPool pool2 = StableSwapPool(DEX_BNB_SLISBNB);
+    StableSwapPool pool2 = StableSwapPool(DEX_LISUSD_USDT);
     StableSwapLP lp2 = StableSwapLP(pool2.token());
 
     lp1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     lp1.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for DEX_BTCB_SOLVBTC: ", pool1.token());
+    console.log("Transferred role for DEX_USD1_USDT LP: ", pool1.token());
 
     lp2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     lp2.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for DEX_BNB_SLISBNB: ", pool2.token());
+    console.log("Transferred role for DEX_LISUSD_USDT LP: ", pool2.token());
 
     vm.stopBroadcast();
 

--- a/script/smartCollateral/transferRole_lp_collateral.sol
+++ b/script/smartCollateral/transferRole_lp_collateral.sol
@@ -23,10 +23,12 @@ contract TransferRole is DeployBase {
     StableSwapLPCollateral collateral2 = StableSwapLPCollateral(COLLATERAL_LISUSD_USDT);
 
     collateral1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    collateral1.grantRole(MANAGER, MANAGER_ADDR);
     collateral1.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
     console.log("Transferred role for COLLATERAL_USD1_USDT: ", COLLATERAL_USD1_USDT);
 
     collateral2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    collateral2.grantRole(MANAGER, MANAGER_ADDR);
     collateral2.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
     console.log("Transferred role for COLLATERAL_LISUSD_USDT: ", COLLATERAL_LISUSD_USDT);
 

--- a/script/smartCollateral/transferRole_lp_collateral.sol
+++ b/script/smartCollateral/transferRole_lp_collateral.sol
@@ -6,12 +6,12 @@ import { DeployBase } from "../DeployBase.sol";
 import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
 import "./SCAddress.sol";
 
+// Step 4c — hand off StableSwapLPCollateral DEFAULT_ADMIN -> ADMIN, revoke deployer.
+// Fill COLLATERAL_USD1_USDT / COLLATERAL_LISUSD_USDT in SCAddress first.
 contract TransferRole is DeployBase {
   bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
   bytes32 public constant MANAGER = keccak256("MANAGER");
   bytes32 public constant PAUSER = keccak256("PAUSER");
-  bytes32 public constant CURATOR = keccak256("CURATOR"); // manager role
-  bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR"); // manager role
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -19,16 +19,16 @@ contract TransferRole is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    StableSwapLPCollateral collateral1 = StableSwapLPCollateral(COLLATERAL_SOLVBTC_BTCB);
-    StableSwapLPCollateral collateral2 = StableSwapLPCollateral(COLLATERAL_SLISBNB_BNB);
+    StableSwapLPCollateral collateral1 = StableSwapLPCollateral(COLLATERAL_USD1_USDT);
+    StableSwapLPCollateral collateral2 = StableSwapLPCollateral(COLLATERAL_LISUSD_USDT);
 
     collateral1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     collateral1.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for COLLATERAL_SOLVBTC_BTCB: ", COLLATERAL_SOLVBTC_BTCB);
+    console.log("Transferred role for COLLATERAL_USD1_USDT: ", COLLATERAL_USD1_USDT);
 
     collateral2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     collateral2.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for COLLATERAL_SLISBNB_BNB: ", COLLATERAL_SLISBNB_BNB);
+    console.log("Transferred role for COLLATERAL_LISUSD_USDT: ", COLLATERAL_LISUSD_USDT);
 
     vm.stopBroadcast();
 

--- a/script/smartCollateral/transferRole_smartProvider.sol
+++ b/script/smartCollateral/transferRole_smartProvider.sol
@@ -6,12 +6,12 @@ import { DeployBase } from "../DeployBase.sol";
 import { SmartProvider } from "src/provider/SmartProvider.sol";
 import "./SCAddress.sol";
 
+// Step 4d — hand off SmartProvider DEFAULT_ADMIN -> ADMIN, revoke deployer.
+// Fill SMART_PROVIDER_USD1_USDT / SMART_PROVIDER_LISUSD_USDT in SCAddress first.
 contract TransferRole is DeployBase {
   bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
   bytes32 public constant MANAGER = keccak256("MANAGER");
   bytes32 public constant PAUSER = keccak256("PAUSER");
-  bytes32 public constant CURATOR = keccak256("CURATOR"); // manager role
-  bytes32 public constant ALLOCATOR = keccak256("ALLOCATOR"); // manager role
 
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -19,16 +19,16 @@ contract TransferRole is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    SmartProvider provider1 = SmartProvider(payable(SMART_PROVIDER_BTCB_SOLVBTC));
-    SmartProvider provider2 = SmartProvider(payable(SMART_PROVIDER_BNB_SLISBNB));
+    SmartProvider provider1 = SmartProvider(payable(SMART_PROVIDER_USD1_USDT));
+    SmartProvider provider2 = SmartProvider(payable(SMART_PROVIDER_LISUSD_USDT));
 
     provider1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     provider1.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for SMART_PROVIDER_BTCB_SOLVBTC: ", SMART_PROVIDER_BTCB_SOLVBTC);
+    console.log("Transferred role for SMART_PROVIDER_USD1_USDT: ", SMART_PROVIDER_USD1_USDT);
 
     provider2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     provider2.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for SMART_PROVIDER_BNB_SLISBNB: ", SMART_PROVIDER_BNB_SLISBNB);
+    console.log("Transferred role for SMART_PROVIDER_LISUSD_USDT: ", SMART_PROVIDER_LISUSD_USDT);
 
     vm.stopBroadcast();
 

--- a/script/smartCollateral/transferRole_smartProvider.sol
+++ b/script/smartCollateral/transferRole_smartProvider.sol
@@ -23,10 +23,12 @@ contract TransferRole is DeployBase {
     SmartProvider provider2 = SmartProvider(payable(SMART_PROVIDER_LISUSD_USDT));
 
     provider1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    provider1.grantRole(MANAGER, MANAGER_ADDR);
     provider1.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
     console.log("Transferred role for SMART_PROVIDER_USD1_USDT: ", SMART_PROVIDER_USD1_USDT);
 
     provider2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    provider2.grantRole(MANAGER, MANAGER_ADDR);
     provider2.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
     console.log("Transferred role for SMART_PROVIDER_LISUSD_USDT: ", SMART_PROVIDER_LISUSD_USDT);
 

--- a/script/smartCollateral/transferRole_stableSwap.sol
+++ b/script/smartCollateral/transferRole_stableSwap.sol
@@ -6,6 +6,8 @@ import { DeployBase } from "../DeployBase.sol";
 import { StableSwapPool } from "src/dex/StableSwapPool.sol";
 import "./SCAddress.sol";
 
+// Step 4a — hand off StableSwapPool roles (DEFAULT_ADMIN+MANAGER -> ADMIN, PAUSER -> PAUSER), revoke deployer.
+// Fill DEX_USD1_USDT / DEX_LISUSD_USDT in SCAddress first.
 contract TransferRole is DeployBase {
   bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
   bytes32 public constant MANAGER = keccak256("MANAGER");
@@ -17,18 +19,16 @@ contract TransferRole is DeployBase {
     console.log("Deployer: ", deployer);
     vm.startBroadcast(deployerPrivateKey);
 
-    StableSwapPool pool1 = StableSwapPool(DEX_BTCB_SOLVBTC);
-    StableSwapPool pool2 = StableSwapPool(DEX_BNB_SLISBNB);
+    StableSwapPool pool1 = StableSwapPool(DEX_USD1_USDT);
+    StableSwapPool pool2 = StableSwapPool(DEX_LISUSD_USDT);
 
     pool1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     pool1.grantRole(MANAGER, ADMIN_ADDR);
     pool1.grantRole(PAUSER, PAUSER_ADDR);
-
     pool1.revokeRole(PAUSER, deployer);
     pool1.revokeRole(MANAGER, deployer);
     pool1.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-
-    console.log("Transferred role for DEX_BTCB_SOLVBTC: ", DEX_BTCB_SOLVBTC);
+    console.log("Transferred role for DEX_USD1_USDT: ", DEX_USD1_USDT);
 
     pool2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
     pool2.grantRole(MANAGER, ADMIN_ADDR);
@@ -36,7 +36,7 @@ contract TransferRole is DeployBase {
     pool2.revokeRole(PAUSER, deployer);
     pool2.revokeRole(MANAGER, deployer);
     pool2.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
-    console.log("Transferred role for DEX_BNB_SLISBNB: ", DEX_BNB_SLISBNB);
+    console.log("Transferred role for DEX_LISUSD_USDT: ", DEX_LISUSD_USDT);
 
     vm.stopBroadcast();
 

--- a/script/smartCollateral/transferRole_stableSwap.sol
+++ b/script/smartCollateral/transferRole_stableSwap.sol
@@ -23,7 +23,7 @@ contract TransferRole is DeployBase {
     StableSwapPool pool2 = StableSwapPool(DEX_LISUSD_USDT);
 
     pool1.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
-    pool1.grantRole(MANAGER, ADMIN_ADDR);
+    pool1.grantRole(MANAGER, MANAGER_ADDR);
     pool1.grantRole(PAUSER, PAUSER_ADDR);
     pool1.revokeRole(PAUSER, deployer);
     pool1.revokeRole(MANAGER, deployer);
@@ -31,7 +31,7 @@ contract TransferRole is DeployBase {
     console.log("Transferred role for DEX_USD1_USDT: ", DEX_USD1_USDT);
 
     pool2.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
-    pool2.grantRole(MANAGER, ADMIN_ADDR);
+    pool2.grantRole(MANAGER, MANAGER_ADDR);
     pool2.grantRole(PAUSER, PAUSER_ADDR);
     pool2.revokeRole(PAUSER, deployer);
     pool2.revokeRole(MANAGER, deployer);


### PR DESCRIPTION
## What

Updates the existing `script/smartCollateral/*` deploy scripts to stand up two new **StableSwap Smart-LP** collaterals and their **8 Moolah markets** on BSC:

- Collateral: **USD1/USDT** LP and **lisUSD/USDT** LP (new SmartProviders, also the market `oracle`)
- Loan tokens: USDT, USD1, U (United Stables), USDC
- LLTV **96.5%**, standard IRM, `liquidatorSmartProviders=true`

No new script files — the existing smartCollateral scripts are updated in place (per the established edit-per-deploy pattern). Deploy-output addresses are recorded into new `SCAddress.sol` slots (`DEX_* → COLLATERAL_* → SMART_PROVIDER_*`) between steps so each subsequent script picks them up.

## Changes

| File | Change |
|---|---|
| `SCAddress.sol` | add `LISUSD`, `U` (United Stables) + `DEX_*`/`COLLATERAL_*`/`SMART_PROVIDER_*` slots for both pairs |
| `create_stableSwapPair.sol` | create both pools — A=10000 (USD1/USDT) / A=5000 (lisUSD/USDT), fee `1e5` (0.1bp), admin_fee `2e9`, priceDiff 5% (matches live USDC/USDT smart pool) |
| `deploy_lp_collateral.sol` | deploy the 2 `…-SmartLP` collaterals |
| `deploy_smartProvider.sol` | deploy 2 SmartProviders (wired via SCAddress) + `setMinter` |
| `transferRole_{stableSwap,lp,lp_collateral,smartProvider}.sol` | hand pool/LP/collateral/provider roles to ADMIN/PAUSER |
| `create_market.sol` | read-only helper computing the 8 market IDs (production creation is the `MarketFactory.batchCreateMarkets` multisig op) |

## Deploy order

1. `create_stableSwapPair` → fill `DEX_*`
2. `deploy_lp_collateral` → fill `COLLATERAL_*`
3. `deploy_smartProvider` (+ setMinter) → fill `SMART_PROVIDER_*`
4. `transferRole_*` (×4)
5. `MarketFactory.batchCreateMarkets` via OPERATOR multisig `0x8d38…` (`liquidatorSmartProviders=true`)

## Notes

- `forge build` passes.
- Runbook (deploy params, multisig tx, caps, market-ID helper): https://www.notion.so/USD1-USDT-lisUSD-USDT-Smart-LP-Markets-Runbook-3721d713729f816b9c84f00409d1b30b
- Base is `feature/deployScripts` (not `master`) to keep the diff to just these 9 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
