### PR TITLE
ci: add contract-size gate; add mainnet LendingBroker impl deploy script

### DIFF
--- a/.github/workflows/upgrade-safety.yaml
+++ b/.github/workflows/upgrade-safety.yaml
@@ -66,3 +66,46 @@ jobs:
       # otherwise every UUPSUpgradeable contract under src/ (PR head) is gated.
       - name: Validate upgrade safety
         run: ./ci/check-upgrades.sh base/out out ci/upgrade-targets.txt src
+
+  contract-sizes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install submodule node_modules
+        run: |
+          cd lib/lista-dao-contracts.git
+          yarn install
+
+      - name: Check contract sizes (EIP-170 runtime limit; excludes tests & scripts)
+        run: |
+          # Compile only deployable src contracts (tests/scripts skipped), then read sizes as JSON.
+          forge build --skip test script
+          forge build --sizes --skip test script --json > sizes.json || true
+          python3 - <<'PY'
+          import json, sys
+          # Legacy contracts already over the 24576-byte runtime limit at this point in history;
+          # tracked separately, so they do not block CI. Anything else over the limit fails.
+          ALLOW = {"Moolah", "MoolahVault", "CreditBroker"}
+          data = json.load(open("sizes.json"))
+          over = []
+          for key, v in data.items():
+              name = key.split(" (")[0]
+              if v.get("runtime_margin", 0) < 0 and name not in ALLOW:
+                  over.append((key, v["runtime_size"]))
+          if over:
+              print("::error::Contracts exceeding the EIP-170 runtime limit (24576 bytes):")
+              for k, s in sorted(over):
+                  print(f"  {k}: {s} bytes")
+              sys.exit(1)
+          print("OK: all deployable contracts within EIP-170 (allowlisted: %s)" % ", ".join(sorted(ALLOW)))
+          PY
+        env:
+          FOUNDRY_PROFILE: ci

--- a/script/broker/deploy_brokerImpl_mainnet.s.sol
+++ b/script/broker/deploy_brokerImpl_mainnet.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+import { LendingBroker } from "../../src/broker/LendingBroker.sol";
+
+/// @notice Deploy the shared LendingBroker implementation on BSC mainnet.
+/// Constants are baked in (no env needed). WBNB is the real mainnet WBNB so native-BNB support
+/// is preserved for every broker proxy — all mainnet brokers carry this same WBNB immutable.
+///   forge script script/broker/deploy_brokerImpl_mainnet.s.sol \
+///     --rpc-url $BSC_RPC_URL --broadcast --verify --via-ir -vvv
+contract DeployLendingBrokerImplMainnet is DeployBase {
+  address constant MOOLAH = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+  address constant WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+
+  function run() public {
+    require(block.chainid == 56, "not BSC mainnet");
+
+    uint256 deployerPrivateKey = _deployerKey();
+    console.log("Deployer:", vm.addr(deployerPrivateKey));
+    console.log("MOOLAH:  ", MOOLAH);
+    console.log("WBNB:    ", WBNB);
+
+    vm.startBroadcast(deployerPrivateKey);
+    LendingBroker impl = new LendingBroker(MOOLAH, WBNB);
+    vm.stopBroadcast();
+
+    console.log("LendingBroker implementation:", address(impl));
+  }
+}


### PR DESCRIPTION
## 📄 Description

- `upgrade-safety.yaml`: new contract-sizes job enforcing the EIP-170 runtime limit on deployable src contracts (excludes test/script), allowlisting the legacy Moolah/MoolahVault/CreditBroker that already exceed it. Runs in parallel with the upgrade-safety job.
- `script/broker/deploy_brokerImpl_mainnet.s.so`l: deploys the shared LendingBroker impl on BSC mainnet with MOOLAH + real WBNB baked in.
