### PR TITLE
fix(liquidator): reject smart collateral in normal liquidate

### DIFF
--- a/src/liquidator/Liquidator.sol
+++ b/src/liquidator/Liquidator.sol
@@ -13,6 +13,10 @@ import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { ISmartProvider } from "../provider/interfaces/IProvider.sol";
 import { ILiquidationVault } from "./ILiquidationVault.sol";
 
+interface IHasMinter {
+  function minter() external view returns (address);
+}
+
 contract Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessControlUpgradeable, ILiquidator {
   using MarketParamsLib for IMoolah.MarketParams;
   using SafeTransferLib for address;
@@ -27,6 +31,7 @@ contract Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessContro
   error SwapFailed();
   error NotAuthorized();
   error InvalidFundSource();
+  error SmartCollateralMustUseDedicatedFunction();
 
   address public immutable MOOLAH;
   mapping(address => bool) public tokenWhitelist;
@@ -380,6 +385,10 @@ contract Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessContro
   ) external nonReentrant onlyRole(BOT) {
     require(marketWhitelist[id], NotWhitelisted());
     IMoolah.MarketParams memory params = IMoolah(MOOLAH).idToMarketParams(id);
+    // Smart LP collateral must use liquidateSmartCollateral: otherwise the reflow below would push the
+    // seized LP into the vault, which has no redeem path for it (needs a MANAGER rescue). Mirrors
+    // BrokerLiquidator.liquidate.
+    require(!_isSmartCollateral(params.collateralToken), SmartCollateralMustUseDedicatedFunction());
     IMoolah(MOOLAH).liquidate(
       params,
       borrower,
@@ -623,6 +632,20 @@ contract Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessContro
     }
 
     arb.loanToken.safeApprove(MOOLAH, repaidAssets);
+  }
+
+  /// @dev Returns true when `collateralToken` is a smart-collateral LP token: its `minter()` is a
+  ///      SmartProvider whose `TOKEN()` points back to the collateral. Mirrors BrokerLiquidator.
+  function _isSmartCollateral(address collateralToken) internal view returns (bool) {
+    try IHasMinter(collateralToken).minter() returns (address minterAddr) {
+      try ISmartProvider(minterAddr).TOKEN() returns (address token) {
+        return token == collateralToken;
+      } catch {
+        return false;
+      }
+    } catch {
+      return false;
+    }
   }
 
   /// @dev Reflow (push) the full balance of `token` to the vault. No-op when fundSource is unset or

--- a/test/liquidator/Liquidator.t.sol
+++ b/test/liquidator/Liquidator.t.sol
@@ -6,6 +6,8 @@ import "../moolah/BaseTest.sol";
 import { Liquidator, ILiquidator } from "liquidator/Liquidator.sol";
 import { MarketParamsLib, MarketParams, Id } from "moolah/libraries/MarketParamsLib.sol";
 import { MockOneInch } from "./mocks/MockOneInch.sol";
+import { MockSmartProvider } from "./mocks/MockSmartProvider.sol";
+import { MockStableSwapLPCollateral } from "./mocks/MockStableSwapLPCollateral.sol";
 
 contract LiquidatorTest is BaseTest {
   using MathLib for uint256;
@@ -62,6 +64,37 @@ contract LiquidatorTest is BaseTest {
     vm.stopPrank();
 
     assertEq(collateralToken.balanceOf(address(liquidator)), collateralAmount, "collateralToken balance");
+  }
+
+  function testLiquidateRevertsForSmartCollateral() public {
+    // Configure a smart-collateral market whose collateral's minter() -> smartProvider,
+    // and smartProvider.TOKEN() -> the collateral (so _isSmartCollateral returns true).
+    MockSmartProvider smartProvider = new MockSmartProvider(address(loanToken), address(collateralToken));
+    MockStableSwapLPCollateral mockLPCollateral = new MockStableSwapLPCollateral(
+      "MockLP",
+      "MLP",
+      address(smartProvider)
+    );
+    smartProvider.setCollateralToken(address(mockLPCollateral));
+
+    MarketParams memory smartMarketParams = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(mockLPCollateral),
+      oracle: address(oracle),
+      irm: address(irm),
+      lltv: 0.8e18
+    });
+    moolah.createMarket(smartMarketParams);
+    bytes32 smartMarketId = Id.unwrap(smartMarketParams.id());
+
+    vm.prank(OWNER);
+    liquidator.setMarketWhitelist(smartMarketId, true);
+
+    // Normal liquidate must reject smart collateral (use liquidateSmartCollateral instead),
+    // otherwise the seized LP would be reflowed into the vault, which cannot redeem it.
+    vm.prank(BOT);
+    vm.expectRevert(Liquidator.SmartCollateralMustUseDedicatedFunction.selector);
+    liquidator.liquidate(smartMarketId, address(1), 1e18, 0);
   }
 
   function testFlashLiquidate() public {


### PR DESCRIPTION
## Summary

The main `Liquidator`'s plain `liquidate` lacked the smart-collateral guard that `BrokerLiquidator.liquidate` already has (spec LIQ-3). On a direct (demand) smart-LP market where the `Liquidator` is in Moolah's `liquidationWhitelist`, calling `liquidate` instead of `liquidateSmartCollateral` reflows the seized LP into the `LiquidationVault`, which has no redeem path for it — the LP is then stuck until a multi-step MANAGER rescue. This is a regression introduced by the vault reflow (pre-vault the LP stayed on the `Liquidator`, which can self-redeem via `redeemSmartCollateral`).

Found during a Claude×Codex parallel audit of the shared-liquidation-fund branch; both reviewers flagged it independently.

## Change type

- [x] Bug fix
- [x] Upgrade (existing proxy) — `Liquidator` UUPS implementation

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| Liquidator | src/liquidator/Liquidator.sol | modified |
| (test) | test/liquidator/Liquidator.t.sol | modified |

## Interface changes

- New `error SmartCollateralMustUseDedicatedFunction()`
- New internal `interface IHasMinter` (identical to `BrokerLiquidator`)
- No changes to any `external`/`public` function signature or event

## Storage layout

🟢 No change. Only an error, a `view` helper (`_isSmartCollateral`), and a `require` were added — no new state variables. `fundSource` remains slot 4; append-only compatibility preserved (verified with `forge inspect ... storageLayout`).

## Access control

Unchanged.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | No storage variable changes |
| Fund safety | 🟢 None | Pure pre-flight `revert`; prevents LP being reflowed into the vault |
| Access control | 🟢 None | No role / modifier changes |
| External call safety | 🟢 None | `_isSmartCollateral` is `view` with nested try/catch; fails safe to `false` |

## Deployment

BSC: redeploy the `Liquidator` UUPS implementation and `upgradeTo` on proxy `0x6a87C15598929B2db22cF68a9a0dDE5Bf297a59a`. Run the upgrade three-piece check (storage-layout diff + selector probe + fork dry-run) before executing.

## Test plan

- [x] `forge test --match-path 'test/liquidator/*'` — 52/52 pass
- [x] New `testLiquidateRevertsForSmartCollateral` (TDD: RED then GREEN)
- [x] Existing `testLiquidate` confirms normal collateral is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
