### PR TITLE
chore: add ETH MoolahVaultFactory deploy scripts

### DIFF
--- a/script/eth/deploy_moolahVaultFactory.sol
+++ b/script/eth/deploy_moolahVaultFactory.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { MoolahVaultFactory } from "moolah-vault/MoolahVaultFactory.sol";
+
+/// @notice Deploys MoolahVaultFactory (implementation + ERC1967 proxy) on Ethereum mainnet.
+/// @dev PREREQUISITE: MoolahVaultFactory.MOOLAH_VAULT_IMPL_18 is a compile-time constant baked
+///      into bytecode. Before running this script it MUST be temp-edited to the ETH 18-dec
+///      MoolahVault impl (from deploy_moolahVault_impl.sol) and the project rebuilt, otherwise
+///      createMoolahVault reverts ERC1967InvalidImplementation on ETH. See
+///      docs/runbooks/eth-moolah-vault-factory-deploy.md.
+///      The proxy is initialized with admin = deployer (transferred to the admin timelock in a
+///      follow-up step) and vaultAdmin = ETH admin timelock.
+contract MoolahVaultFactoryDeploy is DeployBase {
+  address moolah = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70; // ETH mainnet Moolah
+  address vaultAdmin = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61; // ETH admin timelock
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy MoolahVaultFactory implementation
+    MoolahVaultFactory impl = new MoolahVaultFactory(moolah);
+    console.log("MoolahVaultFactory implementation: ", address(impl));
+
+    // Deploy MoolahVaultFactory proxy
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, deployer, vaultAdmin)
+    );
+    console.log("MoolahVaultFactory proxy: ", address(proxy));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/eth/deploy_moolahVaultFactory_transferRole.sol
+++ b/script/eth/deploy_moolahVaultFactory_transferRole.sol
@@ -1,0 +1,35 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { MoolahVaultFactory } from "moolah-vault/MoolahVaultFactory.sol";
+
+/// @notice Transfers MoolahVaultFactory DEFAULT_ADMIN_ROLE from the deployer to the ETH admin
+///         timelock. Run after deploy_moolahVaultFactory.sol (which initializes admin = deployer).
+/// @dev Set `factory` to the deployed proxy address before running.
+contract MoolahVaultFactoryTransferRoleDeploy is DeployBase {
+  MoolahVaultFactory factory = MoolahVaultFactory(0x0000000000000000000000000000000000000000); // set after deploy
+
+  address admin = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61; // ETH admin timelock
+
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+  function run() public {
+    require(address(factory) != address(0), "set factory address");
+
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Hand factory admin to the ETH admin timelock, then drop the deployer's.
+    factory.grantRole(DEFAULT_ADMIN_ROLE, admin);
+    factory.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+
+    vm.stopBroadcast();
+
+    console.log("transfer role done!");
+  }
+}

--- a/script/eth/deploy_moolahVault_impl.sol
+++ b/script/eth/deploy_moolahVault_impl.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { MoolahVault } from "moolah-vault/MoolahVault.sol";
+
+/// @notice Deploys a fresh 18-decimals MoolahVault implementation on Ethereum mainnet.
+/// @dev The constructor `asset` arg only fixes the immutable DECIMALS_OFFSET (USD1 has 18
+///      decimals). The deployed impl address becomes MoolahVaultFactory.MOOLAH_VAULT_IMPL_18
+///      on ETH: temp-edit that constant to this address and rebuild before deploying the
+///      factory. See docs/runbooks/eth-moolah-vault-factory-deploy.md.
+contract MoolahVaultImplDeploy is DeployBase {
+  address moolah = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70; // ETH mainnet Moolah
+  address USD1 = 0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d; // USD1 on ETH (18 decimals)
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy the 18-decimals MoolahVault implementation used by MoolahVaultFactory.
+    MoolahVault impl = new MoolahVault(moolah, USD1);
+    console.log("MoolahVault(18) implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}


### PR DESCRIPTION
## Summary

Adds the Foundry deploy scripts to bring `MoolahVaultFactory` to **Ethereum mainnet**: a fresh 18-dec `MoolahVault` implementation, the factory (impl + ERC1967 proxy), and a DEFAULT_ADMIN_ROLE transfer script. The full deployment runbook (incl. the `MOOLAH_VAULT_IMPL_18` temp-edit dance) lives in the AI SOP Notion page: **MoolahVaultFactory 上线 (Ethereum)**.

## Change type

- [x] Migration / deploy script

## Contracts changed

| File | Type |
|------|------|
| `script/eth/deploy_moolahVault_impl.sol` (`MoolahVaultImplDeploy`) | new |
| `script/eth/deploy_moolahVaultFactory.sol` (`MoolahVaultFactoryDeploy`) | new |
| `script/eth/deploy_moolahVaultFactory_transferRole.sol` (`MoolahVaultFactoryTransferRoleDeploy`) | new |

## Interface changes

None — scripts only; no protocol contract modified.

## Storage layout

N/A — deploy scripts, not upgradeable contracts.

## Access control

No protocol access-control code changed. `deploy_moolahVaultFactory.sol` initializes the factory with `admin = deployer`, `vaultAdmin = ETH admin timelock 0xa18ae79A…400D61`. `deploy_moolahVaultFactory_transferRole.sol` then `grantRole(DEFAULT_ADMIN_ROLE, adminTimelock)` + `revokeRole(DEFAULT_ADMIN_ROLE, deployer)`.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | No contract storage changed |
| Fund safety | 🟢 None | Factory/impl are inert until `createMoolahVault` is called; no funds touched |
| Access control | 🟡 Low | Transfer script moves factory admin to the ETH admin timelock; `factory` address must be filled in post-deploy (guarded by a `require`) |
| External call safety | 🟢 None | Only `new MoolahVault(...)` / `new MoolahVaultFactory(...)` / role grants |

## Deployment

- **Chain:** Ethereum mainnet (chain id 1); `--rpc-url eth`.
- **Scripts:** the three above (run in order: impl → factory → transfer-role).
- ⚠️ **`MOOLAH_VAULT_IMPL_18` is a compile-time `constant`** baked into the factory bytecode (currently the BSC address). Between the impl and factory deploys it must be **temp-edited** to the freshly deployed ETH impl and rebuilt, then reverted — **do not commit that edit**. See the Notion runbook.
- ⚠️ The local `.env` `PRIVATE_KEY` (`0x6616…4f06`) is the testnet key (nonce 0 / 0 ETH on mainnet); broadcast requires the team's funded ETH deployer.
- Fill the deployed factory proxy address into `deploy_moolahVaultFactory_transferRole.sol` before running it.

## Test plan

- [x] All three scripts compile (`forge build … --via-ir`)
- [ ] Phase A fork dry-run: `createMoolahVault` succeeds (no `ERC1967InvalidImplementation`) — per runbook
- [ ] Mainnet deploy + Etherscan verify; confirm `MOOLAH_VAULT_IMPL_18() == new impl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
