### PR TITLE
ci: add upgrade-safety PR gate

### DIFF
--- a/.github/workflows/upgrade-safety.yaml
+++ b/.github/workflows/upgrade-safety.yaml
@@ -1,0 +1,68 @@
+# Drop this into moolah at .github/workflows/upgrade-safety.yaml
+# (and copy check-upgrades.sh + upgrade-targets.txt into moolah's ci/ dir).
+#
+# Gates every PR: builds the storage layout for the base branch and the PR head,
+# then fails if any upgradeable contract has an incompatible storage layout,
+# a SELFDESTRUCT/DELEGATECALL regression, or an unlinked library.
+name: Upgrade safety
+
+on:
+  pull_request:
+
+jobs:
+  upgrade-safety:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Checkout base branch into base/
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          submodules: recursive
+          fetch-depth: 1
+          path: base
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # upgrade-guard is a PUBLIC repo, so no token is needed. Pin a tag (or rev)
+      # for reproducible, supply-chain-safe builds.
+      - name: Install upgrade-guard
+        run: |
+          cargo install --git https://github.com/razww/upgrade-guard \
+            --tag v0.1.1 upgrade-guard --locked
+
+      # Faster alternative: skip the Rust build, download the prebuilt binary.
+      #   - run: |
+      #       gh release download v0.1.1 --repo razww/upgrade-guard \
+      #         --pattern 'upgrade-guard-x86_64-linux*' --dir /tmp/ug
+      #       ( cd /tmp/ug && sha256sum -c upgrade-guard-x86_64-linux.sha256 )
+      #       install -m0755 /tmp/ug/upgrade-guard-x86_64-linux /usr/local/bin/upgrade-guard
+      #     env: { GH_TOKEN: ${{ github.token }} }   # public asset; token avoids rate limits
+
+      - name: Install submodule node_modules (head + base)
+        run: |
+          (cd lib/lista-dao-contracts.git && yarn install)
+          (cd base/lib/lista-dao-contracts.git && yarn install)
+
+      # moolah's `ci` foundry profile sets extra_output = [], so request the
+      # storage layout explicitly on both builds.
+      - name: Build NEW storage layout (PR head)
+        run: forge build --extra-output storageLayout --out out
+
+      - name: Build OLD storage layout (base branch)
+        working-directory: base
+        run: forge build --extra-output storageLayout --out out
+
+      # Targets: if ci/upgrade-targets.txt has entries they are used as-is;
+      # otherwise every UUPSUpgradeable contract under src/ (PR head) is gated.
+      - name: Validate upgrade safety
+        run: ./ci/check-upgrades.sh base/out out ci/upgrade-targets.txt src

--- a/ci/check-upgrades.sh
+++ b/ci/check-upgrades.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Run upgrade-guard over a set of upgradeable contracts, comparing the OLD build
+# (base branch / last release) against the NEW build (PR head).
+#
+# Usage: check-upgrades.sh <old-out-dir> <new-out-dir> <targets-file> [src-dir]
+#
+# Target selection (the switch):
+#   * If <targets-file> has any non-comment entries  -> use them verbatim
+#     (manual override / allow-list).
+#   * Otherwise AUTO-DISCOVER every contract under <src-dir> (default "src")
+#     that inherits UUPSUpgradeable — so new upgradeable contracts are covered
+#     automatically and the list never goes stale.
+#
+# Targets entry format: `Contract` (assumes Contract.sol) or `File.sol:Contract`.
+#
+# Exit: 0 if every target is upgrade-safe, 1 if any is unsafe / errored.
+set -uo pipefail
+
+OLD_OUT="${1:?old out dir}"
+NEW_OUT="${2:?new out dir}"
+TARGETS="${3:?targets file}"
+SRC_DIR="${4:-src}"
+
+# Build the working list of entries into a temp file (portable to bash 3.2).
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+if [[ -f "$TARGETS" ]] && grep -qvE '^[[:space:]]*(#.*)?$' "$TARGETS"; then
+  echo "Using manual target list: $TARGETS"
+  sed 's/#.*//' "$TARGETS" | grep -vE '^[[:space:]]*$' > "$TMP"
+else
+  echo "No manual targets — auto-discovering UUPSUpgradeable contracts under $SRC_DIR/"
+  grep -rl 'UUPSUpgradeable' "$SRC_DIR" --include='*.sol' \
+    | xargs -n1 basename \
+    | sed 's/\.sol$//' \
+    | sort -u > "$TMP"
+fi
+
+count="$(grep -cvE '^[[:space:]]*$' "$TMP" || true)"
+if [[ "$count" -eq 0 ]]; then
+  echo "::error::no contracts to check (empty target list and no UUPSUpgradeable matches under $SRC_DIR/)"
+  exit 1
+fi
+echo "Gating $count contract(s)."
+
+fail=0
+while IFS= read -r raw || [[ -n "$raw" ]]; do
+  entry="$(echo -n "$raw" | xargs)" # trim whitespace
+  [[ -z "$entry" ]] && continue
+
+  if [[ "$entry" == *:* ]]; then
+    file="${entry%%:*}"; name="${entry##*:}"
+  else
+    name="$entry"; file="${name}.sol"
+  fi
+
+  old="$OLD_OUT/$file/$name.json"
+  new="$NEW_OUT/$file/$name.json"
+
+  if [[ ! -f "$new" ]]; then
+    echo "::error::missing NEW artifact for $name ($new) — did the build emit storageLayout?"
+    fail=1; continue
+  fi
+  if [[ ! -f "$old" ]]; then
+    echo "::notice::$name has no base artifact — treating as a new contract, skipping upgrade check"
+    continue
+  fi
+
+  echo "::group::upgrade check — $name"
+  if upgrade-guard --old "$old" --new "$new"; then
+    echo "::endgroup::"
+  else
+    echo "::endgroup::"
+    echo "::error::$name failed the upgrade-safety check (see log above)"
+    fail=1
+  fi
+done < "$TMP"
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "All upgrade-safety checks passed."
+fi
+exit "$fail"

--- a/ci/upgrade-targets.txt
+++ b/ci/upgrade-targets.txt
@@ -1,0 +1,14 @@
+# Optional manual override for the upgrade-safety gate.
+#
+# Leave this file empty (comments only) to AUTO-DISCOVER every UUPSUpgradeable
+# contract under src/ at CI time — recommended, so new upgradeable contracts are
+# gated automatically and this list never goes stale.
+#
+# To pin an explicit allow-list instead, add entries one per line:
+#   Contract            (assumes Contract.sol)
+#   File.sol:Contract   (when the file name differs from the contract name)
+#
+# Example:
+# Moolah
+# MoolahVault
+# LendingBroker


### PR DESCRIPTION
## Summary

Adds an **upgrade-safety PR gate** that validates Solidity proxy upgrade safety on every PR, using [`upgrade-guard`](https://github.com/razww/upgrade-guard).

For each upgradeable contract it diffs the **base branch** against the **PR head** and fails the check on:

- **Storage layout incompatibility** — a live slot reordered, removed, or retyped (only *appending* new variables is allowed)
- **New `SELFDESTRUCT`** in the implementation (self-destructing an impl bricks every proxy pointing at it)
- **New `DELEGATECALL`** vs. the old code (flagged for review)
- **Unlinked library placeholder** (`__$…$__`) left in the bytecode

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/upgrade-safety.yaml` | Runs on every PR: builds `storageLayout` for base + head, then runs `upgrade-guard` over each upgradeable contract |
| `ci/check-upgrades.sh` | Auto-discovers `UUPSUpgradeable` contracts under `src/` (or uses a manual allow-list) and aggregates results |
| `ci/upgrade-targets.txt` | Empty by default → **all 42 `UUPSUpgradeable` contracts are gated automatically** |

## How it works

1. Checks out PR head + base branch (`base/`).
2. Installs Foundry + Rust, then `cargo install --git https://github.com/razww/upgrade-guard --tag v0.1.0 …` (public repo, **no token needed**).
3. Builds storage layout for both: `forge build --extra-output storageLayout` — explicit because the `ci` Foundry profile sets `extra_output = []`.
4. `check-upgrades.sh base/out out ci/upgrade-targets.txt src` → exits non-zero on any Critical finding.

## Target selection

`ci/upgrade-targets.txt` is comment-only, so the gate **auto-discovers** every `UUPSUpgradeable` contract under `src/` at CI time — new upgradeable contracts are covered automatically and the list never goes stale. To pin an explicit allow-list instead, add entries (`Contract` or `File.sol:Contract`) to that file.
