### PR TITLE
feat: adapt MarketFactory for ETH deployment with storage-based rateCalculator/brokerLiquidator

### DIFF
--- a/script/deploy_marketFactory.sol
+++ b/script/deploy_marketFactory.sol
@@ -31,6 +31,8 @@ contract MarketFactoryDeploy is DeployBase {
     vm.startBroadcast(deployerPrivateKey);
 
     // Deploy implementation
+    // NOTE: rateCalculator and brokerLiquidator are storage variables,
+    // set via setRateCalculator() and setBrokerLiquidator() after deploy/upgrade
     MarketFactory impl = new MarketFactory(
       moolah,
       liquidator,
@@ -41,9 +43,7 @@ contract MarketFactoryDeploy is DeployBase {
       WBNB,
       slisBNB,
       BNBProvider,
-      slisBNBProvider,
-      rateCalculator,
-      brokerLiquidator
+      slisBNBProvider
     );
     console.log("Implementation: ", address(impl));
 

--- a/script/eth/deploy_marketFactory.sol
+++ b/script/eth/deploy_marketFactory.sol
@@ -1,0 +1,67 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { MarketFactory } from "../../src/moolah/MarketFactory.sol";
+
+contract MarketFactoryDeploy is DeployBase {
+  // ETH mainnet addresses
+  // Deploy order: ListaRevenueDistributor → MarketFactory → configure LendingFeeRecipient.setMarketFeeRecipient()
+  address moolah = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70; // ETH Moolah Core
+  address liquidator = 0x5Bf5c3B5f5c29dBC647d2557Cc22B00ED29f301C; // ETH Liquidator
+  address publicLiquidator = 0x796302e041d1715a8b1f16Fd7d7CBA38bb031DE5; // ETH PublicLiquidator
+  address listaRevenueDistributor = address(0); // TODO: deploy ListaRevenueDistributor first, then fill address here
+  address buyback = address(0); // not used on ETH, no buyback mechanism
+  address autoBuyback = address(0); // not used on ETH, no auto buyback mechanism
+  address WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // WETH on ETH (corresponds to WBNB on BSC)
+  address sliBNB = address(0); // not used on ETH
+  address ETHProvider = 0xFe34BF713F3C2499026cdFA5af43eb22AA2d1aDb; // ETHProvider (corresponds to BNBProvider on BSC)
+  address slisBNBProvider = address(0); // not used on ETH
+  address rateCalculator = address(0); // not needed initially, can be set later via setRateCalculator()
+  address brokerLiquidator = address(0); // not needed initially, can be set later via setBrokerLiquidator()
+
+  address operator = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // Manager Safe
+  address pauser = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // Manager Safe
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy implementation
+    // NOTE: rateCalculator and brokerLiquidator are storage variables,
+    // set via setRateCalculator() and setBrokerLiquidator() when needed
+    MarketFactory impl = new MarketFactory(
+      moolah,
+      liquidator,
+      publicLiquidator,
+      listaRevenueDistributor,
+      buyback,
+      autoBuyback,
+      WETH, // on BSC: WBNB
+      sliBNB, // on ETH: address(0)
+      ETHProvider, // on BSC: BNBProvider
+      slisBNBProvider // on ETH: address(0)
+    );
+    console.log("MarketFactory implementation: ", address(impl));
+
+    // Deploy proxy
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, deployer, operator, pauser)
+    );
+    console.log("MarketFactory proxy: ", address(proxy));
+
+    // Note: rateCalculator and brokerLiquidator are storage variables (not immutable).
+    // Constructor writes to implementation storage, NOT proxy storage.
+    // After deployment, call MarketFactory(proxy).setRateCalculator(addr) and
+    // MarketFactory(proxy).setBrokerLiquidator(addr) when broker infra is ready.
+    // On ETH these are address(0) initially — no action needed until fixed-term markets are introduced.
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/moolah/MarketFactory.sol
+++ b/src/moolah/MarketFactory.sol
@@ -34,32 +34,33 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
   IBuyBack public immutable buyBack;
   IListaAutoBuyBack public immutable autoBuyBack;
   IPublicLiquidator public immutable publicLiquidator;
-  address public immutable WBNB;
-  address public immutable sliBNB;
-  address public immutable BNBProvider;
-  address public immutable slisBNBProvider;
-  IRateCalculator public immutable rateCalculator;
-  IBrokerLiquidator public immutable brokerLiquidator;
+  address public immutable WBNB; // on ETH: WETH
+  address public immutable sliBNB; // on ETH: not used (address(0))
+  address public immutable BNBProvider; // on ETH: ETHProvider
+  address public immutable slisBNBProvider; // on ETH: not used (address(0))
+  IRateCalculator public rateCalculator;
+  IBrokerLiquidator public brokerLiquidator;
 
   bytes32 public constant OPERATOR = keccak256("OPERATOR");
   bytes32 public constant PAUSER = keccak256("PAUSER");
 
   event BrokerMarketDeployed(FixedTermMarketParams fixedTermMarketParams, Id marketId, address broker);
   event CommonMarketDeployed(MarketParams marketParams, Id marketId);
+  event RateCalculatorUpdated(address indexed oldAddress, address indexed newAddress);
+  event BrokerLiquidatorUpdated(address indexed oldAddress, address indexed newAddress);
+
   /**
    * @dev constructor to set immutable variables
    * @param _moolah The address of the Moolah contract
    * @param _liquidator The address of the Liquidator contract
    * @param _publicLiquidator The address of the PublicLiquidator contract
-   * @param _revenueDistributor The address of the RevenueDistributor contract
-   * @param _buyBack The address of the BuyBack contract
-   * @param _autoBuyBack The address of the AutoBuyBack contract
-   * @param _WBNB The address of the WBNB token
-   * @param _sliBNB The address of the sliBNB token
-   * @param _BNBProvider The address of the BNB provider
-   * @param _slisBNBProvider The address of the slisBNB provider
-   * @param _rateCalculator The address of the rate calculator contract
-   * @param _brokerLiquidator The address of the broker liquidator contract
+   * @param _revenueDistributor The address of the RevenueDistributor contract (on ETH: address(0) if not needed)
+   * @param _buyBack The address of the BuyBack contract (on ETH: address(0) if not needed)
+   * @param _autoBuyBack The address of the AutoBuyBack contract (on ETH: address(0) if not needed)
+   * @param _WBNB The address of the WBNB token (on ETH: WETH address)
+   * @param _sliBNB The address of the sliBNB token (on ETH: address(0))
+   * @param _BNBProvider The address of the BNB provider (on ETH: ETHProvider)
+   * @param _slisBNBProvider The address of the slisBNB provider (on ETH: address(0))
    */
   constructor(
     address _moolah,
@@ -71,23 +72,14 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     address _WBNB,
     address _sliBNB,
     address _BNBProvider,
-    address _slisBNBProvider,
-    address _rateCalculator,
-    address _brokerLiquidator
+    address _slisBNBProvider
   ) {
     // sanity check for constructor arguments
     require(_moolah != address(0), "ZeroAddress");
     require(_liquidator != address(0), "ZeroAddress");
     require(_publicLiquidator != address(0), "ZeroAddress");
-    require(_revenueDistributor != address(0), "ZeroAddress");
-    require(_buyBack != address(0), "ZeroAddress");
-    require(_autoBuyBack != address(0), "ZeroAddress");
     require(_WBNB != address(0), "ZeroAddress");
-    require(_sliBNB != address(0), "ZeroAddress");
     require(_BNBProvider != address(0), "ZeroAddress");
-    require(_slisBNBProvider != address(0), "ZeroAddress");
-    require(_rateCalculator != address(0), "ZeroAddress");
-    require(_brokerLiquidator != address(0), "ZeroAddress");
     // set immutable variables
     moolah = IMoolah(_moolah);
     liquidator = ILiquidator(_liquidator);
@@ -99,8 +91,6 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     sliBNB = _sliBNB;
     BNBProvider = _BNBProvider;
     slisBNBProvider = _slisBNBProvider;
-    rateCalculator = IRateCalculator(_rateCalculator);
-    brokerLiquidator = IBrokerLiquidator(_brokerLiquidator);
 
     _disableInitializers();
   }
@@ -228,17 +218,17 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
       liquidator.setTokenWhitelist(param.collateralToken, true);
     }
     // revenue distributor set token whitelist
-    if (!revenueDistributor.tokenWhitelist(param.loanToken)) {
+    if (address(revenueDistributor) != address(0) && !revenueDistributor.tokenWhitelist(param.loanToken)) {
       address[] memory tokens = new address[](1);
       tokens[0] = param.loanToken;
       revenueDistributor.addTokensToWhitelist(tokens);
     }
     // buyback set token whitelist
-    if (!buyBack.tokenInWhitelist(param.loanToken)) {
+    if (address(buyBack) != address(0) && !buyBack.tokenInWhitelist(param.loanToken)) {
       buyBack.addTokenInWhitelist(param.loanToken);
     }
     // auto buyback set token whitelist
-    if (!autoBuyBack.tokenWhitelist(param.loanToken)) {
+    if (address(autoBuyBack) != address(0) && !autoBuyBack.tokenWhitelist(param.loanToken)) {
       autoBuyBack.setTokenWhitelist(param.loanToken, true);
     }
     // set BNBProvider for BNB markets
@@ -246,7 +236,7 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
       moolah.setProvider(id, BNBProvider, true);
     }
     // set slisBNBProvider for sliBNB markets
-    if (param.collateralToken == sliBNB) {
+    if (slisBNBProvider != address(0) && param.collateralToken == sliBNB) {
       moolah.setProvider(id, slisBNBProvider, true);
     }
     // set supply whitelist
@@ -267,6 +257,8 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
   function _createFixedTermMarket(FixedTermMarketParams memory param) private whenNotPaused returns (Id) {
     IBroker broker = IBroker(param.broker);
     require(param.broker != address(0), "Zero broker address");
+    require(address(rateCalculator) != address(0), "RateCalculator not set");
+    require(address(brokerLiquidator) != address(0), "BrokerLiquidator not set");
 
     // moolah create market
     MarketParams memory marketParam = MarketParams({
@@ -294,7 +286,7 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     broker.toggleLiquidationWhitelist(address(brokerLiquidator), true);
 
     // set slisBNBProvider for sliBNB markets
-    if (param.collateralToken == sliBNB) {
+    if (slisBNBProvider != address(0) && param.collateralToken == sliBNB) {
       moolah.setProvider(id, slisBNBProvider, true);
     }
 
@@ -344,6 +336,26 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     if (!liquidator.tokenWhitelist(token1)) {
       liquidator.setTokenWhitelist(token1, true);
     }
+  }
+
+  /**
+   * @dev Set the rate calculator address
+   * @param _rateCalculator The address of the rate calculator contract
+   */
+  function setRateCalculator(address _rateCalculator) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_rateCalculator != address(0), "ZeroAddress");
+    emit RateCalculatorUpdated(address(rateCalculator), _rateCalculator);
+    rateCalculator = IRateCalculator(_rateCalculator);
+  }
+
+  /**
+   * @dev Set the broker liquidator address
+   * @param _brokerLiquidator The address of the broker liquidator contract
+   */
+  function setBrokerLiquidator(address _brokerLiquidator) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_brokerLiquidator != address(0), "ZeroAddress");
+    emit BrokerLiquidatorUpdated(address(brokerLiquidator), _brokerLiquidator);
+    brokerLiquidator = IBrokerLiquidator(_brokerLiquidator);
   }
 
   /**

--- a/test/moolah/MarketFactoryTest.sol
+++ b/test/moolah/MarketFactoryTest.sol
@@ -109,15 +109,19 @@ contract MarketFactoryTest is Test {
       address(WBNB),
       address(slisBNB),
       address(bnbProvider),
-      address(slisBNBProvider),
-      address(rateCalculator),
-      address(brokerLiquidator)
+      address(slisBNBProvider)
     );
     ERC1967Proxy marketFactoryProxy = new ERC1967Proxy(
       address(marketFactoryImpl),
       abi.encodeWithSelector(marketFactoryImpl.initialize.selector, admin, operator, pauser)
     );
     marketFactory = MarketFactory(address(marketFactoryProxy));
+
+    // Set storage-based variables via setter
+    vm.startPrank(admin);
+    marketFactory.setRateCalculator(address(rateCalculator));
+    marketFactory.setBrokerLiquidator(address(brokerLiquidator));
+    vm.stopPrank();
 
     vm.startPrank(manager);
     moolah.enableIrm(address(irm));


### PR DESCRIPTION
## Summary

Modify the existing `MarketFactory` contract to support both BSC and ETH mainnet deployments. The existing factory is adapted with address(0) guards and storage-based setters for broker infrastructure. `rateCalculator` and `brokerLiquidator` are moved from immutable to storage variables and **removed from the constructor** (per audit feedback: constructor writes to storage are meaningless for proxy pattern). Also adds the ETH mainnet deploy script with real addresses.

## Change Type

- [x] Configuration change (existing contract)
- [x] Deploy script (new)
- [x] Test (updated)
- [ ] New contract
- [ ] Upgrade (existing proxy)
- [ ] Bug fix

## Contracts Changed

| Contract | File | Type | Description |
|----------|------|------|-------------|
| MarketFactory | `src/moolah/MarketFactory.sol` | modified | address(0) guards + immutable→storage for broker infra, constructor reduced to 10 params |
| MarketFactoryDeploy (ETH) | `script/eth/deploy_marketFactory.sol` | new | ETH mainnet deploy script |
| MarketFactoryDeploy (BSC) | `script/deploy_marketFactory.sol` | modified | Updated constructor call (10 params) |
| MarketFactoryTest | `test/moolah/MarketFactoryTest.sol` | modified | Updated constructor + setter calls |

## Key Changes to MarketFactory.sol

| Area | Before | After |
|------|--------|-------|
| `rateCalculator` | `immutable` (constructor param) | storage variable (set via setter post-deploy) |
| `brokerLiquidator` | `immutable` (constructor param) | storage variable (set via setter post-deploy) |
| Constructor | 12 params | **10 params** (removed rateCalculator/brokerLiquidator) |
| `_createMarket` | Always calls revenueDistributor/buyBack/autoBuyBack | Skips if address(0) |
| `_createFixedTermMarket` | Always calls slisBNBProvider | Skips if address(0) |
| New: `setRateCalculator()` | — | DEFAULT_ADMIN_ROLE can set rateCalculator address |
| New: `setBrokerLiquidator()` | — | DEFAULT_ADMIN_ROLE can set brokerLiquidator address |

## Design Decisions

1. **Single contract, dual-chain**: Rather than forking a separate `MarketFactoryETH`, we adapt the existing contract with runtime guards. This avoids code duplication and ensures both chains benefit from future improvements.

2. **immutable → storage, removed from constructor**: Per audit feedback — setting storage variables in constructor is meaningless for UUPS proxy pattern (constructor writes go to implementation storage, not proxy storage). The values must be set via setter after proxy deployment.

3. **address(0) guard pattern**: In `_createMarket`, revenue/buyback operations are gated by `if (address(xxx) != address(0))`. In `_createFixedTermMarket`, `rateCalculator` and `brokerLiquidator` remain hard `require` since fixed-term markets cannot function without them.

4. **Constructor reduced to 10 params**: BSC deploy script updated accordingly. Existing BSC proxy does **NOT** need upgrade — the deployed implementation still has the old bytecode with immutable values baked in. Only future redeployments use the new constructor.

## ETH Deploy Script

`script/eth/deploy_marketFactory.sol` — addresses sourced from Notion SOP:

| Param | ETH Address | Note |
|-------|-------------|------|
| moolah | `0xf820fB46...Fd70` | ETH Moolah Core |
| liquidator | `0x5Bf5c3B5...301C` | ETH Liquidator |
| publicLiquidator | `0x796302e0...1DE5` | ETH PublicLiquidator |
| listaRevenueDistributor | `address(0)` | TODO: fill after deploying ListaRevenueDistributor |
| buyback / autoBuyback | `address(0)` | Not used on ETH |
| WETH | `0xC02aaA39...6Cc2` | Corresponds to WBNB on BSC |
| sliBNB / slisBNBProvider | `address(0)` | Not used on ETH |
| ETHProvider | `0xFe34BF71...1aDb` | Corresponds to BNBProvider on BSC |
| operator / pauser | `0x8d388136...B0c6` | Manager Safe |

## Deploy Order

```
1. Deploy ListaRevenueDistributor (lista-token repo)
2. Fill listaRevenueDistributor address in this script
3. Deploy MarketFactory via this script
4. Call setRateCalculator() and setBrokerLiquidator() when broker infra is ready
5. (Multisig) LendingFeeRecipient.setMarketFeeRecipient(ListaRevenueDistributor address)
```

## Storage Layout

`rateCalculator` and `brokerLiquidator` changed from immutable to storage. Since immutables are not in storage slots, this does NOT affect existing proxy storage layout. For BSC, the existing proxy does NOT need to be upgraded.

## BSC Impact

| Scenario | Impact |
|----------|--------|
| Existing BSC proxy | **No change needed** — old implementation bytecode still has immutable values |
| Future BSC upgrade | Must call `setRateCalculator()` and `setBrokerLiquidator()` after upgrade |
| BSC deploy script | Updated to 10-param constructor (for future redeployment only) |

## Access Control

| Operation | Role | Contract |
|-----------|------|----------|
| `createMarket` / `batchCreateMarkets` | OPERATOR | MarketFactory |
| `createFixedTermMarket` / `batchCreateFixedTermMarkets` | OPERATOR | MarketFactory |
| `setRateCalculator` | DEFAULT_ADMIN_ROLE | MarketFactory |
| `setBrokerLiquidator` | DEFAULT_ADMIN_ROLE | MarketFactory |
| `pause` | PAUSER | MarketFactory |
| `unpause` | OPERATOR | MarketFactory |
| `_authorizeUpgrade` | DEFAULT_ADMIN_ROLE | MarketFactory |

## Risk Assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | None | immutable→storage is additive; no slot conflict |
| Fund safety | None | Factory only configures — no fund movements |
| BSC regression | None | Existing proxy unaffected; script change for future use only |
| ETH optional subsystems | Low | address(0) guard prevents calls to zero address |
| Broker future-proof | Low | `setRateCalculator`/`setBrokerLiquidator` allow later configuration |

## Test Plan

```bash
forge test --match-contract MarketFactoryTest -vvv --via-ir
```

Scenarios:
- Constructor with 10 params (both BSC-like and ETH-like)
- `createMarket` skips revenue/buyback when address(0)
- `createFixedTermMarket` reverts when rateCalculator/brokerLiquidator are address(0)
- `setRateCalculator` / `setBrokerLiquidator` — only DEFAULT_ADMIN_ROLE, emits event
- Pausable behavior preserved