### PR TITLE
feat: move StockOracleSwitch setGlobal to MANAGER + add batchSetStatus

### DIFF
--- a/script/oracle/deploy_stockOracle.sol
+++ b/script/oracle/deploy_stockOracle.sol
@@ -11,7 +11,7 @@ import { StockOracleSwitch } from "../../src/oracle/StockOracleSwitch.sol";
 /// @notice Deploys StockOracleSwitch + StockOracle (UUPS proxies) and registers the managed bStocks.
 ///         admin = manager = deployer (hand off later via deploy_stockOracleTransferRole.sol);
 ///         BOT is a dedicated wallet. Network config (resilient oracle, bot, stock list) is resolved
-///         by chain id. The market stays CLOSED after deploy (globalEnabled = false) until the BOT opens it.
+///         by chain id. The market stays CLOSED after deploy (globalEnabled = false) until MANAGER opens it.
 contract StockOracleDeploy is DeployBase {
   function run() public {
     uint256 deployerPrivateKey = _deployerKey();
@@ -57,7 +57,7 @@ contract StockOracleDeploy is DeployBase {
     console.log("StockOracle proxy: ", address(oracle));
 
     // --- Register managed bStocks. setStock also enables each per-stock; the market stays closed
-    //     globally until the BOT calls setGlobal(true) during trading hours. ---
+    //     globally until MANAGER calls setGlobal(true) during trading hours. ---
     for (uint256 i = 0; i < stocks.length; i++) {
       stockSwitch.setStock(stocks[i], true);
       console.log("registered stock: ", stocks[i]);

--- a/src/oracle/StockOracleSwitch.sol
+++ b/src/oracle/StockOracleSwitch.sol
@@ -6,15 +6,16 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 /// @title StockOracleSwitch
 /// @notice Market open/closed control for tokenized stocks (bStocks), consumed by {StockOracle}.
-/// @dev    Two orthogonal layers:
+/// @dev    Layers:
 ///         - `registered` (MANAGER): whether a token is a managed stock. Unregistered tokens are NOT
 ///           gated (e.g. the loan token USDT) — {StockOracle} passes them straight through.
-///         - open/closed (BOT): a per-stock `enabled` flag plus a single `globalEnabled` market-hours
-///           switch. A registered stock is enabled only while both the global switch and its own flag are on.
+///         - per-stock `enabled` (BOT): toggled individually via open / close, or in bulk via batchSetStatus.
+///         - global market switch `globalEnabled` (MANAGER): the market-hours switch (setGlobal). A
+///           registered stock is enabled only while both the global switch and its own flag are on.
 ///         PAUSER can force the whole market closed in an emergency (globalEnabled = false).
 contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeable {
-  bytes32 public constant MANAGER = keccak256("MANAGER"); // register / un-register stocks; admins BOT
-  bytes32 public constant BOT = keccak256("BOT"); // global daily switch + per-stock open / close
+  bytes32 public constant MANAGER = keccak256("MANAGER"); // register / un-register stocks; global daily switch; admins BOT
+  bytes32 public constant BOT = keccak256("BOT"); // per-stock open / close (single + batch)
   bytes32 public constant PAUSER = keccak256("PAUSER"); // emergency force-close
 
   /// @dev token => is a managed stock. Unregistered (false) => passthrough (never gated).
@@ -38,8 +39,8 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
   }
 
   /// @param admin   DEFAULT_ADMIN_ROLE holder (upgrade + role admin)
-  /// @param manager MANAGER role (register / un-register stocks; admins BOT)
-  /// @param bot     BOT role (global daily switch + per-stock open / close)
+  /// @param manager MANAGER role (register / un-register stocks; global daily switch; admins BOT)
+  /// @param bot     BOT role (per-stock open / close, single + batch)
   /// @param pauser  PAUSER role (emergency force-close)
   function initialize(address admin, address manager, address bot, address pauser) external initializer {
     require(admin != address(0), ZeroAddress());
@@ -54,7 +55,7 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
     _grantRole(PAUSER, pauser);
     // MANAGER administers the BOT role, so it can grant / revoke BOT via grantRole / revokeRole.
     _setRoleAdmin(BOT, MANAGER);
-    // globalEnabled stays false on purpose: market is closed until BOT opens it.
+    // globalEnabled stays false on purpose: market is closed until MANAGER opens it.
   }
 
   /// @notice Whether `token` is currently enabled (tradable). Unregistered tokens are always enabled (passthrough).
@@ -93,8 +94,23 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
     emit StockEnable(token, false);
   }
 
-  /// @notice Toggle the global market switch (daily open/close). BOT role.
-  function setGlobal(bool open) external onlyRole(BOT) {
+  /// @notice Bulk per-stock open/close. BOT role. Sets every token in `tokens` to `status`
+  ///         (true = open, false = close) in one call.
+  /// @dev    Idempotent: a token already in its target state is skipped (no event). Only registered stocks
+  ///         can be toggled — an unregistered token reverts the whole batch.
+  function batchSetStatus(address[] calldata tokens, bool status) external onlyRole(BOT) {
+    for (uint256 i; i < tokens.length; ++i) {
+      address token = tokens[i];
+      require(registered[token], NotRegistered());
+      if (enabled[token] != status) {
+        enabled[token] = status;
+        emit StockEnable(token, status);
+      }
+    }
+  }
+
+  /// @notice Toggle the global market switch (daily open/close). MANAGER role.
+  function setGlobal(bool open) external onlyRole(MANAGER) {
     require(open != globalEnabled, AlreadySet());
     globalEnabled = open;
     emit GlobalEnabledSet(open);

--- a/src/oracle/StockOracleSwitch.sol
+++ b/src/oracle/StockOracleSwitch.sol
@@ -79,7 +79,7 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
   }
 
   /// @notice Open a registered stock for trading. BOT role. Only registered stocks can be toggled.
-  function open(address token) external onlyRole(BOT) {
+  function open(address token) public onlyRole(BOT) {
     require(registered[token], NotRegistered());
     require(!enabled[token], AlreadySet());
     enabled[token] = true;
@@ -87,25 +87,21 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
   }
 
   /// @notice Close a registered stock. BOT role. Only registered stocks can be toggled.
-  function close(address token) external onlyRole(BOT) {
+  function close(address token) public onlyRole(BOT) {
     require(registered[token], NotRegistered());
     require(enabled[token], AlreadySet());
     enabled[token] = false;
     emit StockEnable(token, false);
   }
 
-  /// @notice Bulk per-stock open/close. BOT role. Sets every token in `tokens` to `status`
-  ///         (true = open, false = close) in one call.
-  /// @dev    Idempotent: a token already in its target state is skipped (no event). Only registered stocks
-  ///         can be toggled — an unregistered token reverts the whole batch.
+  /// @notice Bulk per-stock open/close. BOT role. Opens (`status = true`) or closes (`status = false`)
+  ///         every token in `tokens` in one call by delegating to {open} / {close}.
+  /// @dev    Strict: inherits the {open} / {close} guards, so a token already in the target state
+  ///         (AlreadySet) or not registered (NotRegistered) reverts the whole batch.
   function batchSetStatus(address[] calldata tokens, bool status) external onlyRole(BOT) {
     for (uint256 i; i < tokens.length; ++i) {
-      address token = tokens[i];
-      require(registered[token], NotRegistered());
-      if (enabled[token] != status) {
-        enabled[token] = status;
-        emit StockEnable(token, status);
-      }
+      if (status) open(tokens[i]);
+      else close(tokens[i]);
     }
   }
 

--- a/src/oracle/StockOracleSwitch.sol
+++ b/src/oracle/StockOracleSwitch.sol
@@ -67,8 +67,10 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
   }
 
   /// @notice Register or un-register a managed stock. MANAGER role.
-  /// @dev    Registering a stock enables it by default; un-registering disables it. BOT can
-  ///         independently toggle the per-stock flag afterwards via open / close.
+  /// @dev    Registering a stock enables it by default. Un-registering removes the token from managed-stock
+  ///         gating entirely: isEnabled then returns true (passthrough), which is NOT the same as closing it.
+  ///         Use close() to gate a registered stock without un-registering. While registered, BOT can toggle
+  ///         the per-stock flag via open / close.
   function setStock(address token, bool isStock) external onlyRole(MANAGER) {
     require(token != address(0), ZeroAddress());
     require(registered[token] != isStock, AlreadySet());
@@ -80,6 +82,7 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
 
   /// @notice Open a registered stock for trading. BOT role. Only registered stocks can be toggled.
   function open(address token) public onlyRole(BOT) {
+    require(token != address(0), ZeroAddress());
     require(registered[token], NotRegistered());
     require(!enabled[token], AlreadySet());
     enabled[token] = true;
@@ -88,6 +91,7 @@ contract StockOracleSwitch is AccessControlEnumerableUpgradeable, UUPSUpgradeabl
 
   /// @notice Close a registered stock. BOT role. Only registered stocks can be toggled.
   function close(address token) public onlyRole(BOT) {
+    require(token != address(0), ZeroAddress());
     require(registered[token], NotRegistered());
     require(enabled[token], AlreadySet());
     enabled[token] = false;

--- a/test/oracle/StockOracle.t.sol
+++ b/test/oracle/StockOracle.t.sol
@@ -64,7 +64,7 @@ contract StockOracleTest is Test {
   function _openStock(address token) internal {
     vm.prank(manager);
     stockSwitch.setStock(token, true); // registers AND enables
-    vm.prank(bot);
+    vm.prank(manager);
     stockSwitch.setGlobal(true);
   }
 
@@ -149,7 +149,7 @@ contract StockOracleTest is Test {
   function test_peek_revertsWhenStockDisabled() public {
     vm.prank(manager);
     stockSwitch.setStock(stock, true); // registered + enabled
-    vm.prank(bot);
+    vm.prank(manager);
     stockSwitch.setGlobal(true);
     vm.prank(bot);
     stockSwitch.close(stock); // market open, but the stock itself is disabled

--- a/test/oracle/StockOracleMoolahIntegration.t.sol
+++ b/test/oracle/StockOracleMoolahIntegration.t.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "../moolah/BaseTest.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+import { StockOracle } from "../../src/oracle/StockOracle.sol";
+import { StockOracleSwitch } from "../../src/oracle/StockOracleSwitch.sol";
+
+/// @dev I11 (HashDit audit): integration tests wiring StockOracle + StockOracleSwitch into Moolah market flows.
+///      The collateral token is a managed bStock gated by the switch; the loan token is unregistered (passthrough).
+///      Covers closed-market gating (borrow / liquidate revert), non-price actions surviving a close
+///      (repay / supplyCollateral), open-market happy paths, createMarket gating, and the PR #196 MANAGER/BOT split.
+contract StockOracleMoolahIntegrationTest is BaseTest {
+  using MarketParamsLib for MarketParams;
+
+  StockOracle internal stockOracle;
+  StockOracleSwitch internal stockSwitch;
+
+  MarketParams internal stockMarket;
+  Id internal stockId;
+
+  address internal STOCK_MANAGER = makeAddr("StockManager");
+  address internal STOCK_BOT = makeAddr("StockBot");
+  address internal STOCK_PAUSER = makeAddr("StockPauser");
+
+  uint256 internal constant SUPPLY_LIQUIDITY = 1_000e18;
+  uint256 internal constant COLLATERAL = 100e18;
+
+  function setUp() public override {
+    super.setUp();
+
+    // switch: admin=OWNER, manager=STOCK_MANAGER, bot=STOCK_BOT, pauser=STOCK_PAUSER
+    StockOracleSwitch swImpl = new StockOracleSwitch();
+    stockSwitch = StockOracleSwitch(
+      address(
+        new ERC1967Proxy(
+          address(swImpl),
+          abi.encodeWithSelector(StockOracleSwitch.initialize.selector, OWNER, STOCK_MANAGER, STOCK_BOT, STOCK_PAUSER)
+        )
+      )
+    );
+
+    // stock oracle delegates pricing to the BaseTest OracleMock (`oracle`) as the resilient (Atlas) feed
+    StockOracle soImpl = new StockOracle();
+    stockOracle = StockOracle(
+      address(
+        new ERC1967Proxy(
+          address(soImpl),
+          abi.encodeWithSelector(
+            StockOracle.initialize.selector,
+            OWNER,
+            STOCK_MANAGER,
+            address(stockSwitch),
+            address(oracle)
+          )
+        )
+      )
+    );
+
+    // register the collateral token as a managed stock and open the market (global + per-stock)
+    vm.startPrank(STOCK_MANAGER);
+    stockSwitch.setStock(address(collateralToken), true); // registers and enables the per-stock flag
+    stockSwitch.setGlobal(true); // MANAGER opens the global market switch
+    vm.stopPrank();
+    assertTrue(stockSwitch.isEnabled(address(collateralToken)), "stock should be open after setup");
+
+    // create the stock-collateral market with StockOracle as the market oracle (peeks succeed while open)
+    stockMarket = MarketParams(
+      address(loanToken),
+      address(collateralToken),
+      address(stockOracle),
+      address(irm),
+      DEFAULT_TEST_LLTV
+    );
+    stockId = stockMarket.id();
+    vm.prank(OWNER);
+    moolah.createMarket(stockMarket);
+
+    _forward(1);
+  }
+
+  /* ------------------------------------------------------------------ helpers */
+
+  function _closeStock() internal {
+    vm.prank(STOCK_BOT);
+    stockSwitch.close(address(collateralToken));
+    assertFalse(stockSwitch.isEnabled(address(collateralToken)), "stock should be closed");
+  }
+
+  /// @dev seed loan liquidity + a borrow position for BORROWER while the market is open.
+  function _seedBorrow(uint256 borrowAmt) internal {
+    loanToken.setBalance(SUPPLIER, SUPPLY_LIQUIDITY);
+    vm.prank(SUPPLIER);
+    moolah.supply(stockMarket, SUPPLY_LIQUIDITY, 0, SUPPLIER, hex"");
+
+    collateralToken.setBalance(BORROWER, COLLATERAL);
+    vm.startPrank(BORROWER);
+    moolah.supplyCollateral(stockMarket, COLLATERAL, BORROWER, hex"");
+    moolah.borrow(stockMarket, borrowAmt, 0, BORROWER, BORROWER);
+    vm.stopPrank();
+  }
+
+  /* ---------------------------------------------- switch CLOSED: price actions revert */
+
+  function test_borrow_revertsWhenClosed() public {
+    _seedBorrow(10e18);
+    _closeStock();
+
+    // health check peeks the (closed) collateral -> reverts
+    vm.prank(BORROWER);
+    vm.expectRevert(StockOracle.StockMarketClosed.selector);
+    moolah.borrow(stockMarket, 1e18, 0, BORROWER, BORROWER);
+  }
+
+  function test_liquidate_revertsWhenClosed() public {
+    _seedBorrow(79e18); // near max (maxBorrow = 100 * 0.8 = 80)
+    oracle.setPrice(address(collateralToken), ORACLE_PRICE_SCALE / 2); // now unhealthy
+    assertFalse(_isHealthy(stockMarket, BORROWER), "position should be unhealthy");
+
+    _closeStock();
+
+    loanToken.setBalance(LIQUIDATOR, SUPPLY_LIQUIDITY);
+    vm.prank(LIQUIDATOR);
+    vm.expectRevert(StockOracle.StockMarketClosed.selector);
+    moolah.liquidate(stockMarket, BORROWER, COLLATERAL, 0, hex"");
+  }
+
+  /* ------------------------------------------ switch CLOSED: non-price actions still work */
+
+  function test_repay_succeedsWhenClosed() public {
+    _seedBorrow(50e18);
+    _closeStock();
+
+    uint256 sharesBefore = moolah.position(stockId, BORROWER).borrowShares;
+    vm.prank(BORROWER);
+    moolah.repay(stockMarket, 10e18, 0, BORROWER, hex"");
+    assertLt(moolah.position(stockId, BORROWER).borrowShares, sharesBefore, "repay should reduce debt while closed");
+  }
+
+  function test_supplyCollateral_succeedsWhenClosed() public {
+    _closeStock();
+
+    collateralToken.setBalance(BORROWER, COLLATERAL);
+    vm.prank(BORROWER);
+    moolah.supplyCollateral(stockMarket, COLLATERAL, BORROWER, hex"");
+    assertEq(moolah.position(stockId, BORROWER).collateral, COLLATERAL, "collateral should be recorded while closed");
+  }
+
+  /* ------------------------------------------------------ switch OPEN: happy paths */
+
+  function test_borrow_succeedsWhenOpen() public {
+    _seedBorrow(50e18);
+    assertGt(moolah.position(stockId, BORROWER).borrowShares, 0, "borrow should succeed while open");
+  }
+
+  function test_liquidate_succeedsWhenOpen() public {
+    _seedBorrow(79e18);
+    oracle.setPrice(address(collateralToken), ORACLE_PRICE_SCALE / 2);
+    assertFalse(_isHealthy(stockMarket, BORROWER), "position should be unhealthy");
+
+    loanToken.setBalance(LIQUIDATOR, SUPPLY_LIQUIDITY);
+    vm.prank(LIQUIDATOR);
+    moolah.liquidate(stockMarket, BORROWER, COLLATERAL, 0, hex""); // seize all collateral
+    assertEq(moolah.position(stockId, BORROWER).collateral, 0, "collateral should be seized while open");
+  }
+
+  /* -------------------------------------------------------- createMarket gating */
+
+  function test_createMarket_revertsWhenClosedCollateral() public {
+    uint256 lltv = 0.5 ether;
+    vm.prank(OWNER);
+    moolah.enableLltv(lltv);
+
+    _closeStock();
+
+    MarketParams memory m = MarketParams(
+      address(loanToken),
+      address(collateralToken),
+      address(stockOracle),
+      address(irm),
+      lltv
+    );
+    vm.prank(OWNER);
+    vm.expectRevert(StockOracle.StockMarketClosed.selector);
+    moolah.createMarket(m);
+  }
+
+  function test_createMarket_succeedsWhenOpenCollateral() public {
+    uint256 lltv = 0.5 ether;
+    vm.prank(OWNER);
+    moolah.enableLltv(lltv);
+
+    MarketParams memory m = MarketParams(
+      address(loanToken),
+      address(collateralToken),
+      address(stockOracle),
+      address(irm),
+      lltv
+    );
+    vm.prank(OWNER);
+    moolah.createMarket(m); // stock is open (from setUp) -> both peeks succeed
+    assertGt(moolah.market(m.id()).lastUpdate, 0, "market should be created while open");
+  }
+
+  /* ------------------------------------------------------ PR #196 role split */
+
+  function test_roleSplit_botCannotSetGlobal() public {
+    bytes32 managerRole = stockSwitch.MANAGER(); // read before prank so it isn't consumed by this call
+    vm.prank(STOCK_BOT);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, STOCK_BOT, managerRole)
+    );
+    stockSwitch.setGlobal(false);
+  }
+
+  function test_roleSplit_managerCannotBatchSetStatus() public {
+    bytes32 botRole = stockSwitch.BOT(); // read before prank so it isn't consumed by this call
+    address[] memory toks = new address[](1);
+    toks[0] = address(collateralToken);
+    vm.prank(STOCK_MANAGER);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, STOCK_MANAGER, botRole)
+    );
+    stockSwitch.batchSetStatus(toks, false);
+  }
+}

--- a/test/oracle/StockOracleSwitch.t.sol
+++ b/test/oracle/StockOracleSwitch.t.sol
@@ -49,7 +49,7 @@ contract StockOracleSwitchTest is Test {
   function _openStock(address token) internal {
     vm.prank(manager);
     sw.setStock(token, true); // registers AND enables
-    vm.prank(bot);
+    vm.prank(manager);
     sw.setGlobal(true);
   }
 
@@ -115,7 +115,7 @@ contract StockOracleSwitchTest is Test {
   function test_isEnabled_unregisteredAlwaysEnabled() public {
     // unregistered token passes through (always enabled) regardless of the global switch
     assertTrue(sw.isEnabled(usdt), "unregistered should be enabled while global off");
-    vm.prank(bot);
+    vm.prank(manager);
     sw.setGlobal(true);
     assertTrue(sw.isEnabled(usdt), "unregistered should be enabled while global on");
   }
@@ -129,7 +129,7 @@ contract StockOracleSwitchTest is Test {
   function test_isEnabled_falseWhileStockDisabled() public {
     vm.prank(manager);
     sw.setStock(stock, true); // registered + enabled
-    vm.prank(bot);
+    vm.prank(manager);
     sw.setGlobal(true);
     vm.prank(bot);
     sw.close(stock); // BOT closes this specific stock
@@ -280,28 +280,124 @@ contract StockOracleSwitchTest is Test {
   }
 
   // ----------------------------------------------------------------------
-  //                          setGlobal (BOT)
+  //               batchSetStatus (BOT) — bulk open / close
   // ----------------------------------------------------------------------
 
-  function test_setGlobal_botTogglesAndEmits() public {
+  function test_batchSetStatus_closesThenOpensAll() public {
+    address s1 = makeAddr("s1");
+    address s2 = makeAddr("s2");
+    vm.startPrank(manager);
+    sw.setStock(s1, true); // registered + enabled
+    sw.setStock(s2, true); // registered + enabled
+    vm.stopPrank();
+
+    address[] memory tokens = new address[](2);
+    tokens[0] = s1;
+    tokens[1] = s2;
+
+    // close both in one call (events emitted in array order)
+    vm.expectEmit(true, false, false, true, address(sw));
+    emit StockEnable(s1, false);
+    vm.expectEmit(true, false, false, true, address(sw));
+    emit StockEnable(s2, false);
+    vm.prank(bot);
+    sw.batchSetStatus(tokens, false);
+    assertFalse(sw.enabled(s1), "s1 closed");
+    assertFalse(sw.enabled(s2), "s2 closed");
+
+    // re-open both in one call
+    vm.expectEmit(true, false, false, true, address(sw));
+    emit StockEnable(s1, true);
+    vm.expectEmit(true, false, false, true, address(sw));
+    emit StockEnable(s2, true);
+    vm.prank(bot);
+    sw.batchSetStatus(tokens, true);
+    assertTrue(sw.enabled(s1), "s1 reopened");
+    assertTrue(sw.enabled(s2), "s2 reopened");
+  }
+
+  function test_batchSetStatus_idempotentSkipsNoOps() public {
+    vm.prank(manager);
+    sw.setStock(stock, true); // registered + enabled
+
+    address[] memory tokens = new address[](1);
+    tokens[0] = stock;
+
+    vm.recordLogs();
+    vm.prank(bot);
+    sw.batchSetStatus(tokens, true); // already enabled -> no-op, must NOT revert
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+
+    assertEq(logs.length, 0, "no event emitted for a no-op");
+    assertTrue(sw.enabled(stock), "state unchanged");
+  }
+
+  function test_batchSetStatus_revertsForNonBot() public {
+    vm.prank(manager);
+    sw.setStock(stock, true);
+
+    address[] memory tokens = new address[](1);
+    tokens[0] = stock;
+
+    vm.prank(stranger);
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, BOT));
+    sw.batchSetStatus(tokens, false);
+  }
+
+  /// @dev an unregistered token reverts the whole batch — registered entries before it roll back.
+  function test_batchSetStatus_revertsAndRollsBackOnUnregistered() public {
+    vm.prank(manager);
+    sw.setStock(stock, true); // registered + enabled
+
+    address[] memory tokens = new address[](2);
+    tokens[0] = stock; // closed first
+    tokens[1] = usdt; // unregistered -> reverts
+
+    vm.prank(bot);
+    vm.expectRevert(StockOracleSwitch.NotRegistered.selector);
+    sw.batchSetStatus(tokens, false);
+
+    assertTrue(sw.enabled(stock), "batch reverted -> stock stays enabled (rolled back)");
+  }
+
+  function test_batchSetStatus_emptyTokensNoop() public {
+    address[] memory tokens = new address[](0);
+    vm.prank(bot);
+    sw.batchSetStatus(tokens, true); // no revert, nothing happens
+  }
+
+  // ----------------------------------------------------------------------
+  //                          setGlobal (MANAGER)
+  // ----------------------------------------------------------------------
+
+  function test_setGlobal_managerTogglesAndEmits() public {
     vm.expectEmit(false, false, false, true, address(sw));
     emit GlobalEnabledSet(true);
 
-    vm.prank(bot);
+    vm.prank(manager);
     sw.setGlobal(true);
 
     assertTrue(sw.globalEnabled());
   }
 
-  function test_setGlobal_revertsForNonBot() public {
+  function test_setGlobal_revertsForNonManager() public {
     vm.prank(stranger);
-    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, BOT));
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER)
+    );
+    sw.setGlobal(true);
+  }
+
+  /// @dev BOT no longer controls the global switch (it moved to MANAGER); BOT must be rejected.
+  function test_setGlobal_revertsForBot() public {
+    vm.prank(bot);
+    vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, bot, MANAGER));
     sw.setGlobal(true);
   }
 
   function test_setGlobal_revertsWhenSameValue() public {
     // defaults to false; setting false again must revert
-    vm.prank(bot);
+    vm.prank(manager);
     vm.expectRevert(StockOracleSwitch.AlreadySet.selector);
     sw.setGlobal(false);
   }
@@ -311,7 +407,7 @@ contract StockOracleSwitchTest is Test {
   // ----------------------------------------------------------------------
 
   function test_emergencyClose_pauserForcesClosed() public {
-    vm.prank(bot);
+    vm.prank(manager);
     sw.setGlobal(true);
     assertTrue(sw.globalEnabled(), "market open");
 
@@ -356,20 +452,24 @@ contract StockOracleSwitchTest is Test {
   function test_manager_grantedBotCanOperate() public {
     address newBot = makeAddr("newBot");
     vm.prank(manager);
+    sw.setStock(stock, true); // register (auto-enabled)
+    vm.prank(manager);
     sw.grantRole(BOT, newBot);
 
     vm.prank(newBot);
-    sw.setGlobal(true);
-    assertTrue(sw.globalEnabled(), "freshly granted BOT can flip the global switch");
+    sw.close(stock); // freshly granted BOT can toggle a per-stock flag
+    assertFalse(sw.enabled(stock), "freshly granted BOT can close a stock");
   }
 
   function test_manager_revokedBotCannotOperate() public {
+    vm.prank(manager);
+    sw.setStock(stock, true); // register so there is a stock to toggle
     vm.prank(manager);
     sw.revokeRole(BOT, bot);
 
     vm.prank(bot);
     vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, bot, BOT));
-    sw.setGlobal(true);
+    sw.close(stock);
   }
 
   /// @dev DEFAULT_ADMIN can no longer grant BOT directly: BOT's admin is now MANAGER.

--- a/test/oracle/StockOracleSwitch.t.sol
+++ b/test/oracle/StockOracleSwitch.t.sol
@@ -316,20 +316,17 @@ contract StockOracleSwitchTest is Test {
     assertTrue(sw.enabled(s2), "s2 reopened");
   }
 
-  function test_batchSetStatus_idempotentSkipsNoOps() public {
+  function test_batchSetStatus_revertsWhenAlreadyInState() public {
     vm.prank(manager);
     sw.setStock(stock, true); // registered + enabled
 
     address[] memory tokens = new address[](1);
     tokens[0] = stock;
 
-    vm.recordLogs();
+    // already enabled -> open() hits AlreadySet -> the whole batch reverts
     vm.prank(bot);
-    sw.batchSetStatus(tokens, true); // already enabled -> no-op, must NOT revert
-    Vm.Log[] memory logs = vm.getRecordedLogs();
-
-    assertEq(logs.length, 0, "no event emitted for a no-op");
-    assertTrue(sw.enabled(stock), "state unchanged");
+    vm.expectRevert(StockOracleSwitch.AlreadySet.selector);
+    sw.batchSetStatus(tokens, true);
   }
 
   function test_batchSetStatus_revertsForNonBot() public {


### PR DESCRIPTION
## Summary

Two changes to `StockOracleSwitch` (the open/closed gate for tokenized-stock markets):

1. **`setGlobal` moves from `BOT` to `MANAGER`** — the single global market-hours switch becomes governance-controlled, while routine per-stock open/close stays with the automation `BOT`.
2. **New `batchSetStatus(address[] tokens, bool status)`** — lets `BOT` open or close many registered stocks in one call by delegating to `open`/`close` (strict — reverts the whole batch on a no-op or unregistered token).

## Change type

- [ ] New contract
- [x] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [ ] Migration / deploy script
- [x] Test

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| StockOracleSwitch | `src/oracle/StockOracleSwitch.sol` | modified |
| StockOracleDeploy | `script/oracle/deploy_stockOracle.sol` | modified (comments only) |
| StockOracleSwitchTest | `test/oracle/StockOracleSwitch.t.sol` | modified (tests) |
| StockOracleTest | `test/oracle/StockOracle.t.sol` | modified (tests) |

## Interface changes

- `setGlobal(bool open)` — **access role changed `BOT` → `MANAGER`** (signature unchanged).
- `open(address)` / `close(address)` — visibility `external` → `public` (still `BOT`-gated) so `batchSetStatus` can call them internally. ABI/selectors unchanged.
- `batchSetStatus(address[] calldata tokens, bool status)` — **new** `external`, `BOT` role. Opens (`status = true`) or closes (`status = false`) every token in `tokens` by delegating to `open`/`close`. **Strict** — inherits the `open`/`close` guards, so a token already in the target state (`AlreadySet`) or unregistered (`NotRegistered`) reverts the whole batch. Emits the existing `StockEnable(token, status)` event per token.
- No new events, errors, or state variables.

## Storage layout

Verified via `forge inspect StockOracleSwitch storage-layout` — **unchanged**:

| Name | Type | Slot |
|------|------|------|
| registered | mapping(address => bool) | 0 |
| enabled | mapping(address => bool) | 1 |
| globalEnabled | bool | 2 |

No state variables added/removed/reordered (only a function added, a modifier changed, and `open`/`close` visibility widened). Safe to deploy as a UUPS implementation upgrade — no collision risk.

## Access control

- `setGlobal` now requires `MANAGER` instead of `BOT`. Operationally, the global daily/market-hours switch must be toggled by the `MANAGER` holder (a Gnosis Safe after `deploy_stockOracleTransferRole.sol`), not the bot.
- `batchSetStatus` is `BOT`-gated and delegates to `open`/`close`, which became `public` but stay `BOT`-gated; the per-element role check still passes because the internal call preserves `msg.sender`.
- Role-admin wiring unchanged (`MANAGER` still admins `BOT`; `_authorizeUpgrade` still `DEFAULT_ADMIN_ROLE`).

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | Layout verified identical; no new/reordered state vars. |
| Fund safety | 🟢 None | Switch holds no funds; only gates `StockOracle.peek` via `isEnabled`. |
| Access control | 🟡 Low | Intentional `setGlobal` role move `BOT`→`MANAGER`; `open`/`close` widened to `public` but stay `BOT`-gated. Covered by tests (incl. a test asserting `BOT` is now rejected on `setGlobal`). |
| External call safety | 🟢 None | No external calls added; `batchSetStatus` only delegates to in-contract `open`/`close`. |

## Deployment

- Chain: BSC mainnet. Requires deploying a new `StockOracleSwitch` implementation and calling `upgradeToAndCall` on the live proxy `0xb4678C3E8B49d2b95Da48458f98805da193A8498` (admin = Timelock `0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253` after role handoff).
- No new env vars, no storage migration.
- Post-upgrade ops note: daily global open/close is now a `MANAGER` (Safe) action; per-stock open/close (incl. bulk `batchSetStatus`) remains a `BOT` action.

## Test plan

- [x] `forge test --mc StockOracle` passes — **64 tests** (StockOracleSwitchTest 43 + StockOracleTest 21).
- [x] New `batchSetStatus` coverage: bulk close-then-open + event order, already-in-state reverts (`AlreadySet`), non-`BOT` rejected, unregistered token reverts the whole batch (state rolled back), empty array no-op.
- [x] `setGlobal` tests updated to `MANAGER`, plus a new test asserting `BOT` can no longer call it.
- [x] `prettier --check` clean.
- Note: the repo-wide `forge test` includes BSC fork suites needing `BSC_RPC`; this PR ran the targeted oracle suites, which exercise all changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
