### PR TITLE
Audit: collateral yield vault

### DIFF
--- a/script/collateralYieldVault/deploy_collateral_yield_vault.sol
+++ b/script/collateralYieldVault/deploy_collateral_yield_vault.sol
@@ -67,7 +67,9 @@ contract DeployCollateralYieldVault is DeployBase {
     // 2. delegate slisBNBx to the governance-approved MPC.
     vault.setDelegateTarget(MPC1);
 
-    // 3. dead seed deposit: keeps totalSupply > 0 forever (whitelist still empty == open here).
+    // 3. dead seed deposit (NOTICE): governance makes the FIRST deposit so any pre-genesis donation is absorbed
+    //    into unredeemable dead shares instead of poisoning the rate; also keeps totalSupply > 0 forever. A donation
+    //    large enough to round this to 0 shares reverts (depositBNB zero-share guard) → redeploy with larger SEED_BNB.
     uint256 seedShares = vault.depositBNB{ value: SEED_BNB }(DEAD);
     console.log("Seed shares minted to dead address:", seedShares);
     require(vault.totalSupply() == seedShares && seedShares > 0, "seed failed");

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -9,7 +9,7 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { IMoolah, MarketParams, Market, Id } from "moolah/interfaces/IMoolah.sol";
 import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { WAD } from "moolah/libraries/MathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
@@ -97,6 +97,8 @@ contract CollateralYieldVault is
 
   error ZeroAmount();
   error SharesOutstanding();
+  error MarketNotCreated();
+  error ProviderNotRegistered();
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(address _provider) {
@@ -127,6 +129,12 @@ contract CollateralYieldVault is
   ) external initializer {
     if (admin == address(0) || manager == address(0) || pauser == address(0)) revert ErrorsLib.ZeroAddress();
     if (_marketParams.collateralToken != SLIS_BNB) revert ErrorsLib.TokenMismatch();
+    // Fail fast on a misconfigured market: it must exist on Moolah and have PROVIDER registered as its slisBNB
+    // collateral provider, otherwise every supply/withdraw (and thus the whole vault) would be bricked or NAV
+    // would silently under-report. The market params are immutable after this, so validate them here.
+    Id id = _marketParams.id();
+    if (MOOLAH.market(id).lastUpdate == 0) revert MarketNotCreated();
+    if (MOOLAH.providers(id, SLIS_BNB) != address(PROVIDER)) revert ProviderNotRegistered();
 
     __AccessControl_init();
     __ReentrancyGuard_init();

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -9,7 +9,8 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { MarketParams } from "moolah/interfaces/IMoolah.sol";
+import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { WAD } from "moolah/libraries/MathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
 import { ConstantsLib } from "./libraries/ConstantsLib.sol";
@@ -41,6 +42,7 @@ contract CollateralYieldVault is
   using UtilsLib for uint256;
   using SafeERC20 for IERC20;
   using EnumerableSet for EnumerableSet.AddressSet;
+  using MarketParamsLib for MarketParams;
 
   /* IMMUTABLES */
 
@@ -50,6 +52,8 @@ contract CollateralYieldVault is
   IStakeManager public immutable STAKE_MANAGER;
   /// @notice SlisBNBProvider that holds the Moolah collateral position on behalf of this vault.
   ISlisBnbProvider public immutable PROVIDER;
+  /// @notice Moolah lending market contract, read from the provider at construction.
+  IMoolah public immutable MOOLAH;
 
   /* ROLES */
 
@@ -101,6 +105,7 @@ contract CollateralYieldVault is
     // slisBNBxMinter is read dynamically at use (the provider may re-set it).
     SLIS_BNB = PROVIDER.TOKEN();
     STAKE_MANAGER = IStakeManager(PROVIDER.STAKE_MANAGER());
+    MOOLAH = IMoolah(PROVIDER.MOOLAH());
     // asset is always slisBNB (18 decimals) => ERC4626 decimals offset is 0 (the inherited default).
   }
 
@@ -150,6 +155,7 @@ contract CollateralYieldVault is
     uint256 newTotalAssets = _accrueFee();
     lastTotalAssets = newTotalAssets;
     shares = _convertToSharesWithTotals(assets, totalSupply(), newTotalAssets, Math.Rounding.Floor);
+    if (shares == 0) revert ZeroAmount();
     _deposit(_msgSender(), receiver, assets, shares);
   }
 
@@ -238,19 +244,25 @@ contract CollateralYieldVault is
   /* VIEWS */
 
   /// @inheritdoc IERC4626
-  /// @dev NAV = the vault's slisBNB collateral tracked by the provider. Note: an external party can raise this by
-  ///      calling `SlisBNBProvider.supplyCollateral(onBehalf=vault)` (a donation that benefits holders).
+  /// @dev NAV = the vault's slisBNB collateral in *this exact Moolah market*, read live from Moolah. Reading the
+  ///      per-market position (not the provider's cross-market `userTotalDeposit`) ensures NAV only ever reflects
+  ///      collateral that the vault can actually withdraw from this market, so slisBNB the vault supplies to any
+  ///      other market cannot inflate the share price. Note: an external party can still raise this by calling
+  ///      `SlisBNBProvider.supplyCollateral(onBehalf=vault)` against this market (a donation that benefits holders).
   function totalAssets() public view override returns (uint256) {
-    return PROVIDER.userTotalDeposit(address(this));
+    return MOOLAH.position(marketParams.id(), address(this)).collateral;
   }
 
+  /// @dev Mirrors the deposit gate (`whenNotPaused` + `_checkWhiteList`): a deposit reverts unless BOTH the caller
+  ///      and the receiver are whitelisted, so reflect the `_msgSender()` whitelist here too.
   function maxDeposit(address receiver) public view override returns (uint256) {
-    if (paused() || !isWhiteList(receiver)) return 0;
+    if (paused() || !isWhiteList(_msgSender()) || !isWhiteList(receiver)) return 0;
     return type(uint256).max;
   }
 
+  /// @dev See {maxDeposit}: reflects both the caller and receiver whitelist so it cannot signal a mint that reverts.
   function maxMint(address receiver) public view override returns (uint256) {
-    if (paused() || !isWhiteList(receiver)) return 0;
+    if (paused() || !isWhiteList(_msgSender()) || !isWhiteList(receiver)) return 0;
     return type(uint256).max;
   }
 

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -29,6 +29,8 @@ import { ICollateralYieldVault } from "./interfaces/ICollateralYieldVault.sol";
 ///         (BOT-only) which stakes BNB->slisBNB, supplies it, and raises the share price. Performance fee follows the
 ///         MoolahVault model (fee-share dilution, high-water `lastTotalAssets`); `fee` is 0 at launch.
 ///         The vault is client-agnostic: per-deployment branding lives only in the token name/symbol.
+/// @dev NOTICE: correctness depends on the underlying SlisBNBProvider / SlisBNBxMinter / Moolah config staying
+///      consistent. Deregistering the provider from the market would lock collateral; governance must manage these.
 contract CollateralYieldVault is
   UUPSUpgradeable,
   AccessControlEnumerableUpgradeable,
@@ -222,6 +224,8 @@ contract CollateralYieldVault is
   ///         the increment. Mints no user shares => share price rises. Initial `fee` = 0 => increment fully accrues
   ///         to holders. Only the slisBNB minted from this call's `msg.value` is compounded (measured as a balance
   ///         delta), so any unrelated slisBNB sitting in the vault is never swept into the position here.
+  /// @dev NOTICE: rewards injected while totalSupply == 0 accrue to the virtual shares. The deploy-time dead-seed
+  ///      first deposit keeps supply > 0, so this state is not reached in practice.
   function increaseVaultAssets() external payable override onlyRole(BOT) nonReentrant whenNotPaused {
     if (msg.value == 0) revert ZeroAmount();
 
@@ -267,6 +271,8 @@ contract CollateralYieldVault is
   }
 
   /// @notice If the whitelist is empty it is treated as open (everyone allowed).
+  /// @dev NOTICE: intentional — launches with the whitelist OFF (open). Enabling it later is a deliberate
+  ///      governance action that, by design, then restricts existing non-listed holders.
   function isWhiteList(address account) public view returns (bool) {
     return userWhiteList.length() == 0 || userWhiteList.contains(account);
   }
@@ -277,13 +283,15 @@ contract CollateralYieldVault is
 
   /* MANAGER: FEE */
 
-  function setFee(uint256 newFee) external onlyRole(MANAGER) {
+  /// @dev NOTICE: `_accrueFee()` charges the old rate on NAV realized so far, but rewards already in the harvester
+  ///      yet not compounded will be charged at the new rate. Bounded by `MAX_FEE`; MANAGER is trusted.
+  function setFee(uint96 newFee) external onlyRole(MANAGER) {
     if (newFee == fee) revert ErrorsLib.AlreadySet();
     if (newFee > ConstantsLib.MAX_FEE) revert ErrorsLib.MaxFeeExceeded();
     if (newFee != 0 && feeRecipient == address(0)) revert ErrorsLib.ZeroFeeRecipient();
 
     _updateLastTotalAssets(_accrueFee());
-    fee = uint96(newFee);
+    fee = newFee;
     emit SetFee(_msgSender(), newFee);
   }
 
@@ -331,8 +339,8 @@ contract CollateralYieldVault is
     if (amount > 0) {
       PROVIDER.withdrawCollateral(marketParams, amount, address(this), to);
       _updateLastTotalAssets(0);
+      emit Swept(to, amount);
     }
-    emit Swept(to, amount);
   }
 
   /// @notice Recover stray tokens / native BNB held by the vault (e.g. directly-donated slisBNB that
@@ -360,11 +368,16 @@ contract CollateralYieldVault is
 
   /* INTERNAL: ERC4626 hooks */
 
+  /// @dev NOTICE: both caller and receiver must be whitelisted, so gasless/meta-tx relayers cannot deposit on a
+  ///      user's behalf (a whitelisted relayer would let anyone bypass the list). Strict by design.
   function _checkWhiteList(address receiver) private view {
     require(isWhiteList(_msgSender()) && isWhiteList(receiver), ErrorsLib.NotWhiteList());
   }
 
   /// @dev super._deposit pulls slisBNB from caller and mints shares; then supply it as collateral.
+  /// @dev NOTICE: supply/withdraw go through the provider's `_syncPosition` -> SlisBNBxMinter.rebalance. A pending
+  ///      module config change (feeRate up / discount down) or a frontrun that exhausts MPC mint cap can make this
+  ///      supply revert (EXCEED_MPC_CAP). Governance must keep MPC caps sufficient; monitor for grief attempts.
   function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
     super._deposit(caller, receiver, assets, shares);
     PROVIDER.supplyCollateral(marketParams, assets, address(this), "");
@@ -436,14 +449,17 @@ contract CollateralYieldVault is
   function _accrueFee() internal returns (uint256 newTotalAssets) {
     uint256 feeShares;
     (feeShares, newTotalAssets) = _accruedFeeShares();
-    if (feeShares != 0) _mint(feeRecipient, feeShares);
-    emit AccrueInterest(newTotalAssets, feeShares);
+    if (feeShares != 0) {
+      _mint(feeRecipient, feeShares);
+      emit AccrueInterest(newTotalAssets, feeShares);
+    }
   }
 
   function _accruedFeeShares() internal view returns (uint256 feeShares, uint256 newTotalAssets) {
     newTotalAssets = totalAssets();
     uint256 totalInterest = newTotalAssets.zeroFloorSub(lastTotalAssets);
     if (totalInterest != 0 && fee != 0) {
+      // NOTICE: rounds the fee down (favoring holders); negligible since totalInterest is BOT-injected, not dust.
       uint256 feeAssets = totalInterest.mulDiv(fee, WAD);
       feeShares = _convertToSharesWithTotals(feeAssets, totalSupply(), newTotalAssets - feeAssets, Math.Rounding.Floor);
     }

--- a/src/moolah-vault/CollateralYieldVault.sol
+++ b/src/moolah-vault/CollateralYieldVault.sol
@@ -167,6 +167,7 @@ contract CollateralYieldVault is
     uint256 newTotalAssets = _accrueFee();
     lastTotalAssets = newTotalAssets;
     assets = _convertToAssetsWithTotals(shares, totalSupply(), newTotalAssets, Math.Rounding.Ceil);
+    if (assets == 0) revert ZeroAmount();
     _deposit(_msgSender(), receiver, assets, shares);
   }
 
@@ -175,8 +176,9 @@ contract CollateralYieldVault is
     _checkWhiteList(receiver);
     if (msg.value == 0) revert ZeroAmount();
 
+    // No interim `lastTotalAssets = newTotalAssets` write: nothing here reads it before the final
+    // `_updateLastTotalAssets(newTotalAssets + assets)` (unlike `deposit`/`mint`, whose `_deposit` reads it).
     uint256 newTotalAssets = _accrueFee();
-    lastTotalAssets = newTotalAssets;
 
     uint256 balBefore = IERC20(SLIS_BNB).balanceOf(address(this));
     STAKE_MANAGER.deposit{ value: msg.value }();
@@ -318,8 +320,12 @@ contract CollateralYieldVault is
 
   /* MANAGER: DELEGATE TARGET (MPC) */
 
+  /// @dev NOTICE: `target` must not be one of the minter's fee MPC wallets — delegating there corrupts the fee
+  ///      ledger (the switch's burn cannot tell fee tokens from delegated ones). The vault cannot enumerate those
+  ///      wallets via the minter interface, so governance must ensure this when choosing the target.
   function setDelegateTarget(address target) external onlyRole(MANAGER) {
     if (target == address(0)) revert ErrorsLib.ZeroAddress();
+    if (target == delegateTarget) revert ErrorsLib.AlreadySet(); // minter no-ops on same target; avoid misleading event
     delegateTarget = target;
     // Redirect 100% of the vault's slisBNBx to the chosen MPC (minter read from the provider).
     ISlisBNBxMinter(PROVIDER.slisBNBxMinter()).delegateAllTo(target);
@@ -332,6 +338,8 @@ contract CollateralYieldVault is
   ///         (last-redeemer rounding dust), and reset the vault to a clean empty state.
   /// @dev Gated on `totalSupply() == 0`: with no shares outstanding nothing backs user value, so this can never
   ///      touch share-backed funds. A deploy-time dead seed deposit keeps supply > 0 and prevents this state.
+  /// @dev NOTICE: under the intended dead-seed deployment supply never returns to 0, so this is effectively
+  ///      unreachable. Retained intentionally as a safety net for non-seeded/edge deployments; left as-is.
   function sweep(address to) external onlyRole(MANAGER) nonReentrant returns (uint256 amount) {
     if (totalSupply() != 0) revert SharesOutstanding();
     if (to == address(0)) revert ErrorsLib.ZeroAddress();

--- a/src/provider/interfaces/IProvider.sol
+++ b/src/provider/interfaces/IProvider.sol
@@ -28,6 +28,8 @@ interface ISlisBnbProvider is IProvider {
   function slisBNBxMinter() external view returns (address);
 
   function STAKE_MANAGER() external view returns (address);
+
+  function MOOLAH() external view returns (address);
 }
 interface ISmartProvider is IProvider {
   function dexLP() external view returns (address);

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -91,7 +91,9 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
   /// @dev NOTICE: since distributor claims are permissionless, MANAGER can claim all rewards here and drain them via
   ///      `rescue`. Use a strong multisig for the MANAGER role to mitigate key-compromise.
   function rescue(address token, address to, uint256 amount) external onlyRole(MANAGER) {
-    require(to != address(0), "zero to");
+    // Reject this contract as the recipient: a self-rescue would not move funds out, leaving them subject to the
+    // next harvest's full-balance compound while emitting a misleading Rescued event.
+    require(to != address(0) && to != address(this), "invalid to");
     if (token == address(0)) {
       (bool ok, ) = payable(to).call{ value: amount }("");
       require(ok, "bnb transfer failed");

--- a/src/utils/RewardHarvester.sol
+++ b/src/utils/RewardHarvester.sol
@@ -60,13 +60,21 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
   /// @param claims Per-epoch claim data (epochId, amount, Merkle proof). `_account` is hardcoded to this contract,
   ///        so the distributor pays the harvester directly and the BOT cannot redirect the funds.
   /// @param minBNBOut Minimum total BNB balance required after claiming (anti-anomaly / sanity bound).
+  /// @dev NOTICE: distributor `claim` is permissionless and always pays this harvester, so anyone can claim extra
+  ///      epochs; `harvest` compounds the full balance, so the injected amount may exceed sum(claims[i].amount).
+  ///      Only ever raises share price. `minBNBOut` is a lower bound, not an equality.
+  /// @dev NOTICE: if the Moolah market is paused, `supplyCollateral` (and thus `harvest`) reverts. While paused,
+  ///      claim directly on the distributor (funds still land here via the fixed `_account`) and call `harvest`
+  ///      after unpause to avoid epochs expiring unclaimed.
   function harvest(ClaimParams[] calldata claims, uint256 minBNBOut) external onlyRole(BOT) nonReentrant {
+    uint256 claimCount;
     for (uint256 i; i < claims.length; ++i) {
       // The Merkle tree's `_account` is configured off-chain to this RewardHarvester, so the distributor pays the
       // launchpool BNB to this contract — receiving it on behalf of the vault — and we then compound it in.
       // Skip already-claimed epochs to keep the batch idempotent.
       if (DISTRIBUTOR.claimed(claims[i].epochId, address(this))) continue;
       DISTRIBUTOR.claim(claims[i].epochId, address(this), claims[i].amount, claims[i].proof);
+      ++claimCount;
     }
 
     uint256 bnbBal = address(this).balance;
@@ -75,10 +83,13 @@ contract RewardHarvester is UUPSUpgradeable, AccessControlEnumerableUpgradeable,
 
     VAULT.increaseVaultAssets{ value: bnbBal }();
 
-    emit Harvested(claims.length, bnbBal);
+    // Emit the number of epochs actually claimed this call (already-claimed epochs are skipped above).
+    emit Harvested(claimCount, bnbBal);
   }
 
   /// @notice Emergency recovery of stranded tokens/BNB (e.g. a non-BNB reward token). Manager-only.
+  /// @dev NOTICE: since distributor claims are permissionless, MANAGER can claim all rewards here and drain them via
+  ///      `rescue`. Use a strong multisig for the MANAGER role to mitigate key-compromise.
   function rescue(address token, address to, uint256 amount) external onlyRole(MANAGER) {
     require(to != address(0), "zero to");
     if (token == address(0)) {


### PR DESCRIPTION
  ## Summary
  
  Adds a new ERC-4626 vault (`CollateralYieldVault`) and its reward-compounding
  helper (`RewardHarvester`) for the slisBNB Launchpool yield strategy.

  Users deposit **slisBNB** (or native BNB, auto-staked via `StakeManager`). The
  deposited slisBNB is supplied as **Moolah collateral with no borrow**, so the
  position is never liquidatable. The minted **slisBNBx** is 100% delegated to a
  governance-set MPC (`delegateTarget`) that participates in Binance Launchpool.
  A backend bot harvests the Launchpool BNB rewards and compounds them back into
  the position via `increaseVaultAssets`, raising the share price without minting
  new shares.
  
  Users therefore earn **double yield**: slisBNB staking appreciation (in BNB
  terms) plus compounded Launchpool rewards.

  ## Architecture

  deposit/depositBNB ──► slisBNB ──► SlisBNBProvider.supplyCollateral (no borrow)
                                           │
                                           ├─► Moolah collateral position (vault NAV)
                                           └─► slisBNBx minted ──► delegateAllTo(MPC) ──► Launchpool

  Launchpool BNB ──► RewardHarvester.harvest ──► increaseVaultAssets ──► (stake + supply) ──► share price ↑
  
  - **`asset` = slisBNB (18 decimals)**. `totalAssets()` reads the vault's
    collateral in its exact Moolah market.
  - **Performance fee** follows the MoolahVault model (fee-share dilution,
    high-water `lastTotalAssets`); `fee = 0` at launch.
  - **Roles**: `DEFAULT_ADMIN_ROLE` (timelock/governance, UUPS upgrades),
    `MANAGER` (fee, whitelist, delegate target, sweep, emergency withdraw),
    `PAUSER` (pause deposits/compounding), `BOT` (held by `RewardHarvester`,
    calls `increaseVaultAssets`).
  - **UUPS upgradeable**, `ReentrancyGuard`, `Pausable`, optional user whitelist
    (empty == open).
  
  ## Files

  | File | Change |
  |---|---|
  | `src/moolah-vault/CollateralYieldVault.sol` | new vault (+485) |
  | `src/moolah-vault/interfaces/ICollateralYieldVault.sol` | new interface (+10) |
  | `src/utils/RewardHarvester.sol` | new harvester (+110) |
  | `src/utils/interfaces/IClisBNBLaunchPoolDistributor.sol` | new interface (+12) |
  | `src/provider/interfaces/IProvider.sol` | extend `ISlisBnbProvider` (+44) |
  | `src/provider/interfaces/IStakeManager.sol` | add `deposit()` (+11) |
  | `script/collateralYieldVault/deploy_collateral_yield_vault.sol` | deploy + dead-seed (+89) |
  | `test/moolah-vault/CollateralYieldVault.t.sol` | fork tests (+402) |
  | `test/utils/RewardHarvester.t.sol` | tests (+229) |

  ## Deployment notes
  
  - Deploy script seeds a **dead first deposit** (shares minted to `0x…dEaD`) so
    `totalSupply > 0` from genesis — neutralizes first-deposit inflation,
    captures any pre-genesis donation, and avoids last-redeemer dust.
  - Prerequisites: the slisBNB Moolah market exists, `SlisBNBProvider` is its
    registered provider (now enforced by `initialize`), and the provider's
    `slisBNBxMinter` has spare MPC fee-wallet capacity.

  ## Testing
```
  forge test --mc "CollateralYieldVault|RewardHarvester" -vv
```
