### PR TITLE
chore: add impl-only deploy script for MoolahVaultManager (BSC mainnet)

### DIFF
--- a/script/deploy_moolahVaultManager_impl.sol
+++ b/script/deploy_moolahVaultManager_impl.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "./DeployBase.sol";
+
+import { MoolahVaultManager } from "moolah-vault/MoolahVaultManager.sol";
+
+contract MoolahVaultManagerImplDeploy is DeployBase {
+  address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy MoolahVaultManager implementation
+    MoolahVaultManager impl = new MoolahVaultManager(moolah);
+    console.log("MoolahVaultManager implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}


### PR DESCRIPTION
## Summary

Adds an impl-only Foundry deploy script for `MoolahVaultManager` on BSC mainnet. Deploys a fresh `MoolahVaultManager` implementation (constructed with the production Moolah address) for later proxy wiring via a timelock upgrade.

## Change type

- [x] Migration / deploy script

## Contracts changed

| File | Type |
|------|------|
| `script/deploy_moolahVaultManager_impl.sol` (`MoolahVaultManagerImplDeploy`) | new |

## Interface changes

None — script only; no protocol contract modified.

## Storage layout

N/A — deploy script, not an upgradeable contract.

## Access control

Unchanged. Script broadcasts from the auto-selected deployer key (`_deployerKey()` from `DeployBase`).

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | No storage; impl deploy only |
| Fund safety | 🟢 None | Deploys an unwired implementation; no funds touched |
| Access control | 🟢 None | No role/owner changes |
| External call safety | 🟢 None | Only `new MoolahVaultManager(moolah)` |

## Deployment

- **Chain:** BSC mainnet
- **Script:** `script/deploy_moolahVaultManager_impl.sol`
- **Moolah:** `0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C` (hardcoded)
- Deployer key auto-selected by chain ID. Impl is inert until a separate timelock proxy upgrade points the proxy at it.

## Test plan

- [x] Script compiles (`forge build script/deploy_moolahVaultManager_impl.sol --via-ir`)
- [ ] Deploy on BSC mainnet and record impl address; wire via timelock upgrade runbook (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
