### PR TITLE
feat: add CollateralYieldVault + RewardHarvester

### DIFF
--- a/script/collateralYieldVault/deploy_collateral_yield_vault.sol
+++ b/script/collateralYieldVault/deploy_collateral_yield_vault.sol
@@ -65,7 +65,6 @@ contract DeployCollateralYieldVault is DeployBase {
     require(vault.asset() == SLIS_BNB, "asset mismatch");
 
     // 2. delegate slisBNBx to the governance-approved MPC.
-    vault.addDelegateTarget(MPC1);
     vault.setDelegateTarget(MPC1);
 
     // 3. dead seed deposit: keeps totalSupply > 0 forever (whitelist still empty == open here).

--- a/script/collateralYieldVault/deploy_collateral_yield_vault.sol
+++ b/script/collateralYieldVault/deploy_collateral_yield_vault.sol
@@ -67,7 +67,9 @@ contract DeployCollateralYieldVault is DeployBase {
     // 2. delegate slisBNBx to the governance-approved MPC.
     vault.setDelegateTarget(MPC1);
 
-    // 3. dead seed deposit: keeps totalSupply > 0 forever (whitelist still empty == open here).
+    // 3. dead seed deposit (NOTICE): governance makes the FIRST deposit so any pre-genesis donation is absorbed
+    //    into unredeemable dead shares instead of poisoning the rate; also keeps totalSupply > 0 forever. A donation
+    //    large enough to round this to 0 shares reverts (depositBNB zero-share guard) → redeploy with larger SEED_BNB.
     uint256 seedShares = vault.depositBNB{ value: SEED_BNB }(DEAD);
     console.log("Seed shares minted to dead address:", seedShares);
     require(vault.totalSupply() == seedShares && seedShares > 0, "seed failed");

--- a/script/collateralYieldVault/deploy_collateral_yield_vault.sol
+++ b/script/collateralYieldVault/deploy_collateral_yield_vault.sol
@@ -1,0 +1,88 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { MarketParams } from "moolah/interfaces/IMoolah.sol";
+import { CollateralYieldVault } from "src/moolah-vault/CollateralYieldVault.sol";
+
+/// @notice Deploys a CollateralYieldVault (asset = slisBNB) behind a UUPS proxy and seeds a dead first deposit
+///         so `totalSupply` is never 0 (first-deposit inflation + last-redeemer dust mitigation).
+///
+/// Prerequisites (must already be true on-chain, else the seed step reverts):
+///   - The slisBNB-collateral Moolah market exists and `SLIS_BNB_PROVIDER` is its registered provider.
+///   - The vault is allowed as `onBehalf` on that market (Moolah market onBehalf whitelist is open or includes it).
+///   - The provider's `slisBNBxMinter` is set and has spare MPC fee-wallet capacity.
+contract DeployCollateralYieldVault is DeployBase {
+  // --- BSC mainnet ---
+  address constant SLIS_BNB_PROVIDER = 0x33f7A980a246f9B8FEA2254E3065576E127D4D5f;
+  address constant SLIS_BNB = 0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B;
+  address constant WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+  address constant SLISBNB_ORACLE = 0x21650E416dC6C89486B2E654c86cC2c36c597b58;
+  address constant IRM = 0xFe7dAe87Ebb11a7BEB9F534BB23267992d9cDe7c;
+  uint256 constant LLTV = 965000000000000000; // 0.965e18
+
+  // roles handed over after configuration
+  address constant TIMELOCK = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253; // DEFAULT_ADMIN
+  address constant VAULT_MANAGER = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // MANAGER
+  address constant PAUSER = 0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8; // PAUSER
+
+  // launchpool MPC (delegate target) — must be governance-approved
+  address constant MPC1 = 0xD57E5321e67607Fab38347D96394e0E58509C506;
+
+  // dead first deposit (BNB → slisBNB), shares minted to a burn address and never redeemed
+  address constant DEAD = 0x000000000000000000000000000000000000dEaD;
+  uint256 constant SEED_BNB = 0.02 ether;
+
+  string constant NAME = "Four.meme slisBNB Vault";
+  string constant SYMBOL = "fmSlisBNB";
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer:", deployer);
+
+    MarketParams memory market = MarketParams({
+      loanToken: WBNB,
+      collateralToken: SLIS_BNB,
+      oracle: SLISBNB_ORACLE,
+      irm: IRM,
+      lltv: LLTV
+    });
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // 1. deploy impl + proxy; deployer is temporary admin + manager so it can configure & seed.
+    CollateralYieldVault impl = new CollateralYieldVault(SLIS_BNB_PROVIDER);
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(CollateralYieldVault.initialize.selector, deployer, deployer, PAUSER, market, NAME, SYMBOL)
+    );
+    CollateralYieldVault vault = CollateralYieldVault(payable(address(proxy)));
+    console.log("CollateralYieldVault impl:", address(impl));
+    console.log("CollateralYieldVault proxy:", address(vault));
+    require(vault.asset() == SLIS_BNB, "asset mismatch");
+
+    // 2. delegate slisBNBx to the governance-approved MPC.
+    vault.addDelegateTarget(MPC1);
+    vault.setDelegateTarget(MPC1);
+
+    // 3. dead seed deposit: keeps totalSupply > 0 forever (whitelist still empty == open here).
+    uint256 seedShares = vault.depositBNB{ value: SEED_BNB }(DEAD);
+    console.log("Seed shares minted to dead address:", seedShares);
+    require(vault.totalSupply() == seedShares && seedShares > 0, "seed failed");
+
+    // 4. hand over roles to governance and drop the deployer's powers.
+    vault.grantRole(vault.MANAGER(), VAULT_MANAGER);
+    vault.grantRole(vault.DEFAULT_ADMIN_ROLE(), TIMELOCK);
+    vault.renounceRole(vault.MANAGER(), deployer);
+    vault.renounceRole(vault.DEFAULT_ADMIN_ROLE(), deployer);
+
+    vm.stopBroadcast();
+
+    console.log("Done. Remaining steps for governance:");
+    console.log(" - populate user whitelist (setWhiteList) if access is gated");
+    console.log(" - deploy RewardHarvester and grant it the BOT role (grantRole BOT, harvester)");
+  }
+}

--- a/src/dex/interfaces/IStableSwap.sol
+++ b/src/dex/interfaces/IStableSwap.sol
@@ -56,6 +56,8 @@ interface IStableSwap {
 
   function remove_liquidity_one_coin(uint256 _token_amount, uint256 i, uint256 min_amount) external;
 
+  function exchange(uint256 i, uint256 j, uint256 dx, uint256 min_dy) external payable;
+
   function withdraw_admin_fees() external;
 
   // events

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -413,7 +413,8 @@ contract CollateralYieldVault is
     super._withdraw(caller, receiver, owner, assets, shares);
   }
 
-  /// @dev Restrict share transfers to whitelisted holders (mint/burn always allowed).
+  /// @dev When the whitelist is active, share transfers are allowed only between whitelisted holders — BOTH sender
+  ///      and receiver must be listed (mint/burn always allowed). Empty whitelist == open.
   function _update(address from, address to, uint256 value) internal override {
     if (from != address(0) && to != address(0)) {
       require(isWhiteList(from) && isWhiteList(to), ErrorsLib.NotWhiteList());

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -9,7 +9,7 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { IMoolah, MarketParams, Market, Id } from "moolah/interfaces/IMoolah.sol";
 import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { WAD } from "moolah/libraries/MathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
@@ -97,6 +97,8 @@ contract CollateralYieldVault is
 
   error ZeroAmount();
   error SharesOutstanding();
+  error MarketNotCreated();
+  error ProviderNotRegistered();
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(address _provider) {
@@ -127,6 +129,12 @@ contract CollateralYieldVault is
   ) external initializer {
     if (admin == address(0) || manager == address(0) || pauser == address(0)) revert ErrorsLib.ZeroAddress();
     if (_marketParams.collateralToken != SLIS_BNB) revert ErrorsLib.TokenMismatch();
+    // Fail fast on a misconfigured market: it must exist on Moolah and have PROVIDER registered as its slisBNB
+    // collateral provider, otherwise every supply/withdraw (and thus the whole vault) would be bricked or NAV
+    // would silently under-report. The market params are immutable after this, so validate them here.
+    Id id = _marketParams.id();
+    if (MOOLAH.market(id).lastUpdate == 0) revert MarketNotCreated();
+    if (MOOLAH.providers(id, SLIS_BNB) != address(PROVIDER)) revert ProviderNotRegistered();
 
     __AccessControl_init();
     __ReentrancyGuard_init();

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -9,7 +9,8 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { MarketParams } from "moolah/interfaces/IMoolah.sol";
+import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { WAD } from "moolah/libraries/MathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
 import { ConstantsLib } from "./libraries/ConstantsLib.sol";
@@ -41,6 +42,7 @@ contract CollateralYieldVault is
   using UtilsLib for uint256;
   using SafeERC20 for IERC20;
   using EnumerableSet for EnumerableSet.AddressSet;
+  using MarketParamsLib for MarketParams;
 
   /* IMMUTABLES */
 
@@ -50,6 +52,8 @@ contract CollateralYieldVault is
   IStakeManager public immutable STAKE_MANAGER;
   /// @notice SlisBNBProvider that holds the Moolah collateral position on behalf of this vault.
   ISlisBnbProvider public immutable PROVIDER;
+  /// @notice Moolah lending market contract, read from the provider at construction.
+  IMoolah public immutable MOOLAH;
 
   /* ROLES */
 
@@ -101,6 +105,7 @@ contract CollateralYieldVault is
     // slisBNBxMinter is read dynamically at use (the provider may re-set it).
     SLIS_BNB = PROVIDER.TOKEN();
     STAKE_MANAGER = IStakeManager(PROVIDER.STAKE_MANAGER());
+    MOOLAH = IMoolah(PROVIDER.MOOLAH());
     // asset is always slisBNB (18 decimals) => ERC4626 decimals offset is 0 (the inherited default).
   }
 
@@ -150,6 +155,7 @@ contract CollateralYieldVault is
     uint256 newTotalAssets = _accrueFee();
     lastTotalAssets = newTotalAssets;
     shares = _convertToSharesWithTotals(assets, totalSupply(), newTotalAssets, Math.Rounding.Floor);
+    if (shares == 0) revert ZeroAmount();
     _deposit(_msgSender(), receiver, assets, shares);
   }
 
@@ -238,19 +244,25 @@ contract CollateralYieldVault is
   /* VIEWS */
 
   /// @inheritdoc IERC4626
-  /// @dev NAV = the vault's slisBNB collateral tracked by the provider. Note: an external party can raise this by
-  ///      calling `SlisBNBProvider.supplyCollateral(onBehalf=vault)` (a donation that benefits holders).
+  /// @dev NAV = the vault's slisBNB collateral in *this exact Moolah market*, read live from Moolah. Reading the
+  ///      per-market position (not the provider's cross-market `userTotalDeposit`) ensures NAV only ever reflects
+  ///      collateral that the vault can actually withdraw from this market, so slisBNB the vault supplies to any
+  ///      other market cannot inflate the share price. Note: an external party can still raise this by calling
+  ///      `SlisBNBProvider.supplyCollateral(onBehalf=vault)` against this market (a donation that benefits holders).
   function totalAssets() public view override returns (uint256) {
-    return PROVIDER.userTotalDeposit(address(this));
+    return MOOLAH.position(marketParams.id(), address(this)).collateral;
   }
 
+  /// @dev Mirrors the deposit gate (`whenNotPaused` + `_checkWhiteList`): a deposit reverts unless BOTH the caller
+  ///      and the receiver are whitelisted, so reflect the `_msgSender()` whitelist here too.
   function maxDeposit(address receiver) public view override returns (uint256) {
-    if (paused() || !isWhiteList(receiver)) return 0;
+    if (paused() || !isWhiteList(_msgSender()) || !isWhiteList(receiver)) return 0;
     return type(uint256).max;
   }
 
+  /// @dev See {maxDeposit}: reflects both the caller and receiver whitelist so it cannot signal a mint that reverts.
   function maxMint(address receiver) public view override returns (uint256) {
-    if (paused() || !isWhiteList(receiver)) return 0;
+    if (paused() || !isWhiteList(_msgSender()) || !isWhiteList(receiver)) return 0;
     return type(uint256).max;
   }
 

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -29,6 +29,8 @@ import { ICollateralYieldVault } from "./interfaces/ICollateralYieldVault.sol";
 ///         (BOT-only) which stakes BNB->slisBNB, supplies it, and raises the share price. Performance fee follows the
 ///         MoolahVault model (fee-share dilution, high-water `lastTotalAssets`); `fee` is 0 at launch.
 ///         The vault is client-agnostic: per-deployment branding lives only in the token name/symbol.
+/// @dev NOTICE: correctness depends on the underlying SlisBNBProvider / SlisBNBxMinter / Moolah config staying
+///      consistent. Deregistering the provider from the market would lock collateral; governance must manage these.
 contract CollateralYieldVault is
   UUPSUpgradeable,
   AccessControlEnumerableUpgradeable,
@@ -222,6 +224,8 @@ contract CollateralYieldVault is
   ///         the increment. Mints no user shares => share price rises. Initial `fee` = 0 => increment fully accrues
   ///         to holders. Only the slisBNB minted from this call's `msg.value` is compounded (measured as a balance
   ///         delta), so any unrelated slisBNB sitting in the vault is never swept into the position here.
+  /// @dev NOTICE: rewards injected while totalSupply == 0 accrue to the virtual shares. The deploy-time dead-seed
+  ///      first deposit keeps supply > 0, so this state is not reached in practice.
   function increaseVaultAssets() external payable override onlyRole(BOT) nonReentrant whenNotPaused {
     if (msg.value == 0) revert ZeroAmount();
 
@@ -267,6 +271,8 @@ contract CollateralYieldVault is
   }
 
   /// @notice If the whitelist is empty it is treated as open (everyone allowed).
+  /// @dev NOTICE: intentional — launches with the whitelist OFF (open). Enabling it later is a deliberate
+  ///      governance action that, by design, then restricts existing non-listed holders.
   function isWhiteList(address account) public view returns (bool) {
     return userWhiteList.length() == 0 || userWhiteList.contains(account);
   }
@@ -277,13 +283,15 @@ contract CollateralYieldVault is
 
   /* MANAGER: FEE */
 
-  function setFee(uint256 newFee) external onlyRole(MANAGER) {
+  /// @dev NOTICE: `_accrueFee()` charges the old rate on NAV realized so far, but rewards already in the harvester
+  ///      yet not compounded will be charged at the new rate. Bounded by `MAX_FEE`; MANAGER is trusted.
+  function setFee(uint96 newFee) external onlyRole(MANAGER) {
     if (newFee == fee) revert ErrorsLib.AlreadySet();
     if (newFee > ConstantsLib.MAX_FEE) revert ErrorsLib.MaxFeeExceeded();
     if (newFee != 0 && feeRecipient == address(0)) revert ErrorsLib.ZeroFeeRecipient();
 
     _updateLastTotalAssets(_accrueFee());
-    fee = uint96(newFee);
+    fee = newFee;
     emit SetFee(_msgSender(), newFee);
   }
 
@@ -331,8 +339,8 @@ contract CollateralYieldVault is
     if (amount > 0) {
       PROVIDER.withdrawCollateral(marketParams, amount, address(this), to);
       _updateLastTotalAssets(0);
+      emit Swept(to, amount);
     }
-    emit Swept(to, amount);
   }
 
   /// @notice Recover stray tokens / native BNB held by the vault (e.g. directly-donated slisBNB that
@@ -360,11 +368,16 @@ contract CollateralYieldVault is
 
   /* INTERNAL: ERC4626 hooks */
 
+  /// @dev NOTICE: both caller and receiver must be whitelisted, so gasless/meta-tx relayers cannot deposit on a
+  ///      user's behalf (a whitelisted relayer would let anyone bypass the list). Strict by design.
   function _checkWhiteList(address receiver) private view {
     require(isWhiteList(_msgSender()) && isWhiteList(receiver), ErrorsLib.NotWhiteList());
   }
 
   /// @dev super._deposit pulls slisBNB from caller and mints shares; then supply it as collateral.
+  /// @dev NOTICE: supply/withdraw go through the provider's `_syncPosition` -> SlisBNBxMinter.rebalance. A pending
+  ///      module config change (feeRate up / discount down) or a frontrun that exhausts MPC mint cap can make this
+  ///      supply revert (EXCEED_MPC_CAP). Governance must keep MPC caps sufficient; monitor for grief attempts.
   function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
     super._deposit(caller, receiver, assets, shares);
     PROVIDER.supplyCollateral(marketParams, assets, address(this), "");
@@ -436,14 +449,17 @@ contract CollateralYieldVault is
   function _accrueFee() internal returns (uint256 newTotalAssets) {
     uint256 feeShares;
     (feeShares, newTotalAssets) = _accruedFeeShares();
-    if (feeShares != 0) _mint(feeRecipient, feeShares);
-    emit AccrueInterest(newTotalAssets, feeShares);
+    if (feeShares != 0) {
+      _mint(feeRecipient, feeShares);
+      emit AccrueInterest(newTotalAssets, feeShares);
+    }
   }
 
   function _accruedFeeShares() internal view returns (uint256 feeShares, uint256 newTotalAssets) {
     newTotalAssets = totalAssets();
     uint256 totalInterest = newTotalAssets.zeroFloorSub(lastTotalAssets);
     if (totalInterest != 0 && fee != 0) {
+      // NOTICE: rounds the fee down (favoring holders); negligible since totalInterest is BOT-injected, not dust.
       uint256 feeAssets = totalInterest.mulDiv(fee, WAD);
       feeShares = _convertToSharesWithTotals(feeAssets, totalSupply(), newTotalAssets - feeAssets, Math.Rounding.Floor);
     }

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -23,7 +23,7 @@ import { ICollateralYieldVault } from "./interfaces/ICollateralYieldVault.sol";
 /// @title CollateralYieldVault
 /// @author Lista DAO
 /// @notice ERC4626 vault (asset = slisBNB). Deposited slisBNB is supplied as Moolah collateral (no borrow) via
-///         SlisBNBProvider; the minted slisBNBx is 100% delegated to a governance-whitelisted MPC (`delegateTarget`)
+///         SlisBNBProvider; the minted slisBNBx is 100% delegated to a MANAGER-set MPC (`delegateTarget`)
 ///         that participates in launchpool. Launchpool BNB rewards are injected back through `increaseVaultAssets`
 ///         (BOT-only) which stakes BNB->slisBNB, supplies it, and raises the share price. Performance fee follows the
 ///         MoolahVault model (fee-share dilution, high-water `lastTotalAssets`); `fee` is 0 at launch.
@@ -60,12 +60,10 @@ contract CollateralYieldVault is
   /* STORAGE */
 
   /// @notice The Moolah market params whose collateralToken == slisBNB (no borrow performed).
-  MarketParams public marketParams;
+  MarketParams public marketParams; //slisBNB/BNB market
 
-  /// @notice Current delegate target (MPC participating in launchpool); must be in `allowedDelegateTargets`.
+  /// @notice Current delegate target (MPC participating in launchpool); MANAGER-set, must be non-zero.
   address public delegateTarget;
-  /// @notice Governance-maintained whitelist of allowed delegate targets (MPCs).
-  mapping(address => bool) public allowedDelegateTargets;
 
   /// @notice User whitelist; if non-empty, only listed addresses may deposit/hold shares.
   EnumerableSet.AddressSet private userWhiteList;
@@ -77,27 +75,20 @@ contract CollateralYieldVault is
   /// @notice High-water snapshot of total assets for fee accrual.
   uint256 public lastTotalAssets;
 
-  // TODO: future — route launchpool rewards through a lock/linear-release buffer so they accrue into NAV
-  //       gradually instead of in one `increaseVaultAssets` step (smooths the step-up, mitigates JIT front-running).
-  // address public buffer; // BrokerInterestLockBuffer
-
   /* EVENTS */
 
   event SetFee(address indexed caller, uint256 fee);
   event SetFeeRecipient(address indexed feeRecipient);
   event SetWhiteList(address indexed account, bool enabled);
-  event AddDelegateTarget(address indexed target);
-  event RemoveDelegateTarget(address indexed target);
   event SetDelegateTarget(address indexed target);
   event IncreaseVaultAssets(address indexed caller, uint256 bnbIn, uint256 slisDelta);
   event UpdateLastTotalAssets(uint256 lastTotalAssets);
   event AccrueInterest(uint256 newTotalAssets, uint256 feeShares);
   event Swept(address indexed to, uint256 amount);
+  event EmergencyWithdraw(address indexed token, address indexed to, uint256 amount);
 
   /* ERRORS */
 
-  error NotWhitelistedDelegate();
-  error SlippageExceeded();
   error ZeroAmount();
   error SharesOutstanding();
 
@@ -221,20 +212,22 @@ contract CollateralYieldVault is
 
   /* COMPOUND (BOT == RewardHarvester) */
 
-  /// @notice Inject launchpool reward BNB: stake to slisBNB, supply to the position, then accrue fee on the increment.
-  ///         Mints no user shares => share price rises. Initial `fee` = 0 => increment fully accrues to holders.
-  function increaseVaultAssets(uint256 minSlisOut) external payable override onlyRole(BOT) nonReentrant whenNotPaused {
-    if (msg.value > 0) STAKE_MANAGER.deposit{ value: msg.value }();
-    // Compound the vault's entire slisBNB balance: freshly-staked slisBNB plus any reward slisBNB sent directly.
-    // The vault holds no slisBNB between operations (deposits pull-then-supply atomically), so this is the reward.
-    uint256 slisAmount = IERC20(SLIS_BNB).balanceOf(address(this));
-    if (slisAmount == 0 || slisAmount < minSlisOut) revert SlippageExceeded();
+  /// @notice Inject launchpool reward BNB (`msg.value`): stake to slisBNB, supply to the position, then accrue fee on
+  ///         the increment. Mints no user shares => share price rises. Initial `fee` = 0 => increment fully accrues
+  ///         to holders. Only the slisBNB minted from this call's `msg.value` is compounded (measured as a balance
+  ///         delta), so any unrelated slisBNB sitting in the vault is never swept into the position here.
+  function increaseVaultAssets() external payable override onlyRole(BOT) nonReentrant whenNotPaused {
+    if (msg.value == 0) revert ZeroAmount();
 
-    PROVIDER.supplyCollateral(marketParams, slisAmount, address(this), "");
+    uint256 balBefore = IERC20(SLIS_BNB).balanceOf(address(this));
+    STAKE_MANAGER.deposit{ value: msg.value }();
+    uint256 slisDelta = IERC20(SLIS_BNB).balanceOf(address(this)) - balBefore;
+
+    PROVIDER.supplyCollateral(marketParams, slisDelta, address(this), "");
     // Inject first, accrue after: the increment is booked as interest and charged `fee` (0 at launch).
     _updateLastTotalAssets(_accrueFee());
 
-    emit IncreaseVaultAssets(_msgSender(), msg.value, slisAmount);
+    emit IncreaseVaultAssets(_msgSender(), msg.value, slisDelta);
   }
 
   /// @notice Permissionlessly crystallize accrued performance fee into fee shares (no-op while `fee == 0`).
@@ -307,7 +300,6 @@ contract CollateralYieldVault is
 
   function setDelegateTarget(address target) external onlyRole(MANAGER) {
     if (target == address(0)) revert ErrorsLib.ZeroAddress();
-    if (!allowedDelegateTargets[target]) revert NotWhitelistedDelegate();
     delegateTarget = target;
     // Redirect 100% of the vault's slisBNBx to the chosen MPC (minter read from the provider).
     ISlisBNBxMinter(PROVIDER.slisBNBxMinter()).delegateAllTo(target);
@@ -331,18 +323,20 @@ contract CollateralYieldVault is
     emit Swept(to, amount);
   }
 
-  /* ADMIN: DELEGATE WHITELIST + PAUSE */
-
-  function addDelegateTarget(address target) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    if (target == address(0)) revert ErrorsLib.ZeroAddress();
-    allowedDelegateTargets[target] = true;
-    emit AddDelegateTarget(target);
+  /// @notice Recover stray tokens / native BNB held by the vault (e.g. directly-donated slisBNB that
+  ///         `increaseVaultAssets` does not fold in). Does NOT touch the Moolah collateral position (which backs
+  ///         shares and is custodied by the provider/Moolah), so `totalAssets` is unaffected. MANAGER-only.
+  function emergencyWithdraw(uint256 amount, address token) external onlyRole(MANAGER) nonReentrant {
+    if (token == address(0)) {
+      (bool ok, ) = payable(_msgSender()).call{ value: amount }("");
+      require(ok, "BNB transfer failed");
+    } else {
+      IERC20(token).safeTransfer(_msgSender(), amount);
+    }
+    emit EmergencyWithdraw(token, _msgSender(), amount);
   }
 
-  function removeDelegateTarget(address target) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    allowedDelegateTargets[target] = false;
-    emit RemoveDelegateTarget(target);
-  }
+  /* PAUSER */
 
   function pause() external onlyRole(PAUSER) {
     _pause();
@@ -365,7 +359,8 @@ contract CollateralYieldVault is
     _updateLastTotalAssets(lastTotalAssets + assets);
   }
 
-  /// @dev Withdraws slisBNB from the Moolah position directly to `receiver` (no double transfer through the vault).
+  /// @dev Pull slisBNB out of the Moolah position into the vault, then let ERC4626 handle the
+  ///      allowance spend, share burn, asset transfer to `receiver`, and Withdraw event.
   function _withdraw(
     address caller,
     address receiver,
@@ -373,10 +368,8 @@ contract CollateralYieldVault is
     uint256 assets,
     uint256 shares
   ) internal override {
-    if (caller != owner) _spendAllowance(owner, caller, shares);
-    _burn(owner, shares);
-    PROVIDER.withdrawCollateral(marketParams, assets, address(this), receiver);
-    emit Withdraw(caller, receiver, owner, assets, shares);
+    PROVIDER.withdrawCollateral(marketParams, assets, address(this), address(this));
+    super._withdraw(caller, receiver, owner, assets, shares);
   }
 
   /// @dev Restrict share transfers to whitelisted holders (mint/burn always allowed).

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import { IERC20, IERC4626, ERC20Upgradeable, ERC4626Upgradeable, Math, SafeERC20 } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import { MarketParams } from "moolah/interfaces/IMoolah.sol";
+import { WAD } from "moolah/libraries/MathLib.sol";
+import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
+import { ConstantsLib } from "./libraries/ConstantsLib.sol";
+import { ErrorsLib } from "./libraries/ErrorsLib.sol";
+
+import { ISlisBnbProvider } from "../provider/interfaces/IProvider.sol";
+import { IStakeManager } from "../provider/interfaces/IStakeManager.sol";
+import { ISlisBNBxMinter } from "../utils/interfaces/ISlisBNBx.sol";
+import { ICollateralYieldVault } from "./interfaces/ICollateralYieldVault.sol";
+
+/// @title CollateralYieldVault
+/// @author Lista DAO
+/// @notice ERC4626 vault (asset = slisBNB). Deposited slisBNB is supplied as Moolah collateral (no borrow) via
+///         SlisBNBProvider; the minted slisBNBx is 100% delegated to a governance-whitelisted MPC (`delegateTarget`)
+///         that participates in launchpool. Launchpool BNB rewards are injected back through `increaseVaultAssets`
+///         (BOT-only) which stakes BNB->slisBNB, supplies it, and raises the share price. Performance fee follows the
+///         MoolahVault model (fee-share dilution, high-water `lastTotalAssets`); `fee` is 0 at launch.
+///         The vault is client-agnostic: per-deployment branding lives only in the token name/symbol.
+contract CollateralYieldVault is
+  UUPSUpgradeable,
+  AccessControlEnumerableUpgradeable,
+  ReentrancyGuardUpgradeable,
+  PausableUpgradeable,
+  ERC4626Upgradeable,
+  ERC20PermitUpgradeable,
+  ICollateralYieldVault
+{
+  using Math for uint256;
+  using UtilsLib for uint256;
+  using SafeERC20 for IERC20;
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  /* IMMUTABLES */
+
+  /// @notice slisBNB, the vault asset, read from the provider (`PROVIDER.TOKEN()`).
+  address public immutable SLIS_BNB;
+  /// @notice Lista StakeManager (BNB -> slisBNB), read from the provider at construction.
+  IStakeManager public immutable STAKE_MANAGER;
+  /// @notice SlisBNBProvider that holds the Moolah collateral position on behalf of this vault.
+  ISlisBnbProvider public immutable PROVIDER;
+
+  /* ROLES */
+
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant PAUSER = keccak256("PAUSER");
+  bytes32 public constant BOT = keccak256("BOT"); // held by RewardHarvester
+
+  /* STORAGE */
+
+  /// @notice The Moolah market params whose collateralToken == slisBNB (no borrow performed).
+  MarketParams public marketParams;
+
+  /// @notice Current delegate target (MPC participating in launchpool); must be in `allowedDelegateTargets`.
+  address public delegateTarget;
+  /// @notice Governance-maintained whitelist of allowed delegate targets (MPCs).
+  mapping(address => bool) public allowedDelegateTargets;
+
+  /// @notice User whitelist; if non-empty, only listed addresses may deposit/hold shares.
+  EnumerableSet.AddressSet private userWhiteList;
+
+  /// @notice Performance fee (WAD); 0 at launch. fee <= MAX_FEE.
+  uint96 public fee;
+  /// @notice Recipient of fee shares.
+  address public feeRecipient;
+  /// @notice High-water snapshot of total assets for fee accrual.
+  uint256 public lastTotalAssets;
+
+  // TODO: future — route launchpool rewards through a lock/linear-release buffer so they accrue into NAV
+  //       gradually instead of in one `increaseVaultAssets` step (smooths the step-up, mitigates JIT front-running).
+  // address public buffer; // BrokerInterestLockBuffer
+
+  /* EVENTS */
+
+  event SetFee(address indexed caller, uint256 fee);
+  event SetFeeRecipient(address indexed feeRecipient);
+  event SetWhiteList(address indexed account, bool enabled);
+  event AddDelegateTarget(address indexed target);
+  event RemoveDelegateTarget(address indexed target);
+  event SetDelegateTarget(address indexed target);
+  event IncreaseVaultAssets(address indexed caller, uint256 bnbIn, uint256 slisDelta);
+  event UpdateLastTotalAssets(uint256 lastTotalAssets);
+  event AccrueInterest(uint256 newTotalAssets, uint256 feeShares);
+
+  /* ERRORS */
+
+  error NotWhitelistedDelegate();
+  error SlippageExceeded();
+  error ZeroAmount();
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor(address _provider) {
+    if (_provider == address(0)) revert ErrorsLib.ZeroAddress();
+    _disableInitializers();
+    PROVIDER = ISlisBnbProvider(_provider);
+    // slisBNB (asset) and StakeManager are read from the provider's immutables;
+    // slisBNBxMinter is read dynamically at use (the provider may re-set it).
+    SLIS_BNB = PROVIDER.TOKEN();
+    STAKE_MANAGER = IStakeManager(PROVIDER.STAKE_MANAGER());
+    // asset is always slisBNB (18 decimals) => ERC4626 decimals offset is 0 (the inherited default).
+  }
+
+  /// @param admin DEFAULT_ADMIN_ROLE (timelock/governance).
+  /// @param manager MANAGER role.
+  /// @param pauser PAUSER role.
+  /// @param _marketParams Moolah market with collateralToken == slisBNB.
+  /// @param _name vault token name.
+  /// @param _symbol vault token symbol.
+  function initialize(
+    address admin,
+    address manager,
+    address pauser,
+    MarketParams calldata _marketParams,
+    string memory _name,
+    string memory _symbol
+  ) external initializer {
+    if (admin == address(0) || manager == address(0) || pauser == address(0)) revert ErrorsLib.ZeroAddress();
+    if (_marketParams.collateralToken != SLIS_BNB) revert ErrorsLib.TokenMismatch();
+
+    __AccessControl_init();
+    __ReentrancyGuard_init();
+    __Pausable_init();
+    __ERC4626_init(IERC20(SLIS_BNB));
+    __ERC20_init(_name, _symbol);
+    __ERC20Permit_init(_name);
+
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+    _grantRole(PAUSER, pauser);
+
+    marketParams = _marketParams;
+    // fee defaults to 0; feeRecipient unset until governance enables fee.
+
+    // Allow the provider to pull slisBNB on supply.
+    IERC20(SLIS_BNB).forceApprove(address(PROVIDER), type(uint256).max);
+  }
+
+  /* DEPOSIT (slisBNB) */
+
+  /// @inheritdoc IERC4626
+  function deposit(
+    uint256 assets,
+    address receiver
+  ) public override nonReentrant whenNotPaused returns (uint256 shares) {
+    _checkWhiteList(receiver);
+    uint256 newTotalAssets = _accrueFee();
+    lastTotalAssets = newTotalAssets;
+    shares = _convertToSharesWithTotals(assets, totalSupply(), newTotalAssets, Math.Rounding.Floor);
+    _deposit(_msgSender(), receiver, assets, shares);
+  }
+
+  /// @inheritdoc IERC4626
+  function mint(uint256 shares, address receiver) public override nonReentrant whenNotPaused returns (uint256 assets) {
+    _checkWhiteList(receiver);
+    uint256 newTotalAssets = _accrueFee();
+    lastTotalAssets = newTotalAssets;
+    assets = _convertToAssetsWithTotals(shares, totalSupply(), newTotalAssets, Math.Rounding.Ceil);
+    _deposit(_msgSender(), receiver, assets, shares);
+  }
+
+  /// @notice Convenience entry: deposit native BNB; the vault stakes it to slisBNB then supplies it.
+  function depositBNB(address receiver) external payable nonReentrant whenNotPaused returns (uint256 shares) {
+    _checkWhiteList(receiver);
+    if (msg.value == 0) revert ZeroAmount();
+
+    uint256 newTotalAssets = _accrueFee();
+    lastTotalAssets = newTotalAssets;
+
+    uint256 balBefore = IERC20(SLIS_BNB).balanceOf(address(this));
+    STAKE_MANAGER.deposit{ value: msg.value }();
+    uint256 assets = IERC20(SLIS_BNB).balanceOf(address(this)) - balBefore;
+
+    shares = _convertToSharesWithTotals(assets, totalSupply(), newTotalAssets, Math.Rounding.Floor);
+    if (shares == 0) revert ZeroAmount();
+
+    _mint(receiver, shares);
+    emit Deposit(_msgSender(), receiver, assets, shares);
+
+    PROVIDER.supplyCollateral(marketParams, assets, address(this), "");
+    _updateLastTotalAssets(newTotalAssets + assets);
+  }
+
+  /* REDEEM / WITHDRAW (slisBNB) */
+
+  /// @inheritdoc IERC4626
+  function withdraw(
+    uint256 assets,
+    address receiver,
+    address owner
+  ) public override nonReentrant returns (uint256 shares) {
+    uint256 newTotalAssets = _accrueFee();
+    shares = _convertToSharesWithTotals(assets, totalSupply(), newTotalAssets, Math.Rounding.Ceil);
+    _updateLastTotalAssets(newTotalAssets.zeroFloorSub(assets));
+    _withdraw(_msgSender(), receiver, owner, assets, shares);
+  }
+
+  /// @inheritdoc IERC4626
+  function redeem(
+    uint256 shares,
+    address receiver,
+    address owner
+  ) public override nonReentrant returns (uint256 assets) {
+    uint256 newTotalAssets = _accrueFee();
+    assets = _convertToAssetsWithTotals(shares, totalSupply(), newTotalAssets, Math.Rounding.Floor);
+    _updateLastTotalAssets(newTotalAssets.zeroFloorSub(assets));
+    _withdraw(_msgSender(), receiver, owner, assets, shares);
+  }
+
+  /* COMPOUND (BOT == RewardHarvester) */
+
+  /// @notice Inject launchpool reward BNB: stake to slisBNB, supply to the position, then accrue fee on the increment.
+  ///         Mints no user shares => share price rises. Initial `fee` = 0 => increment fully accrues to holders.
+  function increaseVaultAssets(uint256 minSlisOut) external payable override onlyRole(BOT) nonReentrant whenNotPaused {
+    if (msg.value > 0) STAKE_MANAGER.deposit{ value: msg.value }();
+    // Compound the vault's entire slisBNB balance: freshly-staked slisBNB plus any reward slisBNB sent directly.
+    // The vault holds no slisBNB between operations (deposits pull-then-supply atomically), so this is the reward.
+    uint256 slisAmount = IERC20(SLIS_BNB).balanceOf(address(this));
+    if (slisAmount == 0 || slisAmount < minSlisOut) revert SlippageExceeded();
+
+    PROVIDER.supplyCollateral(marketParams, slisAmount, address(this), "");
+    // Inject first, accrue after: the increment is booked as interest and charged `fee` (0 at launch).
+    _updateLastTotalAssets(_accrueFee());
+
+    emit IncreaseVaultAssets(_msgSender(), msg.value, slisAmount);
+  }
+
+  /// @notice Permissionlessly crystallize accrued performance fee into fee shares (no-op while `fee == 0`).
+  function accrueFee() external nonReentrant {
+    _updateLastTotalAssets(_accrueFee());
+  }
+
+  /* VIEWS */
+
+  /// @inheritdoc IERC4626
+  /// @dev NAV = the vault's slisBNB collateral tracked by the provider. Note: an external party can raise this by
+  ///      calling `SlisBNBProvider.supplyCollateral(onBehalf=vault)` (a donation that benefits holders).
+  function totalAssets() public view override returns (uint256) {
+    return PROVIDER.userTotalDeposit(address(this));
+  }
+
+  function maxDeposit(address receiver) public view override returns (uint256) {
+    if (paused() || !isWhiteList(receiver)) return 0;
+    return type(uint256).max;
+  }
+
+  function maxMint(address receiver) public view override returns (uint256) {
+    if (paused() || !isWhiteList(receiver)) return 0;
+    return type(uint256).max;
+  }
+
+  /// @notice If the whitelist is empty it is treated as open (everyone allowed).
+  function isWhiteList(address account) public view returns (bool) {
+    return userWhiteList.length() == 0 || userWhiteList.contains(account);
+  }
+
+  function getWhiteList() external view returns (address[] memory) {
+    return userWhiteList.values();
+  }
+
+  /* MANAGER: FEE */
+
+  function setFee(uint256 newFee) external onlyRole(MANAGER) {
+    if (newFee == fee) revert ErrorsLib.AlreadySet();
+    if (newFee > ConstantsLib.MAX_FEE) revert ErrorsLib.MaxFeeExceeded();
+    if (newFee != 0 && feeRecipient == address(0)) revert ErrorsLib.ZeroFeeRecipient();
+
+    _updateLastTotalAssets(_accrueFee());
+    fee = uint96(newFee);
+    emit SetFee(_msgSender(), newFee);
+  }
+
+  function setFeeRecipient(address newFeeRecipient) external onlyRole(MANAGER) {
+    if (newFeeRecipient == feeRecipient) revert ErrorsLib.AlreadySet();
+    if (newFeeRecipient == address(0) && fee != 0) revert ErrorsLib.ZeroFeeRecipient();
+
+    _updateLastTotalAssets(_accrueFee());
+    feeRecipient = newFeeRecipient;
+    emit SetFeeRecipient(newFeeRecipient);
+  }
+
+  /* MANAGER: USER WHITELIST */
+
+  function setWhiteList(address account, bool enabled) external onlyRole(MANAGER) {
+    if (account == address(0)) revert ErrorsLib.ZeroAddress();
+    if (enabled) {
+      if (!userWhiteList.add(account)) revert ErrorsLib.AlreadySet();
+    } else {
+      if (!userWhiteList.remove(account)) revert ErrorsLib.NotSet();
+    }
+    emit SetWhiteList(account, enabled);
+  }
+
+  /* MANAGER: DELEGATE TARGET (MPC) */
+
+  function setDelegateTarget(address target) external onlyRole(MANAGER) {
+    if (target == address(0)) revert ErrorsLib.ZeroAddress();
+    if (!allowedDelegateTargets[target]) revert NotWhitelistedDelegate();
+    delegateTarget = target;
+    // Redirect 100% of the vault's slisBNBx to the chosen MPC (minter read from the provider).
+    ISlisBNBxMinter(PROVIDER.slisBNBxMinter()).delegateAllTo(target);
+    emit SetDelegateTarget(target);
+  }
+
+  /* ADMIN: DELEGATE WHITELIST + PAUSE */
+
+  function addDelegateTarget(address target) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    if (target == address(0)) revert ErrorsLib.ZeroAddress();
+    allowedDelegateTargets[target] = true;
+    emit AddDelegateTarget(target);
+  }
+
+  function removeDelegateTarget(address target) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    allowedDelegateTargets[target] = false;
+    emit RemoveDelegateTarget(target);
+  }
+
+  function pause() external onlyRole(PAUSER) {
+    _pause();
+  }
+
+  function unpause() external onlyRole(PAUSER) {
+    _unpause();
+  }
+
+  /* INTERNAL: ERC4626 hooks */
+
+  function _checkWhiteList(address receiver) private view {
+    require(isWhiteList(_msgSender()) && isWhiteList(receiver), ErrorsLib.NotWhiteList());
+  }
+
+  /// @dev super._deposit pulls slisBNB from caller and mints shares; then supply it as collateral.
+  function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
+    super._deposit(caller, receiver, assets, shares);
+    PROVIDER.supplyCollateral(marketParams, assets, address(this), "");
+    _updateLastTotalAssets(lastTotalAssets + assets);
+  }
+
+  /// @dev Withdraws slisBNB from the Moolah position directly to `receiver` (no double transfer through the vault).
+  function _withdraw(
+    address caller,
+    address receiver,
+    address owner,
+    uint256 assets,
+    uint256 shares
+  ) internal override {
+    if (caller != owner) _spendAllowance(owner, caller, shares);
+    _burn(owner, shares);
+    PROVIDER.withdrawCollateral(marketParams, assets, address(this), receiver);
+    emit Withdraw(caller, receiver, owner, assets, shares);
+  }
+
+  /// @dev Restrict share transfers to whitelisted holders (mint/burn always allowed).
+  function _update(address from, address to, uint256 value) internal override {
+    if (from != address(0) && to != address(0)) {
+      require(isWhiteList(from) && isWhiteList(to), ErrorsLib.NotWhiteList());
+    }
+    super._update(from, to, value);
+  }
+
+  function decimals() public view override(ERC20Upgradeable, ERC4626Upgradeable) returns (uint8) {
+    return ERC4626Upgradeable.decimals();
+  }
+
+  /* INTERNAL: conversions with fee */
+
+  function _convertToShares(uint256 assets, Math.Rounding rounding) internal view override returns (uint256) {
+    (uint256 feeShares, uint256 newTotalAssets) = _accruedFeeShares();
+    return _convertToSharesWithTotals(assets, totalSupply() + feeShares, newTotalAssets, rounding);
+  }
+
+  function _convertToAssets(uint256 shares, Math.Rounding rounding) internal view override returns (uint256) {
+    (uint256 feeShares, uint256 newTotalAssets) = _accruedFeeShares();
+    return _convertToAssetsWithTotals(shares, totalSupply() + feeShares, newTotalAssets, rounding);
+  }
+
+  function _convertToSharesWithTotals(
+    uint256 assets,
+    uint256 newTotalSupply,
+    uint256 newTotalAssets,
+    Math.Rounding rounding
+  ) internal view returns (uint256) {
+    return assets.mulDiv(newTotalSupply + 1, newTotalAssets + 1, rounding);
+  }
+
+  function _convertToAssetsWithTotals(
+    uint256 shares,
+    uint256 newTotalSupply,
+    uint256 newTotalAssets,
+    Math.Rounding rounding
+  ) internal view returns (uint256) {
+    return shares.mulDiv(newTotalAssets + 1, newTotalSupply + 1, rounding);
+  }
+
+  /* INTERNAL: fee */
+
+  function _updateLastTotalAssets(uint256 updatedTotalAssets) internal {
+    lastTotalAssets = updatedTotalAssets;
+    emit UpdateLastTotalAssets(updatedTotalAssets);
+  }
+
+  function _accrueFee() internal returns (uint256 newTotalAssets) {
+    uint256 feeShares;
+    (feeShares, newTotalAssets) = _accruedFeeShares();
+    if (feeShares != 0) _mint(feeRecipient, feeShares);
+    emit AccrueInterest(newTotalAssets, feeShares);
+  }
+
+  function _accruedFeeShares() internal view returns (uint256 feeShares, uint256 newTotalAssets) {
+    newTotalAssets = totalAssets();
+    uint256 totalInterest = newTotalAssets.zeroFloorSub(lastTotalAssets);
+    if (totalInterest != 0 && fee != 0) {
+      uint256 feeAssets = totalInterest.mulDiv(fee, WAD);
+      feeShares = _convertToSharesWithTotals(feeAssets, totalSupply(), newTotalAssets - feeAssets, Math.Rounding.Floor);
+    }
+  }
+
+  function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -167,6 +167,7 @@ contract CollateralYieldVault is
     uint256 newTotalAssets = _accrueFee();
     lastTotalAssets = newTotalAssets;
     assets = _convertToAssetsWithTotals(shares, totalSupply(), newTotalAssets, Math.Rounding.Ceil);
+    if (assets == 0) revert ZeroAmount();
     _deposit(_msgSender(), receiver, assets, shares);
   }
 
@@ -175,8 +176,9 @@ contract CollateralYieldVault is
     _checkWhiteList(receiver);
     if (msg.value == 0) revert ZeroAmount();
 
+    // No interim `lastTotalAssets = newTotalAssets` write: nothing here reads it before the final
+    // `_updateLastTotalAssets(newTotalAssets + assets)` (unlike `deposit`/`mint`, whose `_deposit` reads it).
     uint256 newTotalAssets = _accrueFee();
-    lastTotalAssets = newTotalAssets;
 
     uint256 balBefore = IERC20(SLIS_BNB).balanceOf(address(this));
     STAKE_MANAGER.deposit{ value: msg.value }();
@@ -318,8 +320,12 @@ contract CollateralYieldVault is
 
   /* MANAGER: DELEGATE TARGET (MPC) */
 
+  /// @dev NOTICE: `target` must not be one of the minter's fee MPC wallets — delegating there corrupts the fee
+  ///      ledger (the switch's burn cannot tell fee tokens from delegated ones). The vault cannot enumerate those
+  ///      wallets via the minter interface, so governance must ensure this when choosing the target.
   function setDelegateTarget(address target) external onlyRole(MANAGER) {
     if (target == address(0)) revert ErrorsLib.ZeroAddress();
+    if (target == delegateTarget) revert ErrorsLib.AlreadySet(); // minter no-ops on same target; avoid misleading event
     delegateTarget = target;
     // Redirect 100% of the vault's slisBNBx to the chosen MPC (minter read from the provider).
     ISlisBNBxMinter(PROVIDER.slisBNBxMinter()).delegateAllTo(target);
@@ -332,6 +338,8 @@ contract CollateralYieldVault is
   ///         (last-redeemer rounding dust), and reset the vault to a clean empty state.
   /// @dev Gated on `totalSupply() == 0`: with no shares outstanding nothing backs user value, so this can never
   ///      touch share-backed funds. A deploy-time dead seed deposit keeps supply > 0 and prevents this state.
+  /// @dev NOTICE: under the intended dead-seed deployment supply never returns to 0, so this is effectively
+  ///      unreachable. Retained intentionally as a safety net for non-seeded/edge deployments; left as-is.
   function sweep(address to) external onlyRole(MANAGER) nonReentrant returns (uint256 amount) {
     if (totalSupply() != 0) revert SharesOutstanding();
     if (to == address(0)) revert ErrorsLib.ZeroAddress();

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -92,12 +92,14 @@ contract CollateralYieldVault is
   event IncreaseVaultAssets(address indexed caller, uint256 bnbIn, uint256 slisDelta);
   event UpdateLastTotalAssets(uint256 lastTotalAssets);
   event AccrueInterest(uint256 newTotalAssets, uint256 feeShares);
+  event Swept(address indexed to, uint256 amount);
 
   /* ERRORS */
 
   error NotWhitelistedDelegate();
   error SlippageExceeded();
   error ZeroAmount();
+  error SharesOutstanding();
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(address _provider) {
@@ -310,6 +312,23 @@ contract CollateralYieldVault is
     // Redirect 100% of the vault's slisBNBx to the chosen MPC (minter read from the provider).
     ISlisBNBxMinter(PROVIDER.slisBNBxMinter()).delegateAllTo(target);
     emit SetDelegateTarget(target);
+  }
+
+  /* MANAGER: SWEEP */
+
+  /// @notice Recover residual collateral left in the position once every share has been redeemed
+  ///         (last-redeemer rounding dust), and reset the vault to a clean empty state.
+  /// @dev Gated on `totalSupply() == 0`: with no shares outstanding nothing backs user value, so this can never
+  ///      touch share-backed funds. A deploy-time dead seed deposit keeps supply > 0 and prevents this state.
+  function sweep(address to) external onlyRole(MANAGER) nonReentrant returns (uint256 amount) {
+    if (totalSupply() != 0) revert SharesOutstanding();
+    if (to == address(0)) revert ErrorsLib.ZeroAddress();
+    amount = totalAssets();
+    if (amount > 0) {
+      PROVIDER.withdrawCollateral(marketParams, amount, address(this), to);
+      _updateLastTotalAssets(0);
+    }
+    emit Swept(to, amount);
   }
 
   /* ADMIN: DELEGATE WHITELIST + PAUSE */

--- a/src/moolah-vault/interfaces/ICollateralYieldVault.sol
+++ b/src/moolah-vault/interfaces/ICollateralYieldVault.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+/// @title ICollateralYieldVault
+/// @author Lista DAO
+/// @notice Vault-specific entrypoint used by the RewardHarvester to inject launchpool rewards.
+interface ICollateralYieldVault {
+  /// @notice Stake injected BNB to slisBNB, supply it as collateral, and raise the share price (BOT-only).
+  function increaseVaultAssets(uint256 minSlisOut) external payable;
+}

--- a/src/moolah-vault/interfaces/ICollateralYieldVault.sol
+++ b/src/moolah-vault/interfaces/ICollateralYieldVault.sol
@@ -5,6 +5,6 @@ pragma solidity 0.8.34;
 /// @author Lista DAO
 /// @notice Vault-specific entrypoint used by the RewardHarvester to inject launchpool rewards.
 interface ICollateralYieldVault {
-  /// @notice Stake injected BNB to slisBNB, supply it as collateral, and raise the share price (BOT-only).
-  function increaseVaultAssets(uint256 minSlisOut) external payable;
+  /// @notice Stake injected BNB (`msg.value`) to slisBNB, supply it as collateral, and raise the share price (BOT-only).
+  function increaseVaultAssets() external payable;
 }

--- a/src/provider/interfaces/IProvider.sol
+++ b/src/provider/interfaces/IProvider.sol
@@ -28,6 +28,8 @@ interface ISlisBnbProvider is IProvider {
   function slisBNBxMinter() external view returns (address);
 
   function STAKE_MANAGER() external view returns (address);
+
+  function MOOLAH() external view returns (address);
 }
 interface ISmartProvider is IProvider {
   function dexLP() external view returns (address);

--- a/src/provider/interfaces/IProvider.sol
+++ b/src/provider/interfaces/IProvider.sol
@@ -8,13 +8,26 @@ interface IProvider {
 
   function TOKEN() external view returns (address);
 }
-interface ISlisBnbProvider {
+interface ISlisBnbProvider is IProvider {
   function supplyCollateral(
     MarketParams memory marketParams,
     uint256 assets,
     address onBehalf,
     bytes calldata data
   ) external;
+
+  function withdrawCollateral(
+    MarketParams memory marketParams,
+    uint256 assets,
+    address onBehalf,
+    address receiver
+  ) external;
+
+  function userTotalDeposit(address account) external view returns (uint256);
+
+  function slisBNBxMinter() external view returns (address);
+
+  function STAKE_MANAGER() external view returns (address);
 }
 interface ISmartProvider is IProvider {
   function dexLP() external view returns (address);

--- a/src/provider/interfaces/IStakeManager.sol
+++ b/src/provider/interfaces/IStakeManager.sol
@@ -2,6 +2,9 @@
 pragma solidity 0.8.34;
 
 interface IStakeManager {
+  /// @notice Stakes native BNB and mints slisBNB to msg.sender.
+  function deposit() external payable;
+
   function convertBnbToSnBnb(uint256 _amount) external view returns (uint256);
 
   function convertSnBnbToBnb(uint256 _amountInSlisBnb) external view returns (uint256);

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -32,7 +32,7 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
     bytes32[] proof;
   }
 
-  event Harvested(uint256 claimCount, uint256 bnbInjected, uint256 minSlisOut);
+  event Harvested(uint256 claimCount, uint256 bnbInjected);
   event Rescued(address indexed token, address indexed to, uint256 amount);
 
   error InsufficientReward();
@@ -57,14 +57,10 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
   }
 
   /// @notice Claim launchpool BNB for the given epochs (to this contract) and compound it into the vault.
-  /// @param claims Per-epoch claim data (epochId, amount, Merkle proof). `_account` is always this contract.
-  /// @param minBNBOut Minimum total BNB balance required after claiming (anti-anomaly).
-  /// @param minSlisOut Forwarded to the vault to bound the BNB->slisBNB stake result.
-  function harvest(
-    ClaimParams[] calldata claims,
-    uint256 minBNBOut,
-    uint256 minSlisOut
-  ) external onlyRole(BOT) nonReentrant {
+  /// @param claims Per-epoch claim data (epochId, amount, Merkle proof). `_account` is hardcoded to this contract,
+  ///        so the distributor pays the harvester directly and the BOT cannot redirect the funds.
+  /// @param minBNBOut Minimum total BNB balance required after claiming (anti-anomaly / sanity bound).
+  function harvest(ClaimParams[] calldata claims, uint256 minBNBOut) external onlyRole(BOT) nonReentrant {
     for (uint256 i; i < claims.length; ++i) {
       // Skip already-claimed epochs to keep the batch idempotent.
       if (DISTRIBUTOR.claimed(claims[i].epochId, address(this))) continue;
@@ -75,9 +71,9 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
     if (bnbBal == 0) revert NothingToCompound();
     if (bnbBal < minBNBOut) revert InsufficientReward();
 
-    VAULT.increaseVaultAssets{ value: bnbBal }(minSlisOut);
+    VAULT.increaseVaultAssets{ value: bnbBal }();
 
-    emit Harvested(claims.length, bnbBal, minSlisOut);
+    emit Harvested(claims.length, bnbBal);
   }
 
   /// @notice Emergency recovery of stranded tokens/BNB (e.g. a non-BNB reward token). Manager-only.

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -91,7 +91,9 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
   /// @dev NOTICE: since distributor claims are permissionless, MANAGER can claim all rewards here and drain them via
   ///      `rescue`. Use a strong multisig for the MANAGER role to mitigate key-compromise.
   function rescue(address token, address to, uint256 amount) external onlyRole(MANAGER) {
-    require(to != address(0), "zero to");
+    // Reject this contract as the recipient: a self-rescue would not move funds out, leaving them subject to the
+    // next harvest's full-balance compound while emitting a misleading Rescued event.
+    require(to != address(0) && to != address(this), "invalid to");
     if (token == address(0)) {
       (bool ok, ) = payable(to).call{ value: amount }("");
       require(ok, "bnb transfer failed");

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { IClisBNBLaunchPoolDistributor } from "./interfaces/IClisBNBLaunchPoolDistributor.sol";
+import { ICollateralYieldVault } from "../moolah-vault/interfaces/ICollateralYieldVault.sol";
+
+/// @title RewardHarvester
+/// @author Lista DAO
+/// @notice Intermediate contract for the CollateralYieldVault. The backend bot calls `harvest` to claim launchpool BNB
+///         rewards from the distributor (paid to THIS contract, as `_account` is hardcoded to `address(this)`), then
+///         injects the BNB into the vault via `increaseVaultAssets`. Claimed BNB can only flow into the vault.
+contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable, ReentrancyGuardUpgradeable {
+  using SafeERC20 for IERC20;
+
+  bytes32 public constant MANAGER = keccak256("MANAGER"); // config / rescue
+  bytes32 public constant BOT = keccak256("BOT"); // backend operator
+
+  /// @notice The launchpool reward distributor.
+  IClisBNBLaunchPoolDistributor public immutable DISTRIBUTOR;
+  /// @notice The CollateralYieldVault to compound into.
+  ICollateralYieldVault public immutable VAULT;
+
+  struct ClaimParams {
+    uint64 epochId;
+    uint256 amount;
+    bytes32[] proof;
+  }
+
+  event Harvested(uint256 claimCount, uint256 bnbInjected, uint256 minSlisOut);
+  event Rescued(address indexed token, address indexed to, uint256 amount);
+
+  error InsufficientReward();
+  error NothingToCompound();
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor(address _distributor, address _vault) {
+    require(_distributor != address(0) && _vault != address(0), "zero address");
+    _disableInitializers();
+    DISTRIBUTOR = IClisBNBLaunchPoolDistributor(_distributor);
+    VAULT = ICollateralYieldVault(_vault);
+  }
+
+  function initialize(address admin, address manager, address bot) external initializer {
+    require(admin != address(0) && manager != address(0) && bot != address(0), "zero address");
+    __AccessControl_init();
+    __ReentrancyGuard_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+    _grantRole(BOT, bot);
+  }
+
+  /// @notice Claim launchpool BNB for the given epochs (to this contract) and compound it into the vault.
+  /// @param claims Per-epoch claim data (epochId, amount, Merkle proof). `_account` is always this contract.
+  /// @param minBNBOut Minimum total BNB balance required after claiming (anti-anomaly).
+  /// @param minSlisOut Forwarded to the vault to bound the BNB->slisBNB stake result.
+  function harvest(
+    ClaimParams[] calldata claims,
+    uint256 minBNBOut,
+    uint256 minSlisOut
+  ) external onlyRole(BOT) nonReentrant {
+    for (uint256 i; i < claims.length; ++i) {
+      // Skip already-claimed epochs to keep the batch idempotent.
+      if (DISTRIBUTOR.claimed(claims[i].epochId, address(this))) continue;
+      DISTRIBUTOR.claim(claims[i].epochId, address(this), claims[i].amount, claims[i].proof);
+    }
+
+    uint256 bnbBal = address(this).balance;
+    if (bnbBal == 0) revert NothingToCompound();
+    if (bnbBal < minBNBOut) revert InsufficientReward();
+
+    VAULT.increaseVaultAssets{ value: bnbBal }(minSlisOut);
+
+    emit Harvested(claims.length, bnbBal, minSlisOut);
+  }
+
+  /// @notice Emergency recovery of stranded tokens/BNB (e.g. a non-BNB reward token). Manager-only.
+  function rescue(address token, address to, uint256 amount) external onlyRole(MANAGER) {
+    require(to != address(0), "zero to");
+    if (token == address(0)) {
+      (bool ok, ) = payable(to).call{ value: amount }("");
+      require(ok, "bnb transfer failed");
+    } else {
+      IERC20(token).safeTransfer(to, amount);
+    }
+    emit Rescued(token, to, amount);
+  }
+
+  function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+
+  /// @notice Receive launchpool BNB rewards from the distributor.
+  receive() external payable {}
+}

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -60,13 +60,21 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
   /// @param claims Per-epoch claim data (epochId, amount, Merkle proof). `_account` is hardcoded to this contract,
   ///        so the distributor pays the harvester directly and the BOT cannot redirect the funds.
   /// @param minBNBOut Minimum total BNB balance required after claiming (anti-anomaly / sanity bound).
+  /// @dev NOTICE: distributor `claim` is permissionless and always pays this harvester, so anyone can claim extra
+  ///      epochs; `harvest` compounds the full balance, so the injected amount may exceed sum(claims[i].amount).
+  ///      Only ever raises share price. `minBNBOut` is a lower bound, not an equality.
+  /// @dev NOTICE: if the Moolah market is paused, `supplyCollateral` (and thus `harvest`) reverts. While paused,
+  ///      claim directly on the distributor (funds still land here via the fixed `_account`) and call `harvest`
+  ///      after unpause to avoid epochs expiring unclaimed.
   function harvest(ClaimParams[] calldata claims, uint256 minBNBOut) external onlyRole(BOT) nonReentrant {
+    uint256 claimCount;
     for (uint256 i; i < claims.length; ++i) {
       // The Merkle tree's `_account` is configured off-chain to this RewardHarvester, so the distributor pays the
       // launchpool BNB to this contract — receiving it on behalf of the vault — and we then compound it in.
       // Skip already-claimed epochs to keep the batch idempotent.
       if (DISTRIBUTOR.claimed(claims[i].epochId, address(this))) continue;
       DISTRIBUTOR.claim(claims[i].epochId, address(this), claims[i].amount, claims[i].proof);
+      ++claimCount;
     }
 
     uint256 bnbBal = address(this).balance;
@@ -75,10 +83,13 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
 
     VAULT.increaseVaultAssets{ value: bnbBal }();
 
-    emit Harvested(claims.length, bnbBal);
+    // Emit the number of epochs actually claimed this call (already-claimed epochs are skipped above).
+    emit Harvested(claimCount, bnbBal);
   }
 
   /// @notice Emergency recovery of stranded tokens/BNB (e.g. a non-BNB reward token). Manager-only.
+  /// @dev NOTICE: since distributor claims are permissionless, MANAGER can claim all rewards here and drain them via
+  ///      `rescue`. Use a strong multisig for the MANAGER role to mitigate key-compromise.
   function rescue(address token, address to, uint256 amount) external onlyRole(MANAGER) {
     require(to != address(0), "zero to");
     if (token == address(0)) {

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -62,6 +62,8 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
   /// @param minBNBOut Minimum total BNB balance required after claiming (anti-anomaly / sanity bound).
   function harvest(ClaimParams[] calldata claims, uint256 minBNBOut) external onlyRole(BOT) nonReentrant {
     for (uint256 i; i < claims.length; ++i) {
+      // The Merkle tree's `_account` is configured off-chain to this RewardHarvester, so the distributor pays the
+      // launchpool BNB to this contract — receiving it on behalf of the vault — and we then compound it in.
       // Skip already-claimed epochs to keep the batch idempotent.
       if (DISTRIBUTOR.claimed(claims[i].epochId, address(this))) continue;
       DISTRIBUTOR.claim(claims[i].epochId, address(this), claims[i].amount, claims[i].proof);

--- a/src/utils/interfaces/IClisBNBLaunchPoolDistributor.sol
+++ b/src/utils/interfaces/IClisBNBLaunchPoolDistributor.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+/// @title IClisBNBLaunchPoolDistributor
+/// @author Lista DAO
+/// @notice Launchpool reward distributor (BSC: 0x81a62B329CC8939494d8613F614171a9955A46e8).
+///         `claim` verifies a Merkle proof and sends `epoch.token` (address(0) => native BNB) to `_account`.
+interface IClisBNBLaunchPoolDistributor {
+  function claim(uint64 _epochId, address _account, uint256 _amount, bytes32[] calldata _proof) external;
+
+  function claimed(uint64 _epochId, address _account) external view returns (bool);
+}

--- a/src/utils/interfaces/ISlisBNBx.sol
+++ b/src/utils/interfaces/ISlisBNBx.sol
@@ -32,6 +32,9 @@ interface ISlisBNBxMinter {
   /// @notice Sync delegatee for user; can only be called by a module
   function syncDelegatee(address account, address newDelegatee) external;
 
+  /// @notice Delegate all of the caller's slisBNBx to `newDelegatee`
+  function delegateAllTo(address newDelegatee) external;
+
   /// @notice Get delegatee for user
   function delegation(address account) external view returns (address);
 }

--- a/test/moolah-vault/CollateralYieldVault.t.sol
+++ b/test/moolah-vault/CollateralYieldVault.t.sol
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+
+import { CollateralYieldVault } from "../../src/moolah-vault/CollateralYieldVault.sol";
+import { SlisBNBProvider } from "../../src/provider/SlisBNBProvider.sol";
+import { ISlisBnbProvider } from "../../src/provider/interfaces/IProvider.sol";
+import { SlisBNBxMinter, ISlisBNBx } from "../../src/utils/SlisBNBxMinter.sol";
+import { Moolah } from "../../src/moolah/Moolah.sol";
+
+interface IStakeManagerLike {
+  function deposit() external payable;
+
+  function convertBnbToSnBnb(uint256 _amount) external view returns (uint256);
+}
+
+contract CollateralYieldVaultTest is Test {
+  using MarketParamsLib for MarketParams;
+
+  // --- mainnet addresses ---
+  Moolah moolah = Moolah(0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C);
+  address admin = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253; // timelock
+  address providerManager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+  address slisBnb = 0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B;
+  address stakeManager = 0x1adB950d8bB3dA4bE104211D5AB038628e477fE6;
+  address slisBnbx = 0x4b30fcAA7945fE9fDEFD2895aae539ba102Ed6F6;
+  address slisBnbModule = 0x33f7A980a246f9B8FEA2254E3065576E127D4D5f; // SlisBNBProvider
+  address slisBnbxOwner = 0x702115D6d3Bbb37F407aae4dEcf9d09980e28ebc;
+
+  // --- vault roles / actors ---
+  address vAdmin = makeAddr("vAdmin");
+  address vManager = makeAddr("vManager");
+  address vPauser = makeAddr("vPauser");
+  address bot = makeAddr("bot");
+  address feeRecipient = makeAddr("feeRecipient");
+  address feeWallet = makeAddr("feeWallet"); // minter MPC fee wallet
+  address delegateMpc = makeAddr("delegateMpc"); // launchpool MPC (delegate target)
+  address alice = makeAddr("alice");
+  address charlie = makeAddr("charlie");
+
+  SlisBNBProvider provider;
+  SlisBNBxMinter minter;
+  CollateralYieldVault vault;
+  MarketParams market; // slisBNB collateral / WBNB loan
+
+  function setUp() public {
+    vm.createSelectFork(vm.envString("BSC_RPC"), 68721673);
+
+    _setupMinterAndProvider();
+
+    // existing slisBNB-collateral market served by the provider
+    market = MarketParams({
+      loanToken: 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c,
+      collateralToken: slisBnb,
+      oracle: 0x21650E416dC6C89486B2E654c86cC2c36c597b58,
+      irm: 0xFe7dAe87Ebb11a7BEB9F534BB23267992d9cDe7c,
+      lltv: 965000000000000000
+    });
+
+    // deploy vault (asset/stakeManager derived from provider)
+    CollateralYieldVault impl = new CollateralYieldVault(slisBnbModule);
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(
+        CollateralYieldVault.initialize.selector,
+        vAdmin,
+        vManager,
+        vPauser,
+        market,
+        "Collateral Yield Vault slisBNB",
+        "cySlisBNB"
+      )
+    );
+    vault = CollateralYieldVault(payable(address(proxy)));
+
+    // wire roles + delegate target
+    vm.startPrank(vAdmin);
+    vault.grantRole(vault.BOT(), bot);
+    vault.addDelegateTarget(delegateMpc);
+    vm.stopPrank();
+
+    vm.prank(vManager);
+    vault.setDelegateTarget(delegateMpc);
+
+    // sanity: provider-derived immutables
+    assertEq(vault.asset(), slisBnb, "asset");
+    assertEq(address(vault.STAKE_MANAGER()), stakeManager, "stakeManager");
+    assertEq(address(vault.PROVIDER()), slisBnbModule, "provider");
+    assertEq(vault.decimals(), 18, "decimals");
+  }
+
+  /* ----------------------------- setUp helpers ----------------------------- */
+
+  function _setupMinterAndProvider() internal {
+    // fresh minter with the SlisBNBProvider as a module
+    SlisBNBxMinter mImpl = new SlisBNBxMinter(slisBnbx);
+    address[] memory modules = new address[](1);
+    modules[0] = slisBnbModule;
+    SlisBNBxMinter.ModuleConfig[] memory cfgs = new SlisBNBxMinter.ModuleConfig[](1);
+    cfgs[0] = SlisBNBxMinter.ModuleConfig({ discount: 0, feeRate: 3e4, moduleAddress: slisBnbModule });
+    ERC1967Proxy mProxy = new ERC1967Proxy(
+      address(mImpl),
+      abi.encodeWithSelector(SlisBNBxMinter.initialize.selector, admin, providerManager, modules, cfgs)
+    );
+    minter = SlisBNBxMinter(address(mProxy));
+
+    vm.prank(providerManager);
+    minter.addMPCWallet(feeWallet, 1_000_000_000 ether);
+
+    // upgrade provider impl and point it at the fresh minter
+    address newImpl = address(new SlisBNBProvider(address(moolah), slisBnb, stakeManager, slisBnbx));
+    vm.prank(admin);
+    UUPSUpgradeable(slisBnbModule).upgradeToAndCall(newImpl, "");
+    provider = SlisBNBProvider(slisBnbModule);
+    vm.prank(providerManager);
+    provider.setSlisBNBxMinter(address(minter));
+
+    // authorize the fresh minter to mint slisBNBx
+    vm.prank(slisBnbxOwner);
+    ISlisBNBx(slisBnbx).addMinter(address(minter));
+  }
+
+  function _pps() internal view returns (uint256) {
+    // assets returned for 1e18 shares
+    return vault.convertToAssets(1e18);
+  }
+
+  /* -------------------------------- tests ---------------------------------- */
+
+  function test_depositBNB_mintsSharesAndDelegates() public {
+    uint256 amount = 10 ether;
+    deal(alice, amount);
+
+    uint256 mpcBefore = ISlisBNBx(slisBnbx).balanceOf(delegateMpc);
+
+    vm.prank(alice);
+    uint256 shares = vault.depositBNB{ value: amount }(alice);
+
+    uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(amount);
+    assertApproxEqAbs(vault.totalAssets(), staked, 2, "totalAssets == staked slisBNB");
+    assertEq(provider.userTotalDeposit(address(vault)), vault.totalAssets(), "provider position == totalAssets");
+    assertEq(shares, vault.balanceOf(alice), "alice shares");
+    assertApproxEqAbs(shares, staked, 2, "first deposit shares ~= assets");
+
+    // slisBNBx delegated to the MPC (minus the minter fee portion)
+    assertEq(minter.delegation(address(vault)), delegateMpc, "delegation target");
+    assertGt(ISlisBNBx(slisBnbx).balanceOf(delegateMpc) - mpcBefore, 0, "slisBNBx to MPC");
+  }
+
+  function test_deposit_slisBNB() public {
+    uint256 amount = 8 ether;
+    deal(slisBnb, alice, amount);
+
+    vm.startPrank(alice);
+    IERC20(slisBnb).approve(address(vault), amount);
+    uint256 shares = vault.deposit(amount, alice);
+    vm.stopPrank();
+
+    assertEq(shares, amount, "first deposit shares == assets");
+    assertEq(vault.totalAssets(), amount, "totalAssets");
+    assertEq(provider.userTotalDeposit(address(vault)), amount, "provider position");
+  }
+
+  function test_redeem_returnsSlisBNB() public {
+    uint256 amount = 8 ether;
+    deal(slisBnb, alice, amount);
+    vm.startPrank(alice);
+    IERC20(slisBnb).approve(address(vault), amount);
+    uint256 shares = vault.deposit(amount, alice);
+
+    uint256 balBefore = IERC20(slisBnb).balanceOf(alice);
+    uint256 assets = vault.redeem(shares, alice, alice);
+    vm.stopPrank();
+
+    assertApproxEqAbs(assets, amount, 2, "assets out ~= deposit");
+    assertEq(IERC20(slisBnb).balanceOf(alice) - balBefore, assets, "slisBNB received");
+    assertEq(vault.balanceOf(alice), 0, "shares burned");
+    assertApproxEqAbs(vault.totalAssets(), 0, 2, "position drained");
+  }
+
+  function test_increaseVaultAssets_feeZero_raisesPriceNoShares() public {
+    // alice seeds the vault
+    _deposit(alice, 100 ether);
+
+    uint256 ppsBefore = _pps();
+    uint256 supplyBefore = vault.totalSupply();
+    uint256 assetsBefore = vault.totalAssets();
+    uint256 aliceRedeemBefore = vault.convertToAssets(vault.balanceOf(alice));
+
+    // bot injects 10 BNB of launchpool reward
+    uint256 reward = 10 ether;
+    deal(bot, reward);
+    vm.prank(bot);
+    vault.increaseVaultAssets{ value: reward }(0);
+
+    uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(reward);
+
+    assertEq(vault.totalSupply(), supplyBefore, "no shares minted (fee=0)");
+    assertApproxEqAbs(vault.totalAssets(), assetsBefore + staked, 2, "totalAssets += reward");
+    assertGt(_pps(), ppsBefore, "pricePerShare up");
+    assertApproxEqAbs(
+      vault.convertToAssets(vault.balanceOf(alice)),
+      aliceRedeemBefore + staked,
+      3,
+      "alice redeemable += full reward"
+    );
+  }
+
+  function test_increaseVaultAssets_feeOn_chargesFeeOnIncrement() public {
+    _deposit(alice, 100 ether);
+
+    // enable 10% performance fee
+    vm.startPrank(vManager);
+    vault.setFeeRecipient(feeRecipient);
+    vault.setFee(0.1e18);
+    vm.stopPrank();
+
+    uint256 reward = 10 ether;
+    deal(bot, reward);
+    vm.prank(bot);
+    vault.increaseVaultAssets{ value: reward }(0);
+
+    uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(reward);
+    uint256 feeShares = vault.balanceOf(feeRecipient);
+    assertGt(feeShares, 0, "fee shares minted");
+    // feeRecipient's asset value ~= 10% of the reward increment
+    assertApproxEqRel(vault.convertToAssets(feeShares), staked / 10, 0.02e18, "fee ~= 10% of increment");
+  }
+
+  function test_userWhitelist_gatesDepositAndTransfer() public {
+    // enable whitelist with only alice
+    vm.prank(vManager);
+    vault.setWhiteList(alice, true);
+
+    // charlie (not whitelisted) cannot deposit
+    deal(slisBnb, charlie, 1 ether);
+    vm.startPrank(charlie);
+    IERC20(slisBnb).approve(address(vault), 1 ether);
+    vm.expectRevert();
+    vault.deposit(1 ether, charlie);
+    vm.stopPrank();
+
+    // alice can deposit
+    _deposit(alice, 5 ether);
+
+    // alice cannot transfer shares to non-whitelisted charlie
+    vm.prank(alice);
+    vm.expectRevert();
+    vault.transfer(charlie, 1 ether);
+
+    // after whitelisting charlie, transfer succeeds
+    vm.prank(vManager);
+    vault.setWhiteList(charlie, true);
+    vm.prank(alice);
+    vault.transfer(charlie, 1 ether);
+    assertEq(vault.balanceOf(charlie), 1 ether, "transfer ok after whitelist");
+  }
+
+  function test_delegateTarget_onlyWhitelisted() public {
+    address rogue = makeAddr("rogue");
+    vm.prank(vManager);
+    vm.expectRevert(CollateralYieldVault.NotWhitelistedDelegate.selector);
+    vault.setDelegateTarget(rogue);
+
+    vm.prank(vAdmin);
+    vault.addDelegateTarget(rogue);
+    vm.prank(vManager);
+    vault.setDelegateTarget(rogue);
+    assertEq(vault.delegateTarget(), rogue, "delegate target updated");
+    assertEq(minter.delegation(address(vault)), rogue, "minter delegation updated");
+  }
+
+  function test_pause_blocksDepositNotRedeem() public {
+    _deposit(alice, 10 ether);
+
+    vm.prank(vPauser);
+    vault.pause();
+
+    deal(slisBnb, alice, 1 ether);
+    vm.startPrank(alice);
+    IERC20(slisBnb).approve(address(vault), 1 ether);
+    vm.expectRevert();
+    vault.deposit(1 ether, alice);
+    // redeem still works while paused
+    uint256 out = vault.redeem(vault.balanceOf(alice), alice, alice);
+    vm.stopPrank();
+    assertGt(out, 0, "redeem allowed while paused");
+  }
+
+  function test_increaseVaultAssets_onlyBot() public {
+    deal(alice, 1 ether);
+    vm.prank(alice);
+    vm.expectRevert();
+    vault.increaseVaultAssets{ value: 1 ether }(0);
+  }
+
+  function test_donation_onlyViaProvider_raisesNavAndMintsSlisBNBx() public {
+    _deposit(alice, 50 ether);
+    uint256 ppsBefore = _pps();
+    uint256 mpcBefore = ISlisBNBx(slisBnbx).balanceOf(delegateMpc);
+
+    uint256 donation = 5 ether;
+    deal(slisBnb, charlie, donation);
+
+    // (1) a raw Moolah call cannot donate: the market has a provider => msg.sender must be the provider.
+    vm.startPrank(charlie);
+    IERC20(slisBnb).approve(address(moolah), donation);
+    vm.expectRevert();
+    moolah.supplyCollateral(market, donation, address(vault), "");
+
+    // (2) the only path is via the provider; this also mints slisBNBx to the vault's delegatee (launchpool).
+    IERC20(slisBnb).approve(address(provider), donation);
+    provider.supplyCollateral(market, donation, address(vault), "");
+    vm.stopPrank();
+
+    assertEq(provider.userTotalDeposit(address(vault)), 55 ether, "donation counted in position");
+    assertGt(_pps(), ppsBefore, "donation raises pricePerShare");
+    assertGt(ISlisBNBx(slisBnbx).balanceOf(delegateMpc) - mpcBefore, 0, "donation also mints slisBNBx to MPC");
+  }
+
+  /* -------------------------------- utils ---------------------------------- */
+
+  function _deposit(address user, uint256 amount) internal returns (uint256 shares) {
+    deal(slisBnb, user, amount);
+    vm.startPrank(user);
+    IERC20(slisBnb).approve(address(vault), amount);
+    shares = vault.deposit(amount, user);
+    vm.stopPrank();
+  }
+}

--- a/test/moolah-vault/CollateralYieldVault.t.sol
+++ b/test/moolah-vault/CollateralYieldVault.t.sol
@@ -81,10 +81,9 @@ contract CollateralYieldVaultTest is Test {
     vault = CollateralYieldVault(payable(address(proxy)));
 
     // wire roles + delegate target
-    vm.startPrank(vAdmin);
-    vault.grantRole(vault.BOT(), bot);
-    vault.addDelegateTarget(delegateMpc);
-    vm.stopPrank();
+    bytes32 botRole = vault.BOT();
+    vm.prank(vAdmin);
+    vault.grantRole(botRole, bot);
 
     vm.prank(vManager);
     vault.setDelegateTarget(delegateMpc);
@@ -198,7 +197,7 @@ contract CollateralYieldVaultTest is Test {
     uint256 reward = 10 ether;
     deal(bot, reward);
     vm.prank(bot);
-    vault.increaseVaultAssets{ value: reward }(0);
+    vault.increaseVaultAssets{ value: reward }();
 
     uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(reward);
 
@@ -225,7 +224,7 @@ contract CollateralYieldVaultTest is Test {
     uint256 reward = 10 ether;
     deal(bot, reward);
     vm.prank(bot);
-    vault.increaseVaultAssets{ value: reward }(0);
+    vault.increaseVaultAssets{ value: reward }();
 
     uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(reward);
     uint256 feeShares = vault.balanceOf(feeRecipient);
@@ -263,18 +262,46 @@ contract CollateralYieldVaultTest is Test {
     assertEq(vault.balanceOf(charlie), 1 ether, "transfer ok after whitelist");
   }
 
-  function test_delegateTarget_onlyWhitelisted() public {
-    address rogue = makeAddr("rogue");
-    vm.prank(vManager);
-    vm.expectRevert(CollateralYieldVault.NotWhitelistedDelegate.selector);
-    vault.setDelegateTarget(rogue);
+  function test_setDelegateTarget_managerOnly_andUpdatesMinter() public {
+    address newMpc = makeAddr("newMpc");
 
-    vm.prank(vAdmin);
-    vault.addDelegateTarget(rogue);
+    // non-manager cannot set
+    vm.prank(alice);
+    vm.expectRevert();
+    vault.setDelegateTarget(newMpc);
+
+    // zero address rejected
     vm.prank(vManager);
-    vault.setDelegateTarget(rogue);
-    assertEq(vault.delegateTarget(), rogue, "delegate target updated");
-    assertEq(minter.delegation(address(vault)), rogue, "minter delegation updated");
+    vm.expectRevert(); // ErrorsLib.ZeroAddress
+    vault.setDelegateTarget(address(0));
+
+    // manager can set any non-zero target; minter delegation follows
+    vm.prank(vManager);
+    vault.setDelegateTarget(newMpc);
+    assertEq(vault.delegateTarget(), newMpc, "delegate target updated");
+    assertEq(minter.delegation(address(vault)), newMpc, "minter delegation updated");
+  }
+
+  function test_emergencyWithdraw_recoversStrayTokens() public {
+    _deposit(alice, 50 ether);
+    uint256 navBefore = vault.totalAssets();
+
+    // a stray slisBNB transfer lands idle in the vault (not in the position, not in NAV)
+    deal(slisBnb, address(vault), 3 ether);
+    assertEq(vault.totalAssets(), navBefore, "stray balance not counted in NAV");
+
+    // non-manager cannot withdraw
+    vm.prank(alice);
+    vm.expectRevert();
+    vault.emergencyWithdraw(3 ether, slisBnb);
+
+    // manager recovers the stray tokens; NAV and position unaffected
+    uint256 mgrBefore = IERC20(slisBnb).balanceOf(vManager);
+    vm.prank(vManager);
+    vault.emergencyWithdraw(3 ether, slisBnb);
+
+    assertEq(IERC20(slisBnb).balanceOf(vManager) - mgrBefore, 3 ether, "stray slisBNB recovered to manager");
+    assertEq(vault.totalAssets(), navBefore, "NAV unchanged");
   }
 
   function test_pause_blocksDepositNotRedeem() public {
@@ -298,7 +325,7 @@ contract CollateralYieldVaultTest is Test {
     deal(alice, 1 ether);
     vm.prank(alice);
     vm.expectRevert();
-    vault.increaseVaultAssets{ value: 1 ether }(0);
+    vault.increaseVaultAssets{ value: 1 ether }();
   }
 
   function test_donation_onlyViaProvider_raisesNavAndMintsSlisBNBx() public {
@@ -333,7 +360,7 @@ contract CollateralYieldVaultTest is Test {
     uint256 reward = 10 ether;
     deal(bot, reward);
     vm.prank(bot);
-    vault.increaseVaultAssets{ value: reward }(0);
+    vault.increaseVaultAssets{ value: reward }();
 
     // sweep is blocked while shares are outstanding
     vm.prank(vManager);

--- a/test/moolah-vault/CollateralYieldVault.t.sol
+++ b/test/moolah-vault/CollateralYieldVault.t.sol
@@ -325,6 +325,44 @@ contract CollateralYieldVaultTest is Test {
     assertGt(ISlisBNBx(slisBnbx).balanceOf(delegateMpc) - mpcBefore, 0, "donation also mints slisBNBx to MPC");
   }
 
+  function test_sweep_recoversDustOnlyWhenEmpty() public {
+    address treasury = makeAddr("treasury");
+    uint256 shares = _deposit(alice, 100 ether);
+
+    // compound so pricePerShare > 1 => redeem rounding will leave dust
+    uint256 reward = 10 ether;
+    deal(bot, reward);
+    vm.prank(bot);
+    vault.increaseVaultAssets{ value: reward }(0);
+
+    // sweep is blocked while shares are outstanding
+    vm.prank(vManager);
+    vm.expectRevert(CollateralYieldVault.SharesOutstanding.selector);
+    vault.sweep(treasury);
+
+    // alice redeems everything -> floor rounding leaves dust in the position
+    vm.prank(alice);
+    vault.redeem(shares, alice, alice);
+
+    uint256 dust = provider.userTotalDeposit(address(vault));
+    assertEq(vault.totalSupply(), 0, "no shares left");
+    assertGt(dust, 0, "dust remains");
+    assertEq(vault.totalAssets(), dust, "totalAssets == dust");
+
+    // only MANAGER can sweep
+    vm.prank(alice);
+    vm.expectRevert();
+    vault.sweep(treasury);
+
+    vm.prank(vManager);
+    uint256 swept = vault.sweep(treasury);
+
+    assertEq(swept, dust, "swept == dust");
+    assertEq(IERC20(slisBnb).balanceOf(treasury), dust, "dust to treasury");
+    assertEq(provider.userTotalDeposit(address(vault)), 0, "position cleared");
+    assertEq(vault.totalAssets(), 0, "clean empty state");
+  }
+
   /* -------------------------------- utils ---------------------------------- */
 
   function _deposit(address user, uint256 amount) internal returns (uint256 shares) {

--- a/test/moolah/mocks/MockStakeManager.sol
+++ b/test/moolah/mocks/MockStakeManager.sol
@@ -10,6 +10,8 @@ contract MockStakeManager is IStakeManager {
     exchangeRate = _exchangeRate;
   }
 
+  function deposit() external payable {}
+
   function convertBnbToSnBnb(uint256 _amount) external view returns (uint256) {
     return (_amount * exchangeRate) / 1e18;
   }

--- a/test/utils/RewardHarvester.t.sol
+++ b/test/utils/RewardHarvester.t.sol
@@ -114,12 +114,10 @@ contract RewardHarvesterTest is Test {
     );
     harvester = RewardHarvester(payable(address(hProxy)));
 
-    // vAdmin config: delegate whitelist + grant the harvester the vault BOT role
+    // grant the harvester the vault BOT role + set delegate target
     bytes32 botRole = vault.BOT();
-    vm.startPrank(vAdmin);
-    vault.addDelegateTarget(delegateMpc);
+    vm.prank(vAdmin);
     vault.grantRole(botRole, address(harvester));
-    vm.stopPrank();
     vm.prank(vManager);
     vault.setDelegateTarget(delegateMpc);
 
@@ -152,7 +150,7 @@ contract RewardHarvesterTest is Test {
     claims[1] = _claim(2, 5 ether);
 
     vm.prank(bot);
-    harvester.harvest(claims, 0, 0);
+    harvester.harvest(claims, 0);
 
     uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(15 ether);
 
@@ -170,7 +168,7 @@ contract RewardHarvesterTest is Test {
     RewardHarvester.ClaimParams[] memory first = new RewardHarvester.ClaimParams[](1);
     first[0] = _claim(1, 10 ether);
     vm.prank(bot);
-    harvester.harvest(first, 0, 0);
+    harvester.harvest(first, 0);
     uint256 distBalAfterFirst = address(distributor).balance;
 
     // second harvest: epoch 1 (already claimed, skipped) + epoch 2 (5 BNB)
@@ -178,7 +176,7 @@ contract RewardHarvesterTest is Test {
     second[0] = _claim(1, 10 ether);
     second[1] = _claim(2, 5 ether);
     vm.prank(bot);
-    harvester.harvest(second, 0, 0);
+    harvester.harvest(second, 0);
 
     // only epoch 2 paid out in the second call
     assertEq(distBalAfterFirst - address(distributor).balance, 5 ether, "epoch1 not double-claimed");
@@ -191,14 +189,14 @@ contract RewardHarvesterTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(RewardHarvester.InsufficientReward.selector);
-    harvester.harvest(claims, 20 ether, 0); // minBNBOut > claimable
+    harvester.harvest(claims, 20 ether); // minBNBOut > claimable
   }
 
   function test_harvest_revertsNothingToCompound() public {
     RewardHarvester.ClaimParams[] memory none = new RewardHarvester.ClaimParams[](0);
     vm.prank(bot);
     vm.expectRevert(RewardHarvester.NothingToCompound.selector);
-    harvester.harvest(none, 0, 0);
+    harvester.harvest(none, 0);
   }
 
   function test_harvest_onlyBot() public {
@@ -206,7 +204,7 @@ contract RewardHarvesterTest is Test {
     claims[0] = _claim(1, 10 ether);
     vm.prank(alice);
     vm.expectRevert();
-    harvester.harvest(claims, 0, 0);
+    harvester.harvest(claims, 0);
   }
 
   function test_rescue_managerOnly() public {

--- a/test/utils/RewardHarvester.t.sol
+++ b/test/utils/RewardHarvester.t.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { MarketParams } from "moolah/interfaces/IMoolah.sol";
+
+import { CollateralYieldVault } from "../../src/moolah-vault/CollateralYieldVault.sol";
+import { SlisBNBProvider } from "../../src/provider/SlisBNBProvider.sol";
+import { SlisBNBxMinter, ISlisBNBx } from "../../src/utils/SlisBNBxMinter.sol";
+import { RewardHarvester } from "../../src/utils/RewardHarvester.sol";
+
+interface IStakeManagerLike {
+  function convertBnbToSnBnb(uint256 _amount) external view returns (uint256);
+}
+
+/// @dev Stand-in for ClisBNBLaunchPoolDistributor: on `claim` it pays `amount` BNB to `_account` (token == BNB).
+contract MockLaunchPoolDistributor {
+  mapping(uint64 => mapping(address => bool)) public claimed;
+  address public lastClaimAccount;
+  uint256 public lastClaimAmount;
+
+  function claim(uint64 epochId, address account, uint256 amount, bytes32[] calldata) external {
+    require(!claimed[epochId][account], "already claimed");
+    claimed[epochId][account] = true;
+    lastClaimAccount = account;
+    lastClaimAmount = amount;
+    (bool ok, ) = payable(account).call{ value: amount }("");
+    require(ok, "pay failed");
+  }
+
+  receive() external payable {}
+}
+
+contract RewardHarvesterTest is Test {
+  // mainnet addresses (same wiring as CollateralYieldVault.t.sol)
+  address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+  address admin = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+  address providerManager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+  address slisBnb = 0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B;
+  address stakeManager = 0x1adB950d8bB3dA4bE104211D5AB038628e477fE6;
+  address slisBnbx = 0x4b30fcAA7945fE9fDEFD2895aae539ba102Ed6F6;
+  address slisBnbModule = 0x33f7A980a246f9B8FEA2254E3065576E127D4D5f;
+  address slisBnbxOwner = 0x702115D6d3Bbb37F407aae4dEcf9d09980e28ebc;
+
+  address vAdmin = makeAddr("vAdmin");
+  address vManager = makeAddr("vManager");
+  address vPauser = makeAddr("vPauser");
+  address hAdmin = makeAddr("hAdmin");
+  address hManager = makeAddr("hManager");
+  address bot = makeAddr("bot");
+  address feeWallet = makeAddr("feeWallet");
+  address delegateMpc = makeAddr("delegateMpc");
+  address alice = makeAddr("alice");
+
+  SlisBNBProvider provider;
+  SlisBNBxMinter minter;
+  CollateralYieldVault vault;
+  RewardHarvester harvester;
+  MockLaunchPoolDistributor distributor;
+  MarketParams market;
+
+  function setUp() public {
+    vm.createSelectFork(vm.envString("BSC_RPC"), 68721673);
+
+    // minter + provider wiring
+    SlisBNBxMinter mImpl = new SlisBNBxMinter(slisBnbx);
+    address[] memory modules = new address[](1);
+    modules[0] = slisBnbModule;
+    SlisBNBxMinter.ModuleConfig[] memory cfgs = new SlisBNBxMinter.ModuleConfig[](1);
+    cfgs[0] = SlisBNBxMinter.ModuleConfig({ discount: 0, feeRate: 3e4, moduleAddress: slisBnbModule });
+    ERC1967Proxy mProxy = new ERC1967Proxy(
+      address(mImpl),
+      abi.encodeWithSelector(SlisBNBxMinter.initialize.selector, admin, providerManager, modules, cfgs)
+    );
+    minter = SlisBNBxMinter(address(mProxy));
+    vm.prank(providerManager);
+    minter.addMPCWallet(feeWallet, 1_000_000_000 ether);
+
+    address newImpl = address(new SlisBNBProvider(moolah, slisBnb, stakeManager, slisBnbx));
+    vm.prank(admin);
+    UUPSUpgradeable(slisBnbModule).upgradeToAndCall(newImpl, "");
+    provider = SlisBNBProvider(slisBnbModule);
+    vm.prank(providerManager);
+    provider.setSlisBNBxMinter(address(minter));
+    vm.prank(slisBnbxOwner);
+    ISlisBNBx(slisBnbx).addMinter(address(minter));
+
+    market = MarketParams({
+      loanToken: 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c,
+      collateralToken: slisBnb,
+      oracle: 0x21650E416dC6C89486B2E654c86cC2c36c597b58,
+      irm: 0xFe7dAe87Ebb11a7BEB9F534BB23267992d9cDe7c,
+      lltv: 965000000000000000
+    });
+
+    // vault
+    CollateralYieldVault vImpl = new CollateralYieldVault(slisBnbModule);
+    ERC1967Proxy vProxy = new ERC1967Proxy(
+      address(vImpl),
+      abi.encodeWithSelector(CollateralYieldVault.initialize.selector, vAdmin, vManager, vPauser, market, "CYV", "CYV")
+    );
+    vault = CollateralYieldVault(payable(address(vProxy)));
+
+    // harvester (mock distributor)
+    distributor = new MockLaunchPoolDistributor();
+    RewardHarvester hImpl = new RewardHarvester(address(distributor), address(vault));
+    ERC1967Proxy hProxy = new ERC1967Proxy(
+      address(hImpl),
+      abi.encodeWithSelector(RewardHarvester.initialize.selector, hAdmin, hManager, bot)
+    );
+    harvester = RewardHarvester(payable(address(hProxy)));
+
+    // vAdmin config: delegate whitelist + grant the harvester the vault BOT role
+    bytes32 botRole = vault.BOT();
+    vm.startPrank(vAdmin);
+    vault.addDelegateTarget(delegateMpc);
+    vault.grantRole(botRole, address(harvester));
+    vm.stopPrank();
+    vm.prank(vManager);
+    vault.setDelegateTarget(delegateMpc);
+
+    // fund the distributor with BNB to pay claims
+    vm.deal(address(distributor), 100 ether);
+  }
+
+  function _claim(uint64 epochId, uint256 amount) internal pure returns (RewardHarvester.ClaimParams memory c) {
+    c.epochId = epochId;
+    c.amount = amount;
+    c.proof = new bytes32[](0);
+  }
+
+  function _depositAlice(uint256 amount) internal {
+    deal(slisBnb, alice, amount);
+    vm.startPrank(alice);
+    IERC20(slisBnb).approve(address(vault), amount);
+    vault.deposit(amount, alice);
+    vm.stopPrank();
+  }
+
+  function test_harvest_claimsToSelf_andCompounds() public {
+    _depositAlice(100 ether);
+    uint256 assetsBefore = vault.totalAssets();
+    uint256 supplyBefore = vault.totalSupply();
+    uint256 ppsBefore = vault.convertToAssets(1e18);
+
+    RewardHarvester.ClaimParams[] memory claims = new RewardHarvester.ClaimParams[](2);
+    claims[0] = _claim(1, 10 ether);
+    claims[1] = _claim(2, 5 ether);
+
+    vm.prank(bot);
+    harvester.harvest(claims, 0, 0);
+
+    uint256 staked = IStakeManagerLike(stakeManager).convertBnbToSnBnb(15 ether);
+
+    assertEq(address(harvester).balance, 0, "all BNB injected");
+    assertEq(distributor.lastClaimAccount(), address(harvester), "claim _account hardcoded to harvester");
+    assertEq(vault.totalSupply(), supplyBefore, "no user shares minted");
+    assertApproxEqAbs(vault.totalAssets(), assetsBefore + staked, 3, "totalAssets += staked reward");
+    assertGt(vault.convertToAssets(1e18), ppsBefore, "pricePerShare up");
+  }
+
+  function test_harvest_skipsAlreadyClaimed() public {
+    _depositAlice(100 ether);
+
+    // first harvest: claim epoch 1 (10 BNB)
+    RewardHarvester.ClaimParams[] memory first = new RewardHarvester.ClaimParams[](1);
+    first[0] = _claim(1, 10 ether);
+    vm.prank(bot);
+    harvester.harvest(first, 0, 0);
+    uint256 distBalAfterFirst = address(distributor).balance;
+
+    // second harvest: epoch 1 (already claimed, skipped) + epoch 2 (5 BNB)
+    RewardHarvester.ClaimParams[] memory second = new RewardHarvester.ClaimParams[](2);
+    second[0] = _claim(1, 10 ether);
+    second[1] = _claim(2, 5 ether);
+    vm.prank(bot);
+    harvester.harvest(second, 0, 0);
+
+    // only epoch 2 paid out in the second call
+    assertEq(distBalAfterFirst - address(distributor).balance, 5 ether, "epoch1 not double-claimed");
+  }
+
+  function test_harvest_revertsBelowMinBNBOut() public {
+    _depositAlice(50 ether);
+    RewardHarvester.ClaimParams[] memory claims = new RewardHarvester.ClaimParams[](1);
+    claims[0] = _claim(1, 10 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(RewardHarvester.InsufficientReward.selector);
+    harvester.harvest(claims, 20 ether, 0); // minBNBOut > claimable
+  }
+
+  function test_harvest_revertsNothingToCompound() public {
+    RewardHarvester.ClaimParams[] memory none = new RewardHarvester.ClaimParams[](0);
+    vm.prank(bot);
+    vm.expectRevert(RewardHarvester.NothingToCompound.selector);
+    harvester.harvest(none, 0, 0);
+  }
+
+  function test_harvest_onlyBot() public {
+    RewardHarvester.ClaimParams[] memory claims = new RewardHarvester.ClaimParams[](1);
+    claims[0] = _claim(1, 10 ether);
+    vm.prank(alice);
+    vm.expectRevert();
+    harvester.harvest(claims, 0, 0);
+  }
+
+  function test_rescue_managerOnly() public {
+    address to = makeAddr("rescueTo");
+
+    // BNB rescue
+    vm.deal(address(harvester), 3 ether);
+    vm.prank(alice);
+    vm.expectRevert();
+    harvester.rescue(address(0), to, 3 ether);
+
+    vm.prank(hManager);
+    harvester.rescue(address(0), to, 3 ether);
+    assertEq(to.balance, 3 ether, "BNB rescued");
+
+    // ERC20 rescue
+    deal(slisBnb, address(harvester), 7 ether);
+    vm.prank(hManager);
+    harvester.rescue(slisBnb, to, 7 ether);
+    assertEq(IERC20(slisBnb).balanceOf(to), 7 ether, "ERC20 rescued");
+  }
+}


### PR DESCRIPTION
  ## Summary
  
  A ERC-4626 vault (asset = `slisBNB`) that turns idle slisBNB into stacked yield with no leverage and no liquidation, plus a `RewardHarvester` that compounds launchpool rewards into share price.

  Flow: deposit `slisBNB` (or BNB via depositBNB, auto-staked) → supplied as Moolah collateral, no borrow via `SlisBNBProvider` → minted slisBNBx is 100% delegated to a governance-whitelisted MPC for launchpool → launchpool BNB rewards are claimed by `RewardHarvester` and injected via `increaseVaultAssets` (BOT-only), which stakes BNB→slisBNB, supplies it, and raises the share price.   

##  Key points

  - NAV = the vault's slisBNB collateral (SlisBNBProvider.userTotalDeposit); pricePerShare rises only via increaseVaultAssets (or benign provider-path donations).
  - Performance fee: MoolahVault model (fee-share dilution, high-water lastTotalAssets); charged on the reward increment, fee = 0 at launch.
  - No liquidation risk: zero borrow ⇒ position never liquidatable; Morpho-style isolation ⇒ collateral never exposed to others' bad debt.
  - Access: user whitelist (gates deposit + share transfer), governance-whitelisted delegate target (MPC), MANAGER/PAUSER/BOT roles, UUPS, Pausable (redeem stays open while paused).
  - Asset / StakeManager / slisBNBx-minter are all derived from the provider (constructor takes only _provider).
  - Existing interfaces extended (IProvider, IStakeManager, ISlisBNBx, IStableSwap) instead of redefining.

##  Files
  
  - New: CollateralYieldVault.sol, RewardHarvester.sol, interfaces/ICollateralYieldVault.sol, interfaces/IClisBNBLaunchPoolDistributor.sol
  - Modified interfaces: IProvider, IStakeManager, ISlisBNBx, IStableSwap; test mock MockStakeManager
  - Tests: test/moolah-vault/CollateralYieldVault.t.sol

##  Testing   

```  
  forge test --mc CollateralYieldVaultTest   # requires BSC_RPC
```
