### PR TITLE
feat: add lisAster/ASTER smart-collateral deployment scripts

### DIFF
--- a/script/smartCollateral/lisAster/1_create_stableSwapPair.sol
+++ b/script/smartCollateral/lisAster/1_create_stableSwapPair.sol
@@ -1,0 +1,62 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../../DeployBase.sol";
+
+import { StableSwapFactory } from "src/dex/StableSwapFactory.sol";
+import { StableSwapPool } from "src/dex/StableSwapPool.sol";
+
+import "./LisAsterAddress.sol";
+
+// Step 1: create the lisAster <> Aster stable swap pool and disable the oracle
+//         price-diff check on it.
+//
+// forge script script/smartCollateral/lisAster/1_create_stableSwapPair.sol \
+//   --rpc-url $BSC_RPC --private-key $PRIVATE_KEY --broadcast -vvv --via-ir
+contract CreateLisAsterAsterPair is DeployBase {
+  StableSwapFactory factory = StableSwapFactory(SS_FACTORY);
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    require(factory.lpImpl() != address(0), "LP impl not set");
+    require(factory.swapImpl() != address(0), "Swap impl not set");
+
+    // Amplification coefficient (requested): A = 20
+    uint256 _A = 20;
+    uint256 _fee = 25000000; // 0.25% (25 bp) swap fee
+    uint256 _adminFee = 2e9; // 20% of swap fee goes to admin
+    string memory name = "lisAster & ASTER-LP";
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    (address _lp, address _pool) = factory.createSwapPair(
+      LISASTER,
+      ASTER,
+      name,
+      name,
+      _A,
+      _fee,
+      _adminFee,
+      deployer, // admin
+      deployer, // manager
+      deployer, // pauser
+      RESILIENT_ORACLE
+    );
+
+    console.log("Created pool: ", name);
+    console.log("StableSwapPool LP token: ", _lp);
+    console.log("StableSwapPool: ", _pool);
+
+    // Disable oracle price-diff check (requested).
+    // Deployer holds MANAGER on the freshly created pool, so this call succeeds here.
+    StableSwapPool(_pool).setSkipPriceDiff(true);
+    console.log("skipPriceDiff enabled (priceDiffCheck disabled)");
+
+    vm.stopBroadcast();
+
+    console.log("NEXT: set DEX_LISASTER_ASTER and LP_LISASTER_ASTER in LisAsterAddress.sol");
+  }
+}

--- a/script/smartCollateral/lisAster/2_deploy_lp_collateral.sol
+++ b/script/smartCollateral/lisAster/2_deploy_lp_collateral.sol
@@ -1,0 +1,43 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../../DeployBase.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
+
+import "./LisAsterAddress.sol";
+
+// Step 2: deploy the SmartLP collateral token used as Moolah collateral.
+//
+// forge script script/smartCollateral/lisAster/2_deploy_lp_collateral.sol \
+//   --rpc-url $BSC_RPC --private-key $PRIVATE_KEY --broadcast -vvv --via-ir
+contract DeployLisAsterAsterCollateral is DeployBase {
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    string memory name = "lisAster & ASTER-SmartLP";
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    StableSwapLPCollateral impl = new StableSwapLPCollateral(MOOLAH);
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(
+        impl.initialize.selector,
+        deployer, // admin
+        deployer, // minter (reassigned to SmartProvider in step 3)
+        name,
+        name
+      )
+    );
+
+    console.log("StableSwapLPCollateral proxy: ", address(proxy));
+
+    vm.stopBroadcast();
+
+    console.log("NEXT: set COLLATERAL_LISASTER_ASTER in LisAsterAddress.sol");
+  }
+}

--- a/script/smartCollateral/lisAster/3_deploy_smartProvider.sol
+++ b/script/smartCollateral/lisAster/3_deploy_smartProvider.sol
@@ -1,0 +1,48 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../../DeployBase.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
+import { SmartProvider } from "src/provider/SmartProvider.sol";
+
+import "./LisAsterAddress.sol";
+
+// Step 3: deploy the SmartProvider (which also serves as the market oracle) and
+//         hand the collateral's minter role to it.
+//
+// Requires DEX_LISASTER_ASTER and COLLATERAL_LISASTER_ASTER set in LisAsterAddress.sol.
+//
+// forge script script/smartCollateral/lisAster/3_deploy_smartProvider.sol \
+//   --rpc-url $BSC_RPC --private-key $PRIVATE_KEY --broadcast -vvv --via-ir
+contract DeployLisAsterAsterSmartProvider is DeployBase {
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    address smartLp = COLLATERAL_LISASTER_ASTER;
+    address dex = DEX_LISASTER_ASTER;
+    require(smartLp != address(0), "set COLLATERAL_LISASTER_ASTER first");
+    require(dex != address(0), "set DEX_LISASTER_ASTER first");
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    SmartProvider impl = new SmartProvider(MOOLAH, smartLp);
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, deployer, dex, SS_INFO, RESILIENT_ORACLE)
+    );
+
+    console.log("SmartProvider deployed at: ", address(proxy));
+
+    // set minter to smart provider
+    StableSwapLPCollateral(smartLp).setMinter(address(proxy));
+    console.log("Minter set to SmartProvider");
+
+    vm.stopBroadcast();
+
+    console.log("NEXT: set SMART_PROVIDER_LISASTER_ASTER in LisAsterAddress.sol");
+  }
+}

--- a/script/smartCollateral/lisAster/4_create_market.sol
+++ b/script/smartCollateral/lisAster/4_create_market.sol
@@ -1,0 +1,63 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../../DeployBase.sol";
+
+import { Moolah } from "moolah/Moolah.sol";
+import { MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+
+import "./LisAsterAddress.sol";
+
+// Step 4: create the Moolah market using the SmartLP as collateral.
+//
+//   loan       = Aster
+//   collateral = lisAster & Aster SmartLP
+//   oracle     = lisAster & Aster SmartProvider
+//   irm        = IRM
+//   lltv       = 91.5%
+//
+// Requires COLLATERAL_LISASTER_ASTER and SMART_PROVIDER_LISASTER_ASTER set in LisAsterAddress.sol.
+//
+// forge script script/smartCollateral/lisAster/4_create_market.sol \
+//   --rpc-url $BSC_RPC --private-key $PRIVATE_KEY --broadcast -vvv --via-ir
+contract CreateLisAsterAsterMarket is DeployBase {
+  using MarketParamsLib for MarketParams;
+
+  Moolah moolah = Moolah(MOOLAH);
+
+  uint256 lltv915 = 915 * 1e15; // 91.5%
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    require(COLLATERAL_LISASTER_ASTER != address(0), "set COLLATERAL_LISASTER_ASTER first");
+    require(SMART_PROVIDER_LISASTER_ASTER != address(0), "set SMART_PROVIDER_LISASTER_ASTER first");
+
+    MarketParams memory params = MarketParams({
+      loanToken: ASTER,
+      collateralToken: COLLATERAL_LISASTER_ASTER,
+      oracle: SMART_PROVIDER_LISASTER_ASTER,
+      irm: IRM,
+      lltv: lltv915
+    });
+
+    Id id = params.id();
+    console.log("market id:");
+    console.logBytes32(Id.unwrap(id));
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    (, , , , uint128 lastUpdate, ) = moolah.market(id);
+    if (lastUpdate != 0) {
+      console.log("market already exists");
+    } else {
+      moolah.createMarket(params);
+      console.log("market created");
+    }
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/smartCollateral/lisAster/5_grant_roles.sol
+++ b/script/smartCollateral/lisAster/5_grant_roles.sol
@@ -1,0 +1,68 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../../DeployBase.sol";
+
+import { StableSwapPool } from "src/dex/StableSwapPool.sol";
+import { StableSwapLP } from "src/dex/StableSwapLP.sol";
+import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
+import { SmartProvider } from "src/provider/SmartProvider.sol";
+
+import "./LisAsterAddress.sol";
+
+// Step 5: grant roles on the pool, collateral and SmartProvider to the admin/pauser
+//         multisigs. Run this BEFORE 6_revoke_roles.sol so the deployer keeps admin
+//         until the new roles are confirmed.
+//
+// Requires DEX_LISASTER_ASTER, COLLATERAL_LISASTER_ASTER and
+// SMART_PROVIDER_LISASTER_ASTER set in LisAsterAddress.sol.
+//
+// forge script script/smartCollateral/lisAster/5_grant_roles.sol \
+//   --rpc-url $BSC_RPC --private-key $PRIVATE_KEY --broadcast -vvv --via-ir
+contract GrantLisAsterAsterRoles is DeployBase {
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant PAUSER = keccak256("PAUSER");
+  bytes32 public constant TRANSFERER = keccak256("TRANSFERER");
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    require(DEX_LISASTER_ASTER != address(0), "set DEX_LISASTER_ASTER first");
+    require(COLLATERAL_LISASTER_ASTER != address(0), "set COLLATERAL_LISASTER_ASTER first");
+    require(SMART_PROVIDER_LISASTER_ASTER != address(0), "set SMART_PROVIDER_LISASTER_ASTER first");
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // --- stable swap pool ---
+    StableSwapPool pool = StableSwapPool(DEX_LISASTER_ASTER);
+    pool.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    pool.grantRole(MANAGER, MANAGER_ADDR); // MANAGER -> 0x8d38...b0c6 multisig
+    pool.grantRole(PAUSER, PAUSER_ADDR);
+    console.log("Granted pool roles: ", DEX_LISASTER_ASTER);
+
+    // --- internal StableSwapLP token (deployer holds DEFAULT_ADMIN_ROLE from factory) ---
+    StableSwapLP lp = StableSwapLP(pool.token());
+    lp.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    console.log("Granted StableSwapLP admin: ", pool.token());
+
+    // --- LP collateral ---
+    StableSwapLPCollateral collateral = StableSwapLPCollateral(COLLATERAL_LISASTER_ASTER);
+    collateral.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    collateral.grantRole(MANAGER, MANAGER_ADDR); // MANAGER -> 0x8d38...b0c6 multisig
+    collateral.grantRole(TRANSFERER, MOOLAH); // TRANSFERER -> Moolah contract
+    console.log("Granted collateral roles: ", COLLATERAL_LISASTER_ASTER);
+
+    // --- SmartProvider ---
+    SmartProvider provider = SmartProvider(payable(SMART_PROVIDER_LISASTER_ASTER));
+    provider.grantRole(DEFAULT_ADMIN_ROLE, ADMIN_ADDR);
+    provider.grantRole(MANAGER, MANAGER_ADDR); // MANAGER -> 0x8d38...b0c6 multisig
+    console.log("Granted provider roles: ", SMART_PROVIDER_LISASTER_ASTER);
+
+    vm.stopBroadcast();
+
+    console.log("grant roles done! NEXT: run 6_revoke_roles.sol once confirmed");
+  }
+}

--- a/script/smartCollateral/lisAster/6_revoke_roles.sol
+++ b/script/smartCollateral/lisAster/6_revoke_roles.sol
@@ -1,0 +1,64 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../../DeployBase.sol";
+
+import { StableSwapPool } from "src/dex/StableSwapPool.sol";
+import { StableSwapLP } from "src/dex/StableSwapLP.sol";
+import { StableSwapLPCollateral } from "src/dex/StableSwapLPCollateral.sol";
+import { SmartProvider } from "src/provider/SmartProvider.sol";
+
+import "./LisAsterAddress.sol";
+
+// Step 6: revoke the deployer's roles on the pool, collateral and SmartProvider.
+//         Run this ONLY AFTER 5_grant_roles.sol and after confirming the admin/pauser
+//         multisigs hold their roles -- this call renounces the deployer's control.
+//
+// Requires DEX_LISASTER_ASTER, COLLATERAL_LISASTER_ASTER and
+// SMART_PROVIDER_LISASTER_ASTER set in LisAsterAddress.sol.
+//
+// forge script script/smartCollateral/lisAster/6_revoke_roles.sol \
+//   --rpc-url $BSC_RPC --private-key $PRIVATE_KEY --broadcast -vvv --via-ir
+contract RevokeLisAsterAsterRoles is DeployBase {
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 public constant MANAGER = keccak256("MANAGER");
+  bytes32 public constant PAUSER = keccak256("PAUSER");
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    require(DEX_LISASTER_ASTER != address(0), "set DEX_LISASTER_ASTER first");
+    require(COLLATERAL_LISASTER_ASTER != address(0), "set COLLATERAL_LISASTER_ASTER first");
+    require(SMART_PROVIDER_LISASTER_ASTER != address(0), "set SMART_PROVIDER_LISASTER_ASTER first");
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // --- stable swap pool --- (revoke DEFAULT_ADMIN_ROLE last)
+    StableSwapPool pool = StableSwapPool(DEX_LISASTER_ASTER);
+    pool.revokeRole(PAUSER, deployer);
+    pool.revokeRole(MANAGER, deployer);
+    pool.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+    console.log("Revoked pool roles: ", DEX_LISASTER_ASTER);
+
+    // --- internal StableSwapLP token (deployer holds DEFAULT_ADMIN_ROLE from factory) ---
+    StableSwapLP lp = StableSwapLP(pool.token());
+    lp.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+    console.log("Revoked StableSwapLP admin: ", pool.token());
+
+    // --- LP collateral ---
+    StableSwapLPCollateral collateral = StableSwapLPCollateral(COLLATERAL_LISASTER_ASTER);
+    collateral.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+    console.log("Revoked collateral roles: ", COLLATERAL_LISASTER_ASTER);
+
+    // --- SmartProvider ---
+    SmartProvider provider = SmartProvider(payable(SMART_PROVIDER_LISASTER_ASTER));
+    provider.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+    console.log("Revoked provider roles: ", SMART_PROVIDER_LISASTER_ASTER);
+
+    vm.stopBroadcast();
+
+    console.log("revoke roles done!");
+  }
+}

--- a/script/smartCollateral/lisAster/LisAsterAddress.sol
+++ b/script/smartCollateral/lisAster/LisAsterAddress.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.8.34;
+
+// Shared smart-collateral addresses (MOOLAH, SS_FACTORY, SS_INFO, RESILIENT_ORACLE, IRM, roles, ...)
+import "../SCAddress.sol";
+
+// ---------------------------------------------------------------------------
+// lisAster / Aster smart-collateral deployment address book
+// ---------------------------------------------------------------------------
+
+// Aster token (loan token)
+address constant ASTER = 0x000Ae314E2A2172a039B26378814C252734f556A;
+
+// lisAster token
+address constant LISASTER = 0xa17A497D20cC143508FE3b63578b13ba6b9c9f06;
+
+// -------- Filled in as each deploy step below is broadcast --------
+
+// [step 1] lisAster <> Aster stable swap pool
+address constant DEX_LISASTER_ASTER = address(0); // TODO: set after 1_create_stableSwapPair
+
+// [step 1] lisAster <> Aster internal StableSwapLP token
+address constant LP_LISASTER_ASTER = address(0); // TODO: set after 1_create_stableSwapPair
+
+// [step 2] lisAster <> Aster SmartLP collateral (Moolah collateral token)
+address constant COLLATERAL_LISASTER_ASTER = address(0); // TODO: set after 2_deploy_lp_collateral
+
+// [step 3] lisAster <> Aster SmartProvider (also the market oracle)
+address constant SMART_PROVIDER_LISASTER_ASTER = address(0); // TODO: set after 3_deploy_smartProvider

--- a/script/smartCollateral/lisAster/LisAsterAddress.sol
+++ b/script/smartCollateral/lisAster/LisAsterAddress.sol
@@ -16,13 +16,13 @@ address constant LISASTER = 0xa17A497D20cC143508FE3b63578b13ba6b9c9f06;
 // -------- Filled in as each deploy step below is broadcast --------
 
 // [step 1] lisAster <> Aster stable swap pool
-address constant DEX_LISASTER_ASTER = address(0); // TODO: set after 1_create_stableSwapPair
+address constant DEX_LISASTER_ASTER = 0x510D69b25A2177EDdCe9becdB0A66a511C944840;
 
 // [step 1] lisAster <> Aster internal StableSwapLP token
-address constant LP_LISASTER_ASTER = address(0); // TODO: set after 1_create_stableSwapPair
+address constant LP_LISASTER_ASTER = 0x0f84dD5EBfceb6fE65B1552A310a000349278068;
 
 // [step 2] lisAster <> Aster SmartLP collateral (Moolah collateral token)
-address constant COLLATERAL_LISASTER_ASTER = address(0); // TODO: set after 2_deploy_lp_collateral
+address constant COLLATERAL_LISASTER_ASTER = 0xC970dc3aF680C2F316b821842E5782a05e886a90;
 
 // [step 3] lisAster <> Aster SmartProvider (also the market oracle)
-address constant SMART_PROVIDER_LISASTER_ASTER = address(0); // TODO: set after 3_deploy_smartProvider
+address constant SMART_PROVIDER_LISASTER_ASTER = 0x1cc913Cde4dF80d271230F615482c1270c0a56C8;


### PR DESCRIPTION
## Summary

Adds ordered deployment scripts to stand up the **lisAster/ASTER SmartLP lending market** on Moolah (BSC), per the market spec (collateral = lisAster/ASTER LP, loan = ASTER, LLTV = 91.5%, Lista Aster Vault).

All new scripts live under `script/smartCollateral/lisAster/` and follow the existing `script/smartCollateral/` conventions.

## Market parameters

| Field | Value |
|---|---|
| Loan token | ASTER `0x000Ae314E2A2172a039B26378814C252734f556A` |
| Collateral | lisAster & ASTER-SmartLP (`StableSwapLPCollateral`) |
| Oracle | lisAster & ASTER `SmartProvider` |
| IRM | `0xFe7dAe87Ebb11a7BEB9F534BB23267992d9cDe7c` |
| LLTV | 91.5% (`lltv915`) |
| Pool A | 20 |
| Swap fee | 25 bp (0.25%) |
| Admin fee | 20% |
| priceDiffCheck | **disabled** (`setSkipPriceDiff(true)`) |

## Scripts (run in order)

| # | File | Action |
|---|---|---|
| — | `LisAsterAddress.sol` | Address book. Known tokens + `TODO` placeholders filled in after each deploy step. |
| 1 | `1_create_stableSwapPair.sol` | Create lisAster↔ASTER stable swap pool (A=20, fee 25bp, adminFee 20%), then disable the oracle price-diff check. |
| 2 | `2_deploy_lp_collateral.sol` | Deploy the `StableSwapLPCollateral` (SmartLP, Moolah collateral). |
| 3 | `3_deploy_smartProvider.sol` | Deploy `SmartProvider` (also the market oracle); set collateral minter → provider. |
| 4 | `4_create_market.sol` | `createMarket(loan=ASTER, collateral=SmartLP, oracle=SmartProvider, irm, lltv=91.5%)`. |
| 5 | `5_grant_roles.sol` | Grant roles to the multisigs (run before step 6). |
| 6 | `6_revoke_roles.sol` | Revoke the deployer's roles once step 5 is confirmed. |

## Role handoff

| Contract | DEFAULT_ADMIN | MANAGER | PAUSER | TRANSFERER |
|---|---|---|---|---|
| StableSwapPool | ADMIN_ADDR | `0x8d38…b0c6` | PAUSER_ADDR | — |
| StableSwapLP | ADMIN_ADDR | — | — | — |
| StableSwapLPCollateral | ADMIN_ADDR | `0x8d38…b0c6` | — | Moolah |
| SmartProvider | ADMIN_ADDR | `0x8d38…b0c6` | — | — |

Deployer roles on all four contracts are revoked in step 6 (including the internal `StableSwapLP` admin that the factory assigns to the deployer).

## Notes / prerequisites

- Contract addresses are resolved between steps: steps 3–6 read the deployed addresses from `LisAsterAddress.sol` and `require` they're set, failing fast if run out of order.
- Deployer must hold the `DEPLOYER` role on `StableSwapFactory` (step 1) and `OPERATOR` on Moolah (step 4) before running.
- `forge build` passes (no new warnings).

## Test plan

- [ ] `forge build`
- [ ] Dry-run each script against a BSC fork
- [ ] Verify market ID and params on-chain after step 4
- [ ] Confirm role assignments before running step 6