### PR TITLE
fix: add receive() to BrokerLiquidator for native BNB redemption

### DIFF
--- a/script/broker/deploy_brokerLiquidator.s.sol
+++ b/script/broker/deploy_brokerLiquidator.s.sol
@@ -39,8 +39,8 @@ contract DeployBrokerLiquidator is DeployBase {
     // grant roles to manager and admin
     bytes32 MANAGER = keccak256("MANAGER");
     bytes32 DEFAULT_ADMIN_ROLE = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    BrokerLiquidator(address(proxy)).grantRole(MANAGER, manager);
-    BrokerLiquidator(address(proxy)).grantRole(DEFAULT_ADMIN_ROLE, timelock);
+    BrokerLiquidator(payable(address(proxy))).grantRole(MANAGER, manager);
+    BrokerLiquidator(payable(address(proxy))).grantRole(DEFAULT_ADMIN_ROLE, timelock);
 
     vm.stopBroadcast();
   }

--- a/script/broker/deploy_brokerLiquidatorImpl.s.sol
+++ b/script/broker/deploy_brokerLiquidatorImpl.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+import { BrokerLiquidator } from "../../src/liquidator/BrokerLiquidator.sol";
+
+contract DeployBrokerLiquidatorImpl is DeployBase {
+  // MOOLAH is immutable in BrokerLiquidator, so the new implementation must be
+  // constructed with the same Moolah the target proxy already uses.
+  address moolah;
+
+  function setUp() public {
+    // BSC testnet Moolah (matches BrokerLiquidator proxy 0xeAe8EaB31E7299Cc4c7C6F08f3C1AA8eF08dC175)
+    moolah = block.chainid == 97 ? 0x4c26397D4ef9EEae55735a1631e69Da965eBC41A : vm.envAddress("MOOLAH");
+  }
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    console.log("Moolah:   ", moolah);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy BrokerLiquidator implementation only (for upgrading an existing proxy)
+    BrokerLiquidator impl = new BrokerLiquidator(moolah);
+    console.log("BrokerLiquidator implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/broker/deploy_brokerLiquidatorImpl.s.sol
+++ b/script/broker/deploy_brokerLiquidatorImpl.s.sol
@@ -10,9 +10,19 @@ contract DeployBrokerLiquidatorImpl is DeployBase {
   // constructed with the same Moolah the target proxy already uses.
   address moolah;
 
+  // BSC mainnet Moolah
+  address constant MOOLAH_BSC = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+  // BSC testnet Moolah (matches BrokerLiquidator proxy 0xeAe8EaB31E7299Cc4c7C6F08f3C1AA8eF08dC175)
+  address constant MOOLAH_BSC_TESTNET = 0x4c26397D4ef9EEae55735a1631e69Da965eBC41A;
+
   function setUp() public {
-    // BSC testnet Moolah (matches BrokerLiquidator proxy 0xeAe8EaB31E7299Cc4c7C6F08f3C1AA8eF08dC175)
-    moolah = block.chainid == 97 ? 0x4c26397D4ef9EEae55735a1631e69Da965eBC41A : vm.envAddress("MOOLAH");
+    if (block.chainid == 56) {
+      moolah = MOOLAH_BSC;
+    } else if (block.chainid == 97) {
+      moolah = MOOLAH_BSC_TESTNET;
+    } else {
+      moolah = vm.envAddress("MOOLAH");
+    }
   }
 
   function run() public {

--- a/src/liquidator/BrokerLiquidator.sol
+++ b/src/liquidator/BrokerLiquidator.sol
@@ -9,6 +9,7 @@ import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { IBroker, IBrokerBase } from "../broker/interfaces/IBroker.sol";
 import { Id, MarketParams, IMoolah } from "moolah/interfaces/IMoolah.sol";
 import "./IBrokerLiquidator.sol";
+import { ISmartProvider } from "../provider/interfaces/IProvider.sol";
 
 contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerLiquidator {
   using MarketParamsLib for MarketParams;
@@ -33,6 +34,8 @@ contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerL
   // then we will know broker is whitelisted or not
   // by checking broker address => marketIdToBroker[market id] == broker address
   mapping(address => bytes32) public brokerToMarketId;
+  // @dev smart collateral provider whitelist
+  mapping(address => bool) public smartProviders;
 
   bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
   bytes32 public constant BOT = keccak256("BOT"); // manager role
@@ -43,6 +46,7 @@ contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerL
   event MarketWhitelistChanged(bytes32 id, address broker, bool added);
   event PairWhitelistChanged(address pair, bool added);
   event SellToken(address pair, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOutMin);
+  event SmartProvidersChanged(address provider, bool added);
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   /// @param moolah The address of the Moolah contract.
@@ -319,6 +323,34 @@ contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerL
     }
 
     SafeTransferLib.safeApprove(arb.loanToken, msg.sender, repaidAssets);
+  }
+
+  /// @dev redeems smart collateral LP tokens.
+  /// @param smartProvider The address of the smart collateral provider.
+  /// @param lpAmount The amount of LP collateral tokens to redeem.
+  /// @param minToken0Amt The minimum amount of token0 to receive.
+  /// @param minToken1Amt The minimum amount of token1 to receive.
+  /// @return The amount of token0 and token1 redeemed.
+  function redeemSmartCollateral(
+    address smartProvider,
+    uint256 lpAmount,
+    uint256 minToken0Amt,
+    uint256 minToken1Amt
+  ) external onlyRole(BOT) returns (uint256, uint256) {
+    require(smartProviders[smartProvider], NotWhitelisted());
+    return ISmartProvider(smartProvider).redeemLpCollateral(lpAmount, minToken0Amt, minToken1Amt);
+  }
+
+  /// @dev sets the smart collateral providers.
+  /// @dev allows the contract to receive native BNB, e.g. when redeeming slisBNB/BNB LP.
+  /// @param providers The array of smart collateral providers.
+  /// @param status The status of the providers.
+  function batchSetSmartProviders(address[] calldata providers, bool status) external onlyRole(MANAGER) {
+    for (uint256 i = 0; i < providers.length; i++) {
+      address provider = providers[i];
+      smartProviders[provider] = status;
+      emit SmartProvidersChanged(provider, status);
+    }
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/src/liquidator/BrokerLiquidator.sol
+++ b/src/liquidator/BrokerLiquidator.sol
@@ -285,4 +285,7 @@ contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerL
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+  /// @dev allows the contract to receive native BNB, e.g. when redeeming slisBNB/BNB LP.
+  receive() external payable {}
 }

--- a/src/liquidator/BrokerLiquidator.sol
+++ b/src/liquidator/BrokerLiquidator.sol
@@ -36,6 +36,8 @@ contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerL
 
   bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
   bytes32 public constant BOT = keccak256("BOT"); // manager role
+  /// @dev sentinel address representing native BNB
+  address public constant BNB_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
   event TokenWhitelistChanged(address indexed token, bool added);
   event MarketWhitelistChanged(bytes32 id, address broker, bool added);
@@ -175,6 +177,41 @@ contract BrokerLiquidator is UUPSUpgradeable, AccessControlUpgradeable, IBrokerL
     SafeTransferLib.safeApprove(tokenIn, pair, 0);
 
     emit SellToken(pair, tokenIn, tokenOut, actualAmountIn, actualAmountOut);
+  }
+
+  /// @dev sell native BNB for a token.
+  /// @param pair The address of the pair.
+  /// @param tokenOut The address of the output token.
+  /// @param amountIn The amount of BNB to sell.
+  /// @param amountOutMin The minimum amount to receive.
+  /// @param swapData The swap data.
+  function sellBNB(
+    address pair,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOutMin,
+    bytes calldata swapData
+  ) external onlyRole(BOT) {
+    require(tokenWhitelist[BNB_ADDRESS], NotWhitelisted());
+    require(tokenWhitelist[tokenOut], NotWhitelisted());
+    require(pairWhitelist[pair], NotWhitelisted());
+    require(amountIn > 0, "amountIn zero");
+
+    require(address(this).balance >= amountIn, ExceedAmount());
+
+    uint256 beforeTokenIn = address(this).balance;
+    uint256 beforeTokenOut = SafeTransferLib.balanceOf(tokenOut, address(this));
+
+    (bool success, ) = pair.call{ value: amountIn }(swapData);
+    require(success, SwapFailed());
+
+    uint256 actualAmountIn = beforeTokenIn - address(this).balance;
+    uint256 actualAmountOut = SafeTransferLib.balanceOf(tokenOut, address(this)) - beforeTokenOut;
+
+    require(actualAmountIn <= amountIn, ExceedAmount());
+    require(actualAmountOut >= amountOutMin, NoProfit());
+
+    emit SellToken(pair, BNB_ADDRESS, tokenOut, actualAmountIn, actualAmountOut);
   }
 
   /// @dev flash liquidates a position.

--- a/src/liquidator/IBrokerLiquidator.sol
+++ b/src/liquidator/IBrokerLiquidator.sol
@@ -38,6 +38,14 @@ interface IBrokerLiquidator {
     bytes calldata swapData
   ) external;
 
+  function sellBNB(
+    address pair,
+    address tokenOut,
+    uint256 amountIn,
+    uint256 amountOutMin,
+    bytes calldata swapData
+  ) external;
+
   function setTokenWhitelist(address token, bool status) external;
 
   function setMarketToBroker(bytes32 id, address broker, bool status) external;

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -29,6 +29,7 @@ import { MathLib, WAD } from "moolah/libraries/MathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
 import { IMoolahLiquidateCallback } from "../../src/moolah/interfaces/IMoolahCallbacks.sol";
 import { BrokerLiquidator } from "../../src/liquidator/BrokerLiquidator.sol";
+import { MockOneInch } from "../liquidator/mocks/MockOneInch.sol";
 import { ORACLE_PRICE_SCALE, LIQUIDATION_CURSOR, MAX_LIQUIDATION_INCENTIVE_FACTOR } from "moolah/libraries/ConstantsLib.sol";
 
 contract LendingBrokerTest is Test {
@@ -1719,6 +1720,169 @@ contract LendingBrokerTest is Test {
     bnbBroker.borrow(1000 ether);
     bnbBroker.repay{ value: 1 ether }(1 ether, borrower);
     vm.stopPrank();
+  }
+
+  // -----------------------------
+  // sellToken / sellBNB (liquidator)
+  // -----------------------------
+
+  address constant LIQ_BNB = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+  /// @dev deploys an aggregator mock and whitelists BNB/BTCB/LISUSD + the pair on the liquidator.
+  function _setupLiquidatorSwap() internal returns (MockOneInch oneInch) {
+    oneInch = new MockOneInch();
+    vm.startPrank(MANAGER);
+    liquidator.setTokenWhitelist(LIQ_BNB, true);
+    liquidator.setTokenWhitelist(address(BTCB), true);
+    liquidator.setTokenWhitelist(address(LISUSD), true);
+    liquidator.setPairWhitelist(address(oneInch), true);
+    vm.stopPrank();
+  }
+
+  function test_sellBNB_swapsBnbToToken() public {
+    MockOneInch oneInch = _setupLiquidatorSwap();
+    uint256 amountIn = 1 ether;
+    uint256 amountOut = 300 ether;
+    vm.deal(address(liquidator), amountIn);
+
+    vm.prank(BOT);
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      amountIn,
+      amountOut,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), amountIn, amountOut)
+    );
+
+    assertEq(LISUSD.balanceOf(address(liquidator)), amountOut, "loanToken balance");
+    assertEq(address(liquidator).balance, 0, "BNB balance should be spent");
+  }
+
+  function test_sellBNB_revertsForNonBot() public {
+    MockOneInch oneInch = _setupLiquidatorSwap();
+    uint256 amountIn = 1 ether;
+    vm.deal(address(liquidator), amountIn);
+
+    vm.expectRevert();
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      amountIn,
+      1 ether,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), amountIn, uint256(1 ether))
+    );
+  }
+
+  function test_sellBNB_revertsWhenBnbNotWhitelisted() public {
+    MockOneInch oneInch = new MockOneInch();
+    vm.startPrank(MANAGER);
+    liquidator.setTokenWhitelist(address(LISUSD), true);
+    liquidator.setPairWhitelist(address(oneInch), true);
+    vm.stopPrank();
+
+    uint256 amountIn = 1 ether;
+    vm.deal(address(liquidator), amountIn);
+
+    vm.prank(BOT);
+    vm.expectRevert(BrokerLiquidator.NotWhitelisted.selector);
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      amountIn,
+      1 ether,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), amountIn, uint256(1 ether))
+    );
+  }
+
+  function test_sellBNB_revertsWhenPairNotWhitelisted() public {
+    MockOneInch oneInch = new MockOneInch();
+    vm.startPrank(MANAGER);
+    liquidator.setTokenWhitelist(LIQ_BNB, true);
+    liquidator.setTokenWhitelist(address(LISUSD), true);
+    vm.stopPrank();
+
+    uint256 amountIn = 1 ether;
+    vm.deal(address(liquidator), amountIn);
+
+    vm.prank(BOT);
+    vm.expectRevert(BrokerLiquidator.NotWhitelisted.selector);
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      amountIn,
+      1 ether,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), amountIn, uint256(1 ether))
+    );
+  }
+
+  function test_sellBNB_revertsOnZeroAmount() public {
+    MockOneInch oneInch = _setupLiquidatorSwap();
+    vm.prank(BOT);
+    vm.expectRevert("amountIn zero");
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      0,
+      0,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), uint256(0), uint256(0))
+    );
+  }
+
+  function test_sellBNB_revertsWhenBalanceInsufficient() public {
+    MockOneInch oneInch = _setupLiquidatorSwap();
+    uint256 amountIn = 1 ether;
+    // liquidator holds only half of amountIn
+    vm.deal(address(liquidator), amountIn / 2);
+
+    vm.prank(BOT);
+    vm.expectRevert(BrokerLiquidator.ExceedAmount.selector);
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      amountIn,
+      1 ether,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), amountIn, uint256(1 ether))
+    );
+  }
+
+  function test_sellBNB_revertsWhenOutputBelowMin() public {
+    MockOneInch oneInch = _setupLiquidatorSwap();
+    uint256 amountIn = 1 ether;
+    uint256 swapOut = 300 ether; // what the aggregator actually returns
+    uint256 amountOutMin = swapOut + 1; // require more than returned
+
+    vm.deal(address(liquidator), amountIn);
+
+    vm.prank(BOT);
+    vm.expectRevert(BrokerLiquidator.NoProfit.selector);
+    liquidator.sellBNB(
+      address(oneInch),
+      address(LISUSD),
+      amountIn,
+      amountOutMin,
+      abi.encodeWithSelector(oneInch.swap.selector, LIQ_BNB, address(LISUSD), amountIn, swapOut)
+    );
+  }
+
+  function test_sellToken_swapsTokenToToken() public {
+    MockOneInch oneInch = _setupLiquidatorSwap();
+    uint256 amountIn = 1 ether;
+    uint256 amountOut = 300 ether;
+    BTCB.setBalance(address(liquidator), amountIn);
+
+    vm.prank(BOT);
+    liquidator.sellToken(
+      address(oneInch),
+      address(BTCB),
+      address(LISUSD),
+      amountIn,
+      amountOut,
+      abi.encodeWithSelector(oneInch.swap.selector, address(BTCB), address(LISUSD), amountIn, amountOut)
+    );
+
+    assertEq(LISUSD.balanceOf(address(liquidator)), amountOut, "loanToken balance");
+    assertEq(BTCB.balanceOf(address(liquidator)), 0, "tokenIn spent");
+    assertEq(BTCB.allowance(address(liquidator), address(oneInch)), 0, "allowance reset");
   }
 }
 

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -248,7 +248,7 @@ contract LendingBrokerTest is Test {
       address(mockLiqImpl),
       abi.encodeWithSelector(BrokerLiquidator.initialize.selector, ADMIN, MANAGER, BOT)
     );
-    liquidator = BrokerLiquidator(address(mockLiqProxy));
+    liquidator = BrokerLiquidator(payable(address(mockLiqProxy)));
 
     // whitelist lendingbroker as liquidator in moolah
     Id[] memory ids = new Id[](2);

--- a/test/moolah/MarketFactoryTest.sol
+++ b/test/moolah/MarketFactoryTest.sol
@@ -84,7 +84,7 @@ contract MarketFactoryTest is Test {
       address(brokerLiquidatorImpl),
       abi.encodeWithSelector(brokerLiquidatorImpl.initialize.selector, admin, manager, bot)
     );
-    brokerLiquidator = BrokerLiquidator(address(brokerLiquidatorProxy));
+    brokerLiquidator = BrokerLiquidator(payable(address(brokerLiquidatorProxy)));
 
     liquidator = new MockLiquidator();
     publicLiquidator = new MockLiquidator();


### PR DESCRIPTION

## 📄 Summary

The `BrokerLiquidator` contract lacked a `receive()` function. During liquidation flows that redeem slisBNB/BNB LP, the contract receives native BNB, and the transfer would revert without a payable receive — causing the liquidation transaction to fail.


## 🧬 Changes Summary
Notable changes:
*src/liquidator/BrokerLiquidator.sol:289 — Added `receive() external payable {}`
* Fix tests and script