### PR TITLE
Fix/yield buffer audit bailsec

### DIFF
--- a/script/utils/deploy_brokerInterestLockBuffer.s.sol
+++ b/script/utils/deploy_brokerInterestLockBuffer.s.sol
@@ -97,8 +97,12 @@ contract DeployBrokerInterestLockBuffer is DeployBase {
     buffer.grantRole(MANAGER, manager);
     buffer.grantRole(DEFAULT_ADMIN_ROLE, timelock);
 
-    // Deployer's temporary roles should be revoked in a follow-up tx (matches the
-    // pattern in script/broker/renounceRoles.s.sol).
+    // 5. Revoke the deployer's temporary roles in the same broadcast so the deployer EOA cannot
+    //    upgrade the buffer impl or reset the unlock clock after deploy. Order matters: revoke
+    //    MANAGER first (still callable by ourselves while we hold DEFAULT_ADMIN_ROLE), then drop
+    //    DEFAULT_ADMIN_ROLE last.
+    buffer.revokeRole(MANAGER, deployer);
+    buffer.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
 
     vm.stopBroadcast();
   }

--- a/script/utils/deploy_brokerInterestLockBuffer.s.sol
+++ b/script/utils/deploy_brokerInterestLockBuffer.s.sol
@@ -27,7 +27,12 @@ import { BrokerInterestLockBuffer } from "../../src/utils/BrokerInterestLockBuff
 /// Rollout reminder (must be ordered):
 ///   1. (this script) deploy buffer + grant RELAYER + hand off admin/manager
 ///   2. upgrade BrokerInterestRelayer / CreditBrokerInterestRelayer to the buffer-aware impl
-///   3. vault.setLockBuffer(<bufferProxy>)  -- only after step 2 lands
+///   3. SEED THE VAULT (audit M-06) — governance deposits a small never-withdrawn balance into
+///      the vault and assigns the shares to TIMELOCK. Required to prevent two failure modes if
+///      every LP ever redeems while currentLocked() > 0:
+///        - orphaned Moolah supply shares (no claimer for the locked reward), and
+///        - the inflation-attack window where totalAssets > 0 while totalSupply == 0.
+///   4. vault.setLockBuffer(<bufferProxy>)  -- only after steps 2 and 3 land
 contract DeployBrokerInterestLockBuffer is DeployBase {
   address timelock;
   address manager;

--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -383,11 +383,13 @@ contract MoolahVault is
   /// @notice Set a custom vault name. Pass empty string to revert to the original name.
   function setName(string calldata newName) external onlyRole(DEFAULT_ADMIN_ROLE) {
     _name = newName;
+    emit EventsLib.SetName(newName);
   }
 
   /// @notice Set a custom vault symbol. Pass empty string to revert to the original symbol.
   function setSymbol(string calldata newSymbol) external onlyRole(DEFAULT_ADMIN_ROLE) {
     _symbol = newSymbol;
+    emit EventsLib.SetSymbol(newSymbol);
   }
 
   /* EXTERNAL */

--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -181,6 +181,11 @@ contract MoolahVault is
 
   /// @notice Set (or unset, with `address(0)`) the broker-interest smoothing buffer.
   function setLockBuffer(address buf) external onlyRole(MANAGER) {
+    // Refuse to drop or swap a buffer that still has residual locked balance — both detach
+    // (A → 0) and replace (A → B) would otherwise produce an immediate NAV jump.
+    address cur = lockBuffer;
+    if (cur != address(0) && IBrokerInterestLockBuffer(cur).currentLocked() != 0)
+      revert ErrorsLib.LockBufferNotEmpty();
     if (buf != address(0)) {
       if (IBrokerInterestLockBuffer(buf).vault() != address(this) || IBrokerInterestLockBuffer(buf).asset() != asset())
         revert ErrorsLib.LockBufferMismatch();

--- a/src/moolah-vault/libraries/EventsLib.sol
+++ b/src/moolah-vault/libraries/EventsLib.sol
@@ -124,4 +124,10 @@ library EventsLib {
 
   /// @notice Emitted when the lock buffer pointer is set (or unset with `address(0)`).
   event SetLockBuffer(address indexed lockBuffer);
+
+  /// @notice Emitted when the vault token name override is changed.
+  event SetName(string newName);
+
+  /// @notice Emitted when the vault token symbol override is changed.
+  event SetSymbol(string newSymbol);
 }

--- a/src/utils/BrokerInterestLockBuffer.sol
+++ b/src/utils/BrokerInterestLockBuffer.sol
@@ -23,8 +23,6 @@ contract BrokerInterestLockBuffer is UUPSUpgradeable, AccessControlEnumerableUpg
   uint64 public override lastUpdate;
   uint64 public override duration;
 
-  uint256[45] private __gap;
-
   event BrokerInterestNotified(address indexed relayer, uint256 amount, uint256 newLocked, uint256 unlockEnd);
   event SetDuration(uint64 newDuration);
 
@@ -58,11 +56,12 @@ contract BrokerInterestLockBuffer is UUPSUpgradeable, AccessControlEnumerableUpg
   }
 
   function currentLocked() public view override returns (uint256) {
+    uint128 locked = lockedAmount;
+    if (locked == 0) return 0;
     uint64 dur = duration;
-    if (dur == 0) return 0;
     uint256 elapsed = block.timestamp - lastUpdate;
     if (elapsed >= dur) return 0;
-    return (uint256(lockedAmount) * (dur - elapsed)) / dur;
+    return (uint256(locked) * (dur - elapsed)) / dur;
   }
 
   /// @dev Combine-and-reset: clock restarts each notify; duration unchanged here.

--- a/src/utils/BrokerInterestLockBuffer.sol
+++ b/src/utils/BrokerInterestLockBuffer.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.34;
 
 import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 import { IBrokerInterestLockBuffer } from "./interfaces/IBrokerInterestLockBuffer.sol";
 
@@ -32,7 +31,6 @@ contract BrokerInterestLockBuffer is UUPSUpgradeable, AccessControlEnumerableUpg
   error ZeroAddress();
   error InvalidDuration();
   error LockedOverflow();
-  error AmountExceedsVaultAssets();
 
   constructor() {
     _disableInitializers();
@@ -69,10 +67,6 @@ contract BrokerInterestLockBuffer is UUPSUpgradeable, AccessControlEnumerableUpg
 
   /// @dev Combine-and-reset: clock restarts each notify; duration unchanged here.
   function notifyBrokerInterest(uint256 amount) external override onlyRole(RELAYER) {
-    // Cap the flush at vault.totalAssets() so a miswired notify cannot drive lockedAmount past
-    // the vault's holdings and collapse NAV / enable an inflation attack.
-    if (amount > IERC4626(vault).totalAssets()) revert AmountExceedsVaultAssets();
-
     uint256 newLocked = currentLocked() + amount;
     if (newLocked > type(uint128).max) revert LockedOverflow();
 

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -1935,18 +1935,6 @@ contract LendingBrokerTest is Test {
     vault.setLockBuffer(address(wrongProxy));
   }
 
-  /// @dev notifyBrokerInterest reverts when amount exceeds vault.totalAssets().
-  function test_lockBuffer_notifyExceedingTotalAssetsReverts() public {
-    bytes32 relayerRole = lockBuffer.RELAYER();
-    vm.startPrank(ADMIN);
-    lockBuffer.grantRole(relayerRole, address(this));
-    vm.stopPrank();
-
-    // Vault has 0 totalAssets — any positive amount must be rejected.
-    vm.expectRevert(BrokerInterestLockBuffer.AmountExceedsVaultAssets.selector);
-    lockBuffer.notifyBrokerInterest(1);
-  }
-
   /// @dev setLockBuffer refuses a buffer with residual locked balance.
   function test_lockBuffer_setLockBufferNonZeroLockedReverts() public {
     _enableLockBuffer();

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -1935,18 +1935,61 @@ contract LendingBrokerTest is Test {
     vault.setLockBuffer(address(wrongProxy));
   }
 
-  /// @dev setLockBuffer refuses a buffer with residual locked balance.
-  function test_lockBuffer_setLockBufferNonZeroLockedReverts() public {
+  /// @dev setLockBuffer refuses to detach or replace a buffer that still has locked balance.
+  function test_lockBuffer_setLockBufferDetachWithLockedReverts() public {
     _enableLockBuffer();
     _depositToVault(address(0xA), 10_000 ether);
-    _triggerInterestFlush(50 ether); // pins 50 in the buffer
+    _triggerInterestFlush(50 ether); // pins 50 in the current buffer
 
+    // Detach (A → 0) must revert while the current buffer still has locked > 0.
+    vm.expectRevert(VaultErrorsLib.LockBufferNotEmpty.selector);
     vm.prank(MANAGER);
     vault.setLockBuffer(address(0));
 
+    // Replace (A → B) must revert too, even if B itself is empty.
+    BrokerInterestLockBuffer otherImpl = new BrokerInterestLockBuffer();
+    ERC1967Proxy otherProxy = new ERC1967Proxy(
+      address(otherImpl),
+      abi.encodeWithSelector(
+        BrokerInterestLockBuffer.initialize.selector,
+        ADMIN,
+        MANAGER,
+        address(vault),
+        address(LISUSD),
+        LOCK_DURATION
+      )
+    );
     vm.expectRevert(VaultErrorsLib.LockBufferNotEmpty.selector);
     vm.prank(MANAGER);
-    vault.setLockBuffer(address(lockBuffer));
+    vault.setLockBuffer(address(otherProxy));
+  }
+
+  /// @dev setLockBuffer refuses to attach a new buffer that already has locked balance.
+  function test_lockBuffer_setLockBufferAttachNonEmptyReverts() public {
+    // Vault starts with lockBuffer == address(0); deploy a fresh buffer and pre-load it.
+    BrokerInterestLockBuffer newImpl = new BrokerInterestLockBuffer();
+    ERC1967Proxy newProxy = new ERC1967Proxy(
+      address(newImpl),
+      abi.encodeWithSelector(
+        BrokerInterestLockBuffer.initialize.selector,
+        ADMIN,
+        MANAGER,
+        address(vault),
+        address(LISUSD),
+        LOCK_DURATION
+      )
+    );
+    BrokerInterestLockBuffer newBuffer = BrokerInterestLockBuffer(address(newProxy));
+
+    bytes32 relayerRole = newBuffer.RELAYER();
+    vm.startPrank(ADMIN);
+    newBuffer.grantRole(relayerRole, address(this));
+    vm.stopPrank();
+    newBuffer.notifyBrokerInterest(1 ether);
+
+    vm.expectRevert(VaultErrorsLib.LockBufferNotEmpty.selector);
+    vm.prank(MANAGER);
+    vault.setLockBuffer(address(newBuffer));
   }
 }
 

--- a/test/credit-loan/CreditBroker.t.sol
+++ b/test/credit-loan/CreditBroker.t.sol
@@ -1828,17 +1828,6 @@ contract CreditBrokerTest is Test {
     assertEq(lockBuffer.currentLocked(), 15 ether);
   }
 
-  /// @dev notifyBrokerInterest reverts when amount exceeds vault.totalAssets().
-  function test_lockBuffer_notifyExceedingTotalAssetsReverts() public {
-    bytes32 relayerRole = lockBuffer.RELAYER();
-    vm.startPrank(ADMIN);
-    lockBuffer.grantRole(relayerRole, address(this));
-    vm.stopPrank();
-
-    vm.expectRevert(BrokerInterestLockBuffer.AmountExceedsVaultAssets.selector);
-    lockBuffer.notifyBrokerInterest(1);
-  }
-
   /// @dev setLockBuffer refuses a buffer with residual locked balance.
   function test_lockBuffer_setLockBufferNonZeroLockedReverts() public {
     _enableLockBuffer();

--- a/test/credit-loan/CreditBroker.t.sol
+++ b/test/credit-loan/CreditBroker.t.sol
@@ -1828,17 +1828,59 @@ contract CreditBrokerTest is Test {
     assertEq(lockBuffer.currentLocked(), 15 ether);
   }
 
-  /// @dev setLockBuffer refuses a buffer with residual locked balance.
-  function test_lockBuffer_setLockBufferNonZeroLockedReverts() public {
+  /// @dev setLockBuffer refuses to detach or replace a buffer that still has locked balance.
+  function test_lockBuffer_setLockBufferDetachWithLockedReverts() public {
     _enableLockBuffer();
     _depositToVault(address(0xA), 10_000 ether);
-    _triggerInterestFlush(50 ether); // pins 50 in the buffer
+    _triggerInterestFlush(50 ether); // pins 50 in the current buffer
 
+    // Detach (A → 0) must revert while the current buffer still has locked > 0.
+    vm.expectRevert(VaultErrorsLib.LockBufferNotEmpty.selector);
     vm.prank(MANAGER);
     vault.setLockBuffer(address(0));
 
+    // Replace (A → B) must revert too, even if B itself is empty.
+    BrokerInterestLockBuffer otherImpl = new BrokerInterestLockBuffer();
+    ERC1967Proxy otherProxy = new ERC1967Proxy(
+      address(otherImpl),
+      abi.encodeWithSelector(
+        BrokerInterestLockBuffer.initialize.selector,
+        ADMIN,
+        MANAGER,
+        address(vault),
+        address(USDT),
+        LOCK_DURATION
+      )
+    );
     vm.expectRevert(VaultErrorsLib.LockBufferNotEmpty.selector);
     vm.prank(MANAGER);
-    vault.setLockBuffer(address(lockBuffer));
+    vault.setLockBuffer(address(otherProxy));
+  }
+
+  /// @dev setLockBuffer refuses to attach a new buffer that already has locked balance.
+  function test_lockBuffer_setLockBufferAttachNonEmptyReverts() public {
+    BrokerInterestLockBuffer newImpl = new BrokerInterestLockBuffer();
+    ERC1967Proxy newProxy = new ERC1967Proxy(
+      address(newImpl),
+      abi.encodeWithSelector(
+        BrokerInterestLockBuffer.initialize.selector,
+        ADMIN,
+        MANAGER,
+        address(vault),
+        address(USDT),
+        LOCK_DURATION
+      )
+    );
+    BrokerInterestLockBuffer newBuffer = BrokerInterestLockBuffer(address(newProxy));
+
+    bytes32 relayerRole = newBuffer.RELAYER();
+    vm.startPrank(ADMIN);
+    newBuffer.grantRole(relayerRole, address(this));
+    vm.stopPrank();
+    newBuffer.notifyBrokerInterest(1 ether);
+
+    vm.expectRevert(VaultErrorsLib.LockBufferNotEmpty.selector);
+    vm.prank(MANAGER);
+    vault.setLockBuffer(address(newBuffer));
   }
 }


### PR DESCRIPTION
## 📄 Description
Address audit findings on top of the audited commit `47d3fc274286b947fd9f7d6778e83e0a29944c80`.

  ## Commits in this PR
  
  ### `7b94af2` — `fix: drop notify totalAssets cap and document vault seed requirement`
  Closes **High Issue_03** and **Medium Issue_20**. The post-supply `amount > IERC4626(vault).totalAssets()` check evaluated against `R + A − L`; whenever `L > R` (reachable via Moolah bad-debt socialisation), the check failed for any positive `A`, reverting every broker repay / liquidation / penalty / credit-broker recovery touching the buffer. The
   check has been removed entirely; defence-in-depth for the inflation surface is now provided by the operational seed deposit (next commit) and the existing `currentLocked() == 0` binding check on `setLockBuffer`. As a side effect, **Low Issue_23** (majority-holder sandwich brick) no longer applies — the check it relied on is gone.

  Adds a third item to the rollout reminder in `script/utils/deploy_brokerInterestLockBuffer.s.sol` requiring a governance dead-share seed deposit before `vault.setLockBuffer(...)`. This addresses **Medium Issue_06** (orphaned buffered rewards if vault becomes empty) and provides operational mitigation for **Medium Issue_04** Impact 1 / Impact 3 — 
  with a permanent non-zero `totalSupply` and `totalAssets`, the inflation-attack window and the `maxWithdraw / maxRedeem` clamp window cannot open.

  ### `f891e5a` — `chore: drop redundant __gap and short-circuit zero-locked path`
  Three Informational findings in one commit on `src/utils/BrokerInterestLockBuffer.sol`:

  - **Issue_24**: removes the unused `uint256[45] private __gap`. The buffer is a standalone UUPS proxy, never inherited, so the storage gap serves no purpose.
  - **Issue_28**: adds an early return in `currentLocked()` when `lockedAmount == 0`, saving the load + arithmetic on the hot read path (`totalAssets()` calls this on every deposit/withdraw/mint/redeem).
  - **Issue_27**: removes the redundant `if (dur == 0) return 0;` line — `initialize()` and `setDuration()` both enforce `dur >= MIN_DURATION = 1 hours`, and the existing `elapsed >= dur` branch already returns 0 if `dur == 0` ever did appear.

  ### `cd50106` — `chore: emit SetName / SetSymbol events on vault metadata changes`
  Closes **Informational Issue_16**. Adds `EventsLib.SetName(string)` and `EventsLib.SetSymbol(string)` and emits them from `MoolahVault.setName` / `setSymbol`.
