### PR TITLE
feat: extract MoolahVaultLib & VaultConfigLib to resolve EIP-170 bytecode limit

### DIFF
--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -244,17 +244,72 @@ contract MoolahVault is
 
   /// @inheritdoc IMoolahVaultBase
   function setSupplyQueue(Id[] calldata newSupplyQueue) external onlyRole(ALLOCATOR) {
-    VaultConfigLib.setSupplyQueue(config, supplyQueue, newSupplyQueue);
+    uint256 length = newSupplyQueue.length;
+
+    if (length > ConstantsLib.MAX_QUEUE_LENGTH) revert ErrorsLib.MaxQueueLengthExceeded();
+
+    for (uint256 i; i < length; ++i) {
+      if (config[newSupplyQueue[i]].cap == 0) revert ErrorsLib.UnauthorizedMarket(newSupplyQueue[i]);
+    }
+
+    supplyQueue = newSupplyQueue;
+
+    emit EventsLib.SetSupplyQueue(_msgSender(), newSupplyQueue);
   }
 
   /// @inheritdoc IMoolahVaultBase
   function updateWithdrawQueue(uint256[] calldata indexes) external onlyRole(ALLOCATOR) {
-    VaultConfigLib.updateWithdrawQueue(config, withdrawQueue, MOOLAH, indexes);
+    uint256 newLength = indexes.length;
+    uint256 currLength = withdrawQueue.length;
+
+    bool[] memory seen = new bool[](currLength);
+    Id[] memory newWithdrawQueue = new Id[](newLength);
+
+    for (uint256 i; i < newLength; ++i) {
+      uint256 prevIndex = indexes[i];
+
+      // If prevIndex >= currLength, it will revert with native "Index out of bounds".
+      Id id = withdrawQueue[prevIndex];
+      if (seen[prevIndex]) revert ErrorsLib.DuplicateMarket(id);
+      seen[prevIndex] = true;
+
+      newWithdrawQueue[i] = id;
+    }
+
+    for (uint256 i; i < currLength; ++i) {
+      if (!seen[i]) {
+        Id id = withdrawQueue[i];
+
+        if (config[id].cap != 0) revert ErrorsLib.InvalidMarketRemovalNonZeroCap(id);
+
+        if (MOOLAH.position(id, address(this)).supplyShares != 0) {
+          if (config[id].removableAt == 0) revert ErrorsLib.InvalidMarketRemovalNonZeroSupply(id);
+
+          if (block.timestamp < config[id].removableAt) {
+            revert ErrorsLib.InvalidMarketRemovalTimelockNotElapsed(id);
+          }
+        }
+
+        delete config[id];
+      }
+    }
+
+    withdrawQueue = newWithdrawQueue;
+
+    emit EventsLib.SetWithdrawQueue(_msgSender(), newWithdrawQueue);
   }
 
   /// @inheritdoc IMoolahVaultBase
   function reallocate(MarketAllocation[] calldata allocations) external onlyAllocatorOrBot {
-    MoolahVaultLib.reallocate(config, MOOLAH, allocations);
+    uint256 len = allocations.length;
+    bool[] memory enabled = new bool[](len);
+    uint184[] memory caps = new uint184[](len);
+    for (uint256 i; i < len; ++i) {
+      Id id = allocations[i].marketParams.id();
+      enabled[i] = config[id].enabled;
+      caps[i] = config[id].cap;
+    }
+    MoolahVaultLib.reallocate(MOOLAH, allocations, enabled, caps);
   }
 
   /// @inheritdoc IMoolahVaultBase
@@ -460,7 +515,14 @@ contract MoolahVault is
 
   /// @dev Returns the maximum amount of assets that the vault can supply on Moolah.
   function _maxDeposit() internal view returns (uint256) {
-    return MoolahVaultLib.maxDeposit(config, supplyQueue, MOOLAH);
+    uint256 len = supplyQueue.length;
+    Id[] memory queue = new Id[](len);
+    uint184[] memory caps = new uint184[](len);
+    for (uint256 i; i < len; ++i) {
+      queue[i] = supplyQueue[i];
+      caps[i] = config[supplyQueue[i]].cap;
+    }
+    return MoolahVaultLib.maxDeposit(MOOLAH, queue, caps);
   }
 
   /// @inheritdoc ERC4626Upgradeable
@@ -618,18 +680,25 @@ contract MoolahVault is
 
   /// @dev Supplies `assets` to Moolah.
   function _supplyMoolah(uint256 assets) internal {
-    MoolahVaultLib.supplyMoolah(config, supplyQueue, MOOLAH, assets);
+    uint256 len = supplyQueue.length;
+    Id[] memory queue = new Id[](len);
+    uint184[] memory caps = new uint184[](len);
+    for (uint256 i; i < len; ++i) {
+      queue[i] = supplyQueue[i];
+      caps[i] = config[supplyQueue[i]].cap;
+    }
+    MoolahVaultLib.supplyMoolah(MOOLAH, queue, caps, assets);
   }
 
   /// @dev Withdraws `assets` from Moolah.
   function _withdrawMoolah(uint256 assets) internal {
-    MoolahVaultLib.withdrawMoolah(withdrawQueue, MOOLAH, assets);
+    MoolahVaultLib.withdrawMoolah(MOOLAH, withdrawQueue, assets);
   }
 
   /// @dev Simulates a withdraw of `assets` from Moolah.
   /// @return The remaining assets to be withdrawn.
   function _simulateWithdrawMoolah(uint256 assets) internal view returns (uint256) {
-    return MoolahVaultLib.simulateWithdrawMoolah(withdrawQueue, MOOLAH, assets);
+    return MoolahVaultLib.simulateWithdrawMoolah(MOOLAH, withdrawQueue, assets);
   }
 
   /* FEE MANAGEMENT */

--- a/src/moolah-vault/MoolahVault.sol
+++ b/src/moolah-vault/MoolahVault.sol
@@ -16,6 +16,8 @@ import { PendingUint192, PendingAddress, PendingLib } from "./libraries/PendingL
 import { ConstantsLib } from "./libraries/ConstantsLib.sol";
 import { ErrorsLib } from "./libraries/ErrorsLib.sol";
 import { EventsLib } from "./libraries/EventsLib.sol";
+import { MoolahVaultLib } from "./libraries/MoolahVaultLib.sol";
+import { VaultConfigLib } from "./libraries/VaultConfigLib.sol";
 import { WAD } from "moolah/libraries/MathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
 import { SharesMathLib } from "moolah/libraries/SharesMathLib.sol";
@@ -201,16 +203,7 @@ contract MoolahVault is
   /// @param account The account to add or remove.
   /// @param enabled True to add, false to remove.
   function setWhiteList(address account, bool enabled) external onlyRole(MANAGER) {
-    if (account == address(0)) revert ErrorsLib.ZeroAddress();
-    if (enabled) {
-      if (whiteList.contains(account)) revert ErrorsLib.AlreadySet();
-      whiteList.add(account);
-    } else {
-      if (!whiteList.contains(account)) revert ErrorsLib.NotSet();
-      whiteList.remove(account);
-    }
-
-    emit EventsLib.SetWhiteList(account, enabled);
+    VaultConfigLib.setWhiteList(whiteList, account, enabled);
   }
 
   /// @inheritdoc IMoolahVaultBase
@@ -251,115 +244,17 @@ contract MoolahVault is
 
   /// @inheritdoc IMoolahVaultBase
   function setSupplyQueue(Id[] calldata newSupplyQueue) external onlyRole(ALLOCATOR) {
-    uint256 length = newSupplyQueue.length;
-
-    if (length > ConstantsLib.MAX_QUEUE_LENGTH) revert ErrorsLib.MaxQueueLengthExceeded();
-
-    for (uint256 i; i < length; ++i) {
-      if (config[newSupplyQueue[i]].cap == 0) revert ErrorsLib.UnauthorizedMarket(newSupplyQueue[i]);
-    }
-
-    supplyQueue = newSupplyQueue;
-
-    emit EventsLib.SetSupplyQueue(_msgSender(), newSupplyQueue);
+    VaultConfigLib.setSupplyQueue(config, supplyQueue, newSupplyQueue);
   }
 
   /// @inheritdoc IMoolahVaultBase
   function updateWithdrawQueue(uint256[] calldata indexes) external onlyRole(ALLOCATOR) {
-    uint256 newLength = indexes.length;
-    uint256 currLength = withdrawQueue.length;
-
-    bool[] memory seen = new bool[](currLength);
-    Id[] memory newWithdrawQueue = new Id[](newLength);
-
-    for (uint256 i; i < newLength; ++i) {
-      uint256 prevIndex = indexes[i];
-
-      // If prevIndex >= currLength, it will revert with native "Index out of bounds".
-      Id id = withdrawQueue[prevIndex];
-      if (seen[prevIndex]) revert ErrorsLib.DuplicateMarket(id);
-      seen[prevIndex] = true;
-
-      newWithdrawQueue[i] = id;
-    }
-
-    for (uint256 i; i < currLength; ++i) {
-      if (!seen[i]) {
-        Id id = withdrawQueue[i];
-
-        if (config[id].cap != 0) revert ErrorsLib.InvalidMarketRemovalNonZeroCap(id);
-
-        if (MOOLAH.position(id, address(this)).supplyShares != 0) {
-          if (config[id].removableAt == 0) revert ErrorsLib.InvalidMarketRemovalNonZeroSupply(id);
-
-          if (block.timestamp < config[id].removableAt) {
-            revert ErrorsLib.InvalidMarketRemovalTimelockNotElapsed(id);
-          }
-        }
-
-        delete config[id];
-      }
-    }
-
-    withdrawQueue = newWithdrawQueue;
-
-    emit EventsLib.SetWithdrawQueue(_msgSender(), newWithdrawQueue);
+    VaultConfigLib.updateWithdrawQueue(config, withdrawQueue, MOOLAH, indexes);
   }
 
   /// @inheritdoc IMoolahVaultBase
   function reallocate(MarketAllocation[] calldata allocations) external onlyAllocatorOrBot {
-    uint256 totalSupplied;
-    uint256 totalWithdrawn;
-    for (uint256 i; i < allocations.length; ++i) {
-      MarketAllocation memory allocation = allocations[i];
-      Id id = allocation.marketParams.id();
-
-      (uint256 supplyAssets, uint256 supplyShares, ) = _accruedSupplyBalance(allocation.marketParams, id);
-      uint256 withdrawn = supplyAssets.zeroFloorSub(allocation.assets);
-
-      if (withdrawn > 0) {
-        if (!config[id].enabled) revert ErrorsLib.MarketNotEnabled(id);
-
-        // Guarantees that unknown frontrunning donations can be withdrawn, in order to disable a market.
-        uint256 shares;
-        if (allocation.assets == 0) {
-          shares = supplyShares;
-          withdrawn = 0;
-        }
-
-        (uint256 withdrawnAssets, uint256 withdrawnShares) = MOOLAH.withdraw(
-          allocation.marketParams,
-          withdrawn,
-          shares,
-          address(this),
-          address(this)
-        );
-
-        emit EventsLib.ReallocateWithdraw(_msgSender(), id, withdrawnAssets, withdrawnShares);
-
-        totalWithdrawn += withdrawnAssets;
-      } else {
-        uint256 suppliedAssets = allocation.assets == type(uint256).max
-          ? totalWithdrawn.zeroFloorSub(totalSupplied)
-          : allocation.assets.zeroFloorSub(supplyAssets);
-
-        if (suppliedAssets == 0) continue;
-
-        uint256 supplyCap = config[id].cap;
-        if (supplyCap == 0) revert ErrorsLib.UnauthorizedMarket(id);
-
-        if (supplyAssets + suppliedAssets > supplyCap) revert ErrorsLib.SupplyCapExceeded(id);
-
-        // The market's loan asset is guaranteed to be the vault's asset because it has a non-zero supply cap.
-        (, uint256 suppliedShares) = MOOLAH.supply(allocation.marketParams, suppliedAssets, 0, address(this), hex"");
-
-        emit EventsLib.ReallocateSupply(_msgSender(), id, suppliedAssets, suppliedShares);
-
-        totalSupplied += suppliedAssets;
-      }
-    }
-
-    if (totalWithdrawn != totalSupplied) revert ErrorsLib.InconsistentReallocation();
+    MoolahVaultLib.reallocate(config, MOOLAH, allocations);
   }
 
   /// @inheritdoc IMoolahVaultBase
@@ -564,20 +459,8 @@ contract MoolahVault is
   }
 
   /// @dev Returns the maximum amount of assets that the vault can supply on Moolah.
-  function _maxDeposit() internal view returns (uint256 totalSuppliable) {
-    for (uint256 i; i < supplyQueue.length; ++i) {
-      Id id = supplyQueue[i];
-
-      uint256 supplyCap = config[id].cap;
-      if (supplyCap == 0) continue;
-
-      uint256 supplyShares = MOOLAH.position(id, address(this)).supplyShares;
-      (uint256 totalSupplyAssets, uint256 totalSupplyShares, , ) = MOOLAH.expectedMarketBalances(_marketParams(id));
-      // `supplyAssets` needs to be rounded up for `totalSuppliable` to be rounded down.
-      uint256 supplyAssets = supplyShares.toAssetsUp(totalSupplyAssets, totalSupplyShares);
-
-      totalSuppliable += supplyCap.zeroFloorSub(supplyAssets);
-    }
+  function _maxDeposit() internal view returns (uint256) {
+    return MoolahVaultLib.maxDeposit(config, supplyQueue, MOOLAH);
   }
 
   /// @inheritdoc ERC4626Upgradeable
@@ -735,106 +618,18 @@ contract MoolahVault is
 
   /// @dev Supplies `assets` to Moolah.
   function _supplyMoolah(uint256 assets) internal {
-    for (uint256 i; i < supplyQueue.length; ++i) {
-      Id id = supplyQueue[i];
-
-      uint256 supplyCap = config[id].cap;
-      if (supplyCap == 0) continue;
-
-      MarketParams memory marketParams = _marketParams(id);
-
-      MOOLAH.accrueInterest(marketParams);
-
-      Market memory market = MOOLAH.market(id);
-      uint256 supplyShares = MOOLAH.position(id, address(this)).supplyShares;
-      // `supplyAssets` needs to be rounded up for `toSupply` to be rounded down.
-      uint256 supplyAssets = supplyShares.toAssetsUp(market.totalSupplyAssets, market.totalSupplyShares);
-
-      uint256 toSupply = UtilsLib.min(supplyCap.zeroFloorSub(supplyAssets), assets);
-
-      if (toSupply > 0) {
-        // Using try/catch to skip markets that revert.
-        try MOOLAH.supply(marketParams, toSupply, 0, address(this), hex"") {
-          assets -= toSupply;
-        } catch {}
-      }
-
-      if (assets == 0) return;
-    }
-
-    if (assets != 0) revert ErrorsLib.AllCapsReached();
+    MoolahVaultLib.supplyMoolah(config, supplyQueue, MOOLAH, assets);
   }
 
   /// @dev Withdraws `assets` from Moolah.
   function _withdrawMoolah(uint256 assets) internal {
-    for (uint256 i; i < withdrawQueue.length; ++i) {
-      Id id = withdrawQueue[i];
-      MarketParams memory marketParams = _marketParams(id);
-      (uint256 supplyAssets, , Market memory market) = _accruedSupplyBalance(marketParams, id);
-
-      uint256 toWithdraw = UtilsLib.min(
-        _withdrawable(marketParams, market.totalSupplyAssets, market.totalBorrowAssets, supplyAssets),
-        assets
-      );
-
-      if (toWithdraw > 0) {
-        // Using try/catch to skip markets that revert.
-        try MOOLAH.withdraw(marketParams, toWithdraw, 0, address(this), address(this)) {
-          assets -= toWithdraw;
-        } catch {}
-      }
-
-      if (assets == 0) return;
-    }
-
-    if (assets != 0) revert ErrorsLib.NotEnoughLiquidity();
+    MoolahVaultLib.withdrawMoolah(withdrawQueue, MOOLAH, assets);
   }
 
   /// @dev Simulates a withdraw of `assets` from Moolah.
   /// @return The remaining assets to be withdrawn.
   function _simulateWithdrawMoolah(uint256 assets) internal view returns (uint256) {
-    for (uint256 i; i < withdrawQueue.length; ++i) {
-      Id id = withdrawQueue[i];
-      MarketParams memory marketParams = _marketParams(id);
-
-      uint256 supplyShares = MOOLAH.position(id, address(this)).supplyShares;
-      (uint256 totalSupplyAssets, uint256 totalSupplyShares, uint256 totalBorrowAssets, ) = MOOLAH
-        .expectedMarketBalances(marketParams);
-
-      // The vault withdrawing from Moolah cannot fail because:
-      // 1. oracle.price() is never called (the vault doesn't borrow)
-      // 2. the amount is capped to the liquidity available on Moolah
-      // 3. virtually accruing interest didn't fail
-      assets = assets.zeroFloorSub(
-        _withdrawable(
-          marketParams,
-          totalSupplyAssets,
-          totalBorrowAssets,
-          supplyShares.toAssetsDown(totalSupplyAssets, totalSupplyShares)
-        )
-      );
-
-      if (assets == 0) break;
-    }
-
-    return assets;
-  }
-
-  /// @dev Returns the withdrawable amount of assets from the market defined by `marketParams`, given the market's
-  /// total supply and borrow assets and the vault's assets supplied.
-  function _withdrawable(
-    MarketParams memory marketParams,
-    uint256 totalSupplyAssets,
-    uint256 totalBorrowAssets,
-    uint256 supplyAssets
-  ) internal view returns (uint256) {
-    // Inside a flashloan callback, liquidity on Moolah may be limited to the singleton's balance.
-    uint256 availableLiquidity = UtilsLib.min(
-      totalSupplyAssets - totalBorrowAssets,
-      ERC20Upgradeable(marketParams.loanToken).balanceOf(address(MOOLAH))
-    );
-
-    return UtilsLib.min(supplyAssets, availableLiquidity);
+    return MoolahVaultLib.simulateWithdrawMoolah(withdrawQueue, MOOLAH, assets);
   }
 
   /* FEE MANAGEMENT */

--- a/src/moolah-vault/libraries/MoolahVaultLib.sol
+++ b/src/moolah-vault/libraries/MoolahVaultLib.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.34;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Id, MarketParams, Market, IMoolah } from "moolah/interfaces/IMoolah.sol";
-import { MarketConfig } from "./PendingLib.sol";
 import { MarketAllocation } from "../interfaces/IMoolahVault.sol";
 import { SharesMathLib } from "moolah/libraries/SharesMathLib.sol";
 import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
@@ -17,7 +16,6 @@ import { EventsLib } from "./EventsLib.sol";
 /// @notice External library for MoolahVault — reduces vault runtime bytecode below EIP-170 limit.
 /// @dev Functions are `public` so the compiler emits DELEGATECALL to this separately-deployed library.
 ///      `address(this)` inside these functions resolves to the calling vault contract.
-///      `msg.sender` inside these functions resolves to the original external caller.
 library MoolahVaultLib {
   using SharesMathLib for uint256;
   using UtilsLib for uint256;
@@ -25,13 +23,15 @@ library MoolahVaultLib {
   using MarketParamsLib for MarketParams;
 
   /// @notice Execute the reallocate loop: withdraw from over-allocated markets and supply to under-allocated ones.
-  /// @param _config  Market config mapping (storage ref from vault)
-  /// @param moolah   Moolah protocol instance (immutable in vault, passed as param)
+  /// @param moolah       Moolah protocol instance
   /// @param allocations  Target allocations (marketParams + target assets)
+  /// @param enabled      Pre-fetched config.enabled for each allocation's market
+  /// @param caps         Pre-fetched config.cap for each allocation's market
   function reallocate(
-    mapping(Id => MarketConfig) storage _config,
     IMoolah moolah,
-    MarketAllocation[] calldata allocations
+    MarketAllocation[] calldata allocations,
+    bool[] memory enabled,
+    uint184[] memory caps
   ) public {
     uint256 totalSupplied;
     uint256 totalWithdrawn;
@@ -39,7 +39,7 @@ library MoolahVaultLib {
       MarketAllocation memory allocation = allocations[i];
       Id id = allocation.marketParams.id();
 
-      // Accrue interest and get current supply balance (inlined _accruedSupplyBalance)
+      // Accrue interest and get current supply balance
       moolah.accrueInterest(allocation.marketParams);
       Market memory market = moolah.market(id);
       uint256 supplyShares = moolah.position(id, address(this)).supplyShares;
@@ -48,7 +48,7 @@ library MoolahVaultLib {
       uint256 withdrawn = supplyAssets.zeroFloorSub(allocation.assets);
 
       if (withdrawn > 0) {
-        if (!_config[id].enabled) revert ErrorsLib.MarketNotEnabled(id);
+        if (!enabled[i]) revert ErrorsLib.MarketNotEnabled(id);
 
         // Guarantees that unknown frontrunning donations can be withdrawn, in order to disable a market.
         uint256 shares;
@@ -75,7 +75,7 @@ library MoolahVaultLib {
 
         if (suppliedAssets == 0) continue;
 
-        uint256 supplyCap = _config[id].cap;
+        uint256 supplyCap = caps[i];
         if (supplyCap == 0) revert ErrorsLib.UnauthorizedMarket(id);
 
         if (supplyAssets + suppliedAssets > supplyCap) revert ErrorsLib.SupplyCapExceeded(id);
@@ -93,20 +93,15 @@ library MoolahVaultLib {
   }
 
   /// @notice Supply `assets` to Moolah markets following the supply queue.
-  /// @param _config  Market config mapping (storage ref from vault)
-  /// @param _supplyQueue  Supply queue array (storage ref from vault)
   /// @param moolah  Moolah protocol instance
+  /// @param queue   Supply queue market IDs (copied from vault storage)
+  /// @param caps    Supply cap for each queue entry (0 = skip)
   /// @param assets  Total assets to distribute across markets
-  function supplyMoolah(
-    mapping(Id => MarketConfig) storage _config,
-    Id[] storage _supplyQueue,
-    IMoolah moolah,
-    uint256 assets
-  ) public {
-    for (uint256 i; i < _supplyQueue.length; ++i) {
-      Id id = _supplyQueue[i];
+  function supplyMoolah(IMoolah moolah, Id[] memory queue, uint184[] memory caps, uint256 assets) public {
+    for (uint256 i; i < queue.length; ++i) {
+      Id id = queue[i];
 
-      uint256 supplyCap = _config[id].cap;
+      uint256 supplyCap = caps[i];
       if (supplyCap == 0) continue;
 
       MarketParams memory marketParams = moolah.idToMarketParams(id);
@@ -134,12 +129,12 @@ library MoolahVaultLib {
   }
 
   /// @notice Withdraw `assets` from Moolah markets following the withdraw queue.
-  /// @param _withdrawQueue  Withdraw queue array (storage ref from vault)
   /// @param moolah  Moolah protocol instance
+  /// @param queue   Withdraw queue market IDs (copied from vault storage)
   /// @param assets  Total assets to withdraw
-  function withdrawMoolah(Id[] storage _withdrawQueue, IMoolah moolah, uint256 assets) public {
-    for (uint256 i; i < _withdrawQueue.length; ++i) {
-      Id id = _withdrawQueue[i];
+  function withdrawMoolah(IMoolah moolah, Id[] memory queue, uint256 assets) public {
+    for (uint256 i; i < queue.length; ++i) {
+      Id id = queue[i];
       MarketParams memory marketParams = moolah.idToMarketParams(id);
 
       // Accrue interest and get supply balance
@@ -167,27 +162,19 @@ library MoolahVaultLib {
   }
 
   /// @notice Simulate a withdraw to compute the remaining unmet assets.
-  /// @param _withdrawQueue  Withdraw queue array (storage ref from vault)
   /// @param moolah  Moolah protocol instance
+  /// @param queue   Withdraw queue market IDs (copied from vault storage)
   /// @param assets  Total assets to simulate withdrawing
   /// @return The remaining assets that cannot be withdrawn (0 = fully satisfiable).
-  function simulateWithdrawMoolah(
-    Id[] storage _withdrawQueue,
-    IMoolah moolah,
-    uint256 assets
-  ) public view returns (uint256) {
-    for (uint256 i; i < _withdrawQueue.length; ++i) {
-      Id id = _withdrawQueue[i];
+  function simulateWithdrawMoolah(IMoolah moolah, Id[] memory queue, uint256 assets) public view returns (uint256) {
+    for (uint256 i; i < queue.length; ++i) {
+      Id id = queue[i];
       MarketParams memory marketParams = moolah.idToMarketParams(id);
 
       uint256 supplyShares = moolah.position(id, address(this)).supplyShares;
       (uint256 totalSupplyAssets, uint256 totalSupplyShares, uint256 totalBorrowAssets, ) = moolah
         .expectedMarketBalances(marketParams);
 
-      // The vault withdrawing from Moolah cannot fail because:
-      // 1. oracle.price() is never called (the vault doesn't borrow)
-      // 2. the amount is capped to the liquidity available on Moolah
-      // 3. virtually accruing interest didn't fail
       assets = assets.zeroFloorSub(
         _withdrawable(
           moolah,
@@ -205,18 +192,18 @@ library MoolahVaultLib {
   }
 
   /// @notice Compute max depositable assets across supply queue markets.
-  /// @param _config  Market config mapping (storage ref from vault)
-  /// @param _supplyQueue  Supply queue array (storage ref from vault)
   /// @param moolah  Moolah protocol instance
+  /// @param queue   Supply queue market IDs (copied from vault storage)
+  /// @param caps    Supply cap for each queue entry (0 = skip)
   function maxDeposit(
-    mapping(Id => MarketConfig) storage _config,
-    Id[] storage _supplyQueue,
-    IMoolah moolah
+    IMoolah moolah,
+    Id[] memory queue,
+    uint184[] memory caps
   ) public view returns (uint256 totalSuppliable) {
-    for (uint256 i; i < _supplyQueue.length; ++i) {
-      Id id = _supplyQueue[i];
+    for (uint256 i; i < queue.length; ++i) {
+      Id id = queue[i];
 
-      uint256 supplyCap = _config[id].cap;
+      uint256 supplyCap = caps[i];
       if (supplyCap == 0) continue;
 
       uint256 supplyShares = moolah.position(id, address(this)).supplyShares;

--- a/src/moolah-vault/libraries/MoolahVaultLib.sol
+++ b/src/moolah-vault/libraries/MoolahVaultLib.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Id, MarketParams, Market, IMoolah } from "moolah/interfaces/IMoolah.sol";
+import { MarketConfig } from "./PendingLib.sol";
+import { MarketAllocation } from "../interfaces/IMoolahVault.sol";
+import { SharesMathLib } from "moolah/libraries/SharesMathLib.sol";
+import { UtilsLib } from "moolah/libraries/UtilsLib.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+import { MoolahBalancesLib } from "moolah/libraries/periphery/MoolahBalancesLib.sol";
+import { ErrorsLib } from "./ErrorsLib.sol";
+import { EventsLib } from "./EventsLib.sol";
+
+/// @title MoolahVaultLib
+/// @author Lista DAO
+/// @notice External library for MoolahVault — reduces vault runtime bytecode below EIP-170 limit.
+/// @dev Functions are `public` so the compiler emits DELEGATECALL to this separately-deployed library.
+///      `address(this)` inside these functions resolves to the calling vault contract.
+///      `msg.sender` inside these functions resolves to the original external caller.
+library MoolahVaultLib {
+  using SharesMathLib for uint256;
+  using UtilsLib for uint256;
+  using MoolahBalancesLib for IMoolah;
+  using MarketParamsLib for MarketParams;
+
+  /// @notice Execute the reallocate loop: withdraw from over-allocated markets and supply to under-allocated ones.
+  /// @param _config  Market config mapping (storage ref from vault)
+  /// @param moolah   Moolah protocol instance (immutable in vault, passed as param)
+  /// @param allocations  Target allocations (marketParams + target assets)
+  function reallocate(
+    mapping(Id => MarketConfig) storage _config,
+    IMoolah moolah,
+    MarketAllocation[] calldata allocations
+  ) public {
+    uint256 totalSupplied;
+    uint256 totalWithdrawn;
+    for (uint256 i; i < allocations.length; ++i) {
+      MarketAllocation memory allocation = allocations[i];
+      Id id = allocation.marketParams.id();
+
+      // Accrue interest and get current supply balance (inlined _accruedSupplyBalance)
+      moolah.accrueInterest(allocation.marketParams);
+      Market memory market = moolah.market(id);
+      uint256 supplyShares = moolah.position(id, address(this)).supplyShares;
+      uint256 supplyAssets = supplyShares.toAssetsDown(market.totalSupplyAssets, market.totalSupplyShares);
+
+      uint256 withdrawn = supplyAssets.zeroFloorSub(allocation.assets);
+
+      if (withdrawn > 0) {
+        if (!_config[id].enabled) revert ErrorsLib.MarketNotEnabled(id);
+
+        // Guarantees that unknown frontrunning donations can be withdrawn, in order to disable a market.
+        uint256 shares;
+        if (allocation.assets == 0) {
+          shares = supplyShares;
+          withdrawn = 0;
+        }
+
+        (uint256 withdrawnAssets, uint256 withdrawnShares) = moolah.withdraw(
+          allocation.marketParams,
+          withdrawn,
+          shares,
+          address(this),
+          address(this)
+        );
+
+        emit EventsLib.ReallocateWithdraw(msg.sender, id, withdrawnAssets, withdrawnShares);
+
+        totalWithdrawn += withdrawnAssets;
+      } else {
+        uint256 suppliedAssets = allocation.assets == type(uint256).max
+          ? totalWithdrawn.zeroFloorSub(totalSupplied)
+          : allocation.assets.zeroFloorSub(supplyAssets);
+
+        if (suppliedAssets == 0) continue;
+
+        uint256 supplyCap = _config[id].cap;
+        if (supplyCap == 0) revert ErrorsLib.UnauthorizedMarket(id);
+
+        if (supplyAssets + suppliedAssets > supplyCap) revert ErrorsLib.SupplyCapExceeded(id);
+
+        // The market's loan asset is guaranteed to be the vault's asset because it has a non-zero supply cap.
+        (, uint256 suppliedShares) = moolah.supply(allocation.marketParams, suppliedAssets, 0, address(this), hex"");
+
+        emit EventsLib.ReallocateSupply(msg.sender, id, suppliedAssets, suppliedShares);
+
+        totalSupplied += suppliedAssets;
+      }
+    }
+
+    if (totalWithdrawn != totalSupplied) revert ErrorsLib.InconsistentReallocation();
+  }
+
+  /// @notice Supply `assets` to Moolah markets following the supply queue.
+  /// @param _config  Market config mapping (storage ref from vault)
+  /// @param _supplyQueue  Supply queue array (storage ref from vault)
+  /// @param moolah  Moolah protocol instance
+  /// @param assets  Total assets to distribute across markets
+  function supplyMoolah(
+    mapping(Id => MarketConfig) storage _config,
+    Id[] storage _supplyQueue,
+    IMoolah moolah,
+    uint256 assets
+  ) public {
+    for (uint256 i; i < _supplyQueue.length; ++i) {
+      Id id = _supplyQueue[i];
+
+      uint256 supplyCap = _config[id].cap;
+      if (supplyCap == 0) continue;
+
+      MarketParams memory marketParams = moolah.idToMarketParams(id);
+
+      moolah.accrueInterest(marketParams);
+
+      Market memory market = moolah.market(id);
+      uint256 supplyShares = moolah.position(id, address(this)).supplyShares;
+      // `supplyAssets` needs to be rounded up for `toSupply` to be rounded down.
+      uint256 supplyAssets = supplyShares.toAssetsUp(market.totalSupplyAssets, market.totalSupplyShares);
+
+      uint256 toSupply = UtilsLib.min(supplyCap.zeroFloorSub(supplyAssets), assets);
+
+      if (toSupply > 0) {
+        // Using try/catch to skip markets that revert.
+        try moolah.supply(marketParams, toSupply, 0, address(this), hex"") {
+          assets -= toSupply;
+        } catch {}
+      }
+
+      if (assets == 0) return;
+    }
+
+    if (assets != 0) revert ErrorsLib.AllCapsReached();
+  }
+
+  /// @notice Withdraw `assets` from Moolah markets following the withdraw queue.
+  /// @param _withdrawQueue  Withdraw queue array (storage ref from vault)
+  /// @param moolah  Moolah protocol instance
+  /// @param assets  Total assets to withdraw
+  function withdrawMoolah(Id[] storage _withdrawQueue, IMoolah moolah, uint256 assets) public {
+    for (uint256 i; i < _withdrawQueue.length; ++i) {
+      Id id = _withdrawQueue[i];
+      MarketParams memory marketParams = moolah.idToMarketParams(id);
+
+      // Accrue interest and get supply balance
+      moolah.accrueInterest(marketParams);
+      Market memory market = moolah.market(id);
+      uint256 shares = moolah.position(id, address(this)).supplyShares;
+      uint256 supplyAssets = shares.toAssetsDown(market.totalSupplyAssets, market.totalSupplyShares);
+
+      uint256 toWithdraw = UtilsLib.min(
+        _withdrawable(moolah, marketParams, market.totalSupplyAssets, market.totalBorrowAssets, supplyAssets),
+        assets
+      );
+
+      if (toWithdraw > 0) {
+        // Using try/catch to skip markets that revert.
+        try moolah.withdraw(marketParams, toWithdraw, 0, address(this), address(this)) {
+          assets -= toWithdraw;
+        } catch {}
+      }
+
+      if (assets == 0) return;
+    }
+
+    if (assets != 0) revert ErrorsLib.NotEnoughLiquidity();
+  }
+
+  /// @notice Simulate a withdraw to compute the remaining unmet assets.
+  /// @param _withdrawQueue  Withdraw queue array (storage ref from vault)
+  /// @param moolah  Moolah protocol instance
+  /// @param assets  Total assets to simulate withdrawing
+  /// @return The remaining assets that cannot be withdrawn (0 = fully satisfiable).
+  function simulateWithdrawMoolah(
+    Id[] storage _withdrawQueue,
+    IMoolah moolah,
+    uint256 assets
+  ) public view returns (uint256) {
+    for (uint256 i; i < _withdrawQueue.length; ++i) {
+      Id id = _withdrawQueue[i];
+      MarketParams memory marketParams = moolah.idToMarketParams(id);
+
+      uint256 supplyShares = moolah.position(id, address(this)).supplyShares;
+      (uint256 totalSupplyAssets, uint256 totalSupplyShares, uint256 totalBorrowAssets, ) = moolah
+        .expectedMarketBalances(marketParams);
+
+      // The vault withdrawing from Moolah cannot fail because:
+      // 1. oracle.price() is never called (the vault doesn't borrow)
+      // 2. the amount is capped to the liquidity available on Moolah
+      // 3. virtually accruing interest didn't fail
+      assets = assets.zeroFloorSub(
+        _withdrawable(
+          moolah,
+          marketParams,
+          totalSupplyAssets,
+          totalBorrowAssets,
+          supplyShares.toAssetsDown(totalSupplyAssets, totalSupplyShares)
+        )
+      );
+
+      if (assets == 0) break;
+    }
+
+    return assets;
+  }
+
+  /// @notice Compute max depositable assets across supply queue markets.
+  /// @param _config  Market config mapping (storage ref from vault)
+  /// @param _supplyQueue  Supply queue array (storage ref from vault)
+  /// @param moolah  Moolah protocol instance
+  function maxDeposit(
+    mapping(Id => MarketConfig) storage _config,
+    Id[] storage _supplyQueue,
+    IMoolah moolah
+  ) public view returns (uint256 totalSuppliable) {
+    for (uint256 i; i < _supplyQueue.length; ++i) {
+      Id id = _supplyQueue[i];
+
+      uint256 supplyCap = _config[id].cap;
+      if (supplyCap == 0) continue;
+
+      uint256 supplyShares = moolah.position(id, address(this)).supplyShares;
+      (uint256 totalSupplyAssets, uint256 totalSupplyShares, , ) = moolah.expectedMarketBalances(
+        moolah.idToMarketParams(id)
+      );
+      // `supplyAssets` needs to be rounded up for `totalSuppliable` to be rounded down.
+      uint256 supplyAssets = supplyShares.toAssetsUp(totalSupplyAssets, totalSupplyShares);
+
+      totalSuppliable += supplyCap.zeroFloorSub(supplyAssets);
+    }
+  }
+
+  /// @dev Returns the withdrawable amount of assets from a market, given the market's
+  /// total supply and borrow assets and the vault's assets supplied.
+  function _withdrawable(
+    IMoolah moolah,
+    MarketParams memory marketParams,
+    uint256 totalSupplyAssets,
+    uint256 totalBorrowAssets,
+    uint256 supplyAssets
+  ) internal view returns (uint256) {
+    // Inside a flashloan callback, liquidity on Moolah may be limited to the singleton's balance.
+    uint256 availableLiquidity = UtilsLib.min(
+      totalSupplyAssets - totalBorrowAssets,
+      IERC20(marketParams.loanToken).balanceOf(address(moolah))
+    );
+
+    return UtilsLib.min(supplyAssets, availableLiquidity);
+  }
+}

--- a/src/moolah-vault/libraries/VaultConfigLib.sol
+++ b/src/moolah-vault/libraries/VaultConfigLib.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { Id, IMoolah } from "moolah/interfaces/IMoolah.sol";
+import { MarketConfig } from "./PendingLib.sol";
+import { ConstantsLib } from "./ConstantsLib.sol";
+import { ErrorsLib } from "./ErrorsLib.sol";
+import { EventsLib } from "./EventsLib.sol";
+
+/// @title VaultConfigLib
+/// @author Lista DAO
+/// @notice External library for MoolahVault configuration operations — reduces vault runtime bytecode below EIP-170 limit.
+/// @dev Functions are `public` so the compiler emits DELEGATECALL to this separately-deployed library.
+///      `address(this)` inside these functions resolves to the calling vault contract.
+///      `msg.sender` inside these functions resolves to the original external caller (DELEGATECALL preserves).
+library VaultConfigLib {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  /// @notice Validate and set the supply queue.
+  /// @param _config   Market config mapping (storage ref from vault)
+  /// @param _supplyQueue  Supply queue array (storage ref from vault)
+  /// @param newSupplyQueue  New supply queue to set
+  function setSupplyQueue(
+    mapping(Id => MarketConfig) storage _config,
+    Id[] storage _supplyQueue,
+    Id[] calldata newSupplyQueue
+  ) public {
+    uint256 length = newSupplyQueue.length;
+
+    if (length > ConstantsLib.MAX_QUEUE_LENGTH) revert ErrorsLib.MaxQueueLengthExceeded();
+
+    for (uint256 i; i < length; ++i) {
+      if (_config[newSupplyQueue[i]].cap == 0) revert ErrorsLib.UnauthorizedMarket(newSupplyQueue[i]);
+    }
+
+    // Overwrite storage array (cannot directly assign to storage reference in library)
+    while (_supplyQueue.length > 0) {
+      _supplyQueue.pop();
+    }
+    for (uint256 i; i < length; ++i) {
+      _supplyQueue.push(newSupplyQueue[i]);
+    }
+
+    emit EventsLib.SetSupplyQueue(msg.sender, newSupplyQueue);
+  }
+
+  /// @notice Validate indexes, rebuild withdraw queue, and clean up removed markets.
+  /// @param _config   Market config mapping (storage ref from vault)
+  /// @param _withdrawQueue  Withdraw queue array (storage ref from vault)
+  /// @param moolah  Moolah protocol instance (immutable in vault, passed as param)
+  /// @param indexes  New index ordering for the withdraw queue
+  function updateWithdrawQueue(
+    mapping(Id => MarketConfig) storage _config,
+    Id[] storage _withdrawQueue,
+    IMoolah moolah,
+    uint256[] calldata indexes
+  ) public {
+    uint256 newLength = indexes.length;
+    uint256 currLength = _withdrawQueue.length;
+
+    bool[] memory seen = new bool[](currLength);
+    Id[] memory newWithdrawQueue = new Id[](newLength);
+
+    for (uint256 i; i < newLength; ++i) {
+      uint256 prevIndex = indexes[i];
+
+      // If prevIndex >= currLength, it will revert with native "Index out of bounds".
+      Id id = _withdrawQueue[prevIndex];
+      if (seen[prevIndex]) revert ErrorsLib.DuplicateMarket(id);
+      seen[prevIndex] = true;
+
+      newWithdrawQueue[i] = id;
+    }
+
+    for (uint256 i; i < currLength; ++i) {
+      if (!seen[i]) {
+        Id id = _withdrawQueue[i];
+
+        if (_config[id].cap != 0) revert ErrorsLib.InvalidMarketRemovalNonZeroCap(id);
+
+        if (moolah.position(id, address(this)).supplyShares != 0) {
+          if (_config[id].removableAt == 0) revert ErrorsLib.InvalidMarketRemovalNonZeroSupply(id);
+
+          if (block.timestamp < _config[id].removableAt) {
+            revert ErrorsLib.InvalidMarketRemovalTimelockNotElapsed(id);
+          }
+        }
+
+        delete _config[id];
+      }
+    }
+
+    // Overwrite storage array
+    while (_withdrawQueue.length > 0) {
+      _withdrawQueue.pop();
+    }
+    for (uint256 i; i < newLength; ++i) {
+      _withdrawQueue.push(newWithdrawQueue[i]);
+    }
+
+    emit EventsLib.SetWithdrawQueue(msg.sender, newWithdrawQueue);
+  }
+
+  /// @notice Add or remove an account from the whitelist.
+  /// @param _whiteList  Whitelist set (storage ref from vault)
+  /// @param account  The account to add or remove
+  /// @param enabled  True to add, false to remove
+  function setWhiteList(EnumerableSet.AddressSet storage _whiteList, address account, bool enabled) public {
+    if (account == address(0)) revert ErrorsLib.ZeroAddress();
+    if (enabled) {
+      if (_whiteList.contains(account)) revert ErrorsLib.AlreadySet();
+      _whiteList.add(account);
+    } else {
+      if (!_whiteList.contains(account)) revert ErrorsLib.NotSet();
+      _whiteList.remove(account);
+    }
+
+    emit EventsLib.SetWhiteList(account, enabled);
+  }
+}

--- a/src/moolah-vault/libraries/VaultConfigLib.sol
+++ b/src/moolah-vault/libraries/VaultConfigLib.sol
@@ -2,9 +2,6 @@
 pragma solidity 0.8.34;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import { Id, IMoolah } from "moolah/interfaces/IMoolah.sol";
-import { MarketConfig } from "./PendingLib.sol";
-import { ConstantsLib } from "./ConstantsLib.sol";
 import { ErrorsLib } from "./ErrorsLib.sol";
 import { EventsLib } from "./EventsLib.sol";
 
@@ -12,95 +9,8 @@ import { EventsLib } from "./EventsLib.sol";
 /// @author Lista DAO
 /// @notice External library for MoolahVault configuration operations — reduces vault runtime bytecode below EIP-170 limit.
 /// @dev Functions are `public` so the compiler emits DELEGATECALL to this separately-deployed library.
-///      `address(this)` inside these functions resolves to the calling vault contract.
-///      `msg.sender` inside these functions resolves to the original external caller (DELEGATECALL preserves).
 library VaultConfigLib {
   using EnumerableSet for EnumerableSet.AddressSet;
-
-  /// @notice Validate and set the supply queue.
-  /// @param _config   Market config mapping (storage ref from vault)
-  /// @param _supplyQueue  Supply queue array (storage ref from vault)
-  /// @param newSupplyQueue  New supply queue to set
-  function setSupplyQueue(
-    mapping(Id => MarketConfig) storage _config,
-    Id[] storage _supplyQueue,
-    Id[] calldata newSupplyQueue
-  ) public {
-    uint256 length = newSupplyQueue.length;
-
-    if (length > ConstantsLib.MAX_QUEUE_LENGTH) revert ErrorsLib.MaxQueueLengthExceeded();
-
-    for (uint256 i; i < length; ++i) {
-      if (_config[newSupplyQueue[i]].cap == 0) revert ErrorsLib.UnauthorizedMarket(newSupplyQueue[i]);
-    }
-
-    // Overwrite storage array (cannot directly assign to storage reference in library)
-    while (_supplyQueue.length > 0) {
-      _supplyQueue.pop();
-    }
-    for (uint256 i; i < length; ++i) {
-      _supplyQueue.push(newSupplyQueue[i]);
-    }
-
-    emit EventsLib.SetSupplyQueue(msg.sender, newSupplyQueue);
-  }
-
-  /// @notice Validate indexes, rebuild withdraw queue, and clean up removed markets.
-  /// @param _config   Market config mapping (storage ref from vault)
-  /// @param _withdrawQueue  Withdraw queue array (storage ref from vault)
-  /// @param moolah  Moolah protocol instance (immutable in vault, passed as param)
-  /// @param indexes  New index ordering for the withdraw queue
-  function updateWithdrawQueue(
-    mapping(Id => MarketConfig) storage _config,
-    Id[] storage _withdrawQueue,
-    IMoolah moolah,
-    uint256[] calldata indexes
-  ) public {
-    uint256 newLength = indexes.length;
-    uint256 currLength = _withdrawQueue.length;
-
-    bool[] memory seen = new bool[](currLength);
-    Id[] memory newWithdrawQueue = new Id[](newLength);
-
-    for (uint256 i; i < newLength; ++i) {
-      uint256 prevIndex = indexes[i];
-
-      // If prevIndex >= currLength, it will revert with native "Index out of bounds".
-      Id id = _withdrawQueue[prevIndex];
-      if (seen[prevIndex]) revert ErrorsLib.DuplicateMarket(id);
-      seen[prevIndex] = true;
-
-      newWithdrawQueue[i] = id;
-    }
-
-    for (uint256 i; i < currLength; ++i) {
-      if (!seen[i]) {
-        Id id = _withdrawQueue[i];
-
-        if (_config[id].cap != 0) revert ErrorsLib.InvalidMarketRemovalNonZeroCap(id);
-
-        if (moolah.position(id, address(this)).supplyShares != 0) {
-          if (_config[id].removableAt == 0) revert ErrorsLib.InvalidMarketRemovalNonZeroSupply(id);
-
-          if (block.timestamp < _config[id].removableAt) {
-            revert ErrorsLib.InvalidMarketRemovalTimelockNotElapsed(id);
-          }
-        }
-
-        delete _config[id];
-      }
-    }
-
-    // Overwrite storage array
-    while (_withdrawQueue.length > 0) {
-      _withdrawQueue.pop();
-    }
-    for (uint256 i; i < newLength; ++i) {
-      _withdrawQueue.push(newWithdrawQueue[i]);
-    }
-
-    emit EventsLib.SetWithdrawQueue(msg.sender, newWithdrawQueue);
-  }
 
   /// @notice Add or remove an account from the whitelist.
   /// @param _whiteList  Whitelist set (storage ref from vault)


### PR DESCRIPTION
## Summary

Extract heavy logic from `MoolahVault.sol` into two external libraries (`MoolahVaultLib` and `VaultConfigLib`) to bring the vault contract's runtime bytecode below the **EIP-170 24KB limit**.

The compiler emits `DELEGATECALL` to the separately-deployed library contracts, preserving identical runtime behavior while reducing `MoolahVault` code size.

## Change Type

- Refactor (existing contract)
- New contract (libraries)

## Contracts Changed

| Contract / Library | File | Type |
|---|---|---|
| MoolahVault | `src/moolah-vault/MoolahVault.sol` | modified |
| MoolahVaultLib | `src/moolah-vault/libraries/MoolahVaultLib.sol` | new |
| VaultConfigLib | `src/moolah-vault/libraries/VaultConfigLib.sol` | new |

### MoolahVaultLib

Extracted functions (all `public` for DELEGATECALL linkage):

| Function | Description |
|---|---|
| `reallocate()` | Execute the reallocate loop: withdraw from over-allocated markets and supply to under-allocated ones |
| `supplyMoolah()` | Supply assets to Moolah markets following the supply queue |
| `withdrawMoolah()` | Withdraw assets from Moolah markets following the withdraw queue |
| `simulateWithdrawMoolah()` | Simulate a withdraw to compute remaining unmet assets |
| `maxDeposit()` | Compute max depositable assets across supply queue markets |

### VaultConfigLib

| Function | Description |
|---|---|
| `setWhiteList()` | Add or remove an account from the whitelist with validation |

## Environment Variables Consumed by Scripts

N/A — no deployment scripts in this PR. Library linking is handled by the Solidity compiler automatically.

## Storage Layout

**No storage layout changes.** Libraries use `DELEGATECALL` and operate on the caller's storage. All state variables in `MoolahVault` remain at the same slots.

## Interface Changes

**No interface changes.** All public/external function signatures on `MoolahVault` remain identical. The extraction is purely an internal implementation detail.

## Access Control

No access control changes. The extracted library functions execute in the context of the calling vault (via DELEGATECALL), inheriting the same `onlyRole` modifiers that gate the vault's entry points.

## Risk Assessment

| Area | Risk | Note |
|---|---|---|
| Storage collision | None | Libraries use DELEGATECALL — no independent storage |
| Behavioral change | None | Logic is moved verbatim; no algorithmic changes |
| Fund safety | None | Supply/withdraw/reallocate logic unchanged |
| Upgrade compatibility | None | No storage slot reordering; proxy upgrade safe |
| Gas impact | Low | DELEGATECALL adds ~2600 gas per external lib call; offset by smaller deployment cost |

## Deployment

- **Chain:** BSC mainnet & Ethereum mainnet (all chains where MoolahVault is deployed)
- **Procedure:**
  1. Deploy `MoolahVaultLib` library contract
  2. Deploy `VaultConfigLib` library contract
  3. Upgrade `MoolahVault` proxy implementation (linked to the two libraries)
- **Pre-requisite:** Library addresses must be known at compile time (or use `--libraries` forge flag)
- **Upgrade type:** Transparent proxy upgrade via TimeLock

## Test Plan

Existing test suite must pass with no modifications — the refactoring preserves identical behavior.

**Verification steps:**

1. `forge build --via-ir` — confirm compilation succeeds and vault bytecode < 24KB
2. `forge test --via-ir -vvv` — full test suite passes
3. Compare ABI output before/after — must be identical
4. Compare storage layout via `forge inspect MoolahVault storage-layout` — must be identical

**Run command:**

```bash
forge build --via-ir --sizes 2>&1 | grep MoolahVault
forge test --via-ir -vvv
```