### PR TITLE
feat(certora): migrate Certora formal verification suite from moolah-certora

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -1,0 +1,237 @@
+# Certora formal verification, triggered by PR comment:
+#
+#   /certora ConsistentState            run one conf
+#   /certora ConsistentState Health     run several
+#   /certora all                        run every conf in certora/confs/
+#
+# Runs on the self-hosted x86 runner using the locally-built open-source
+# Certora Prover image (ghcr.io/lista-dao/certora-local). Results are posted
+# back to the PR as a comment; full HTML reports are uploaded as an artifact.
+#
+# Security notes:
+# - issue_comment workflows always execute the definition from the default
+#   branch, so a PR cannot tamper with this pipeline.
+# - Only OWNER/MEMBER/COLLABORATOR comments trigger a run (public repo +
+#   self-hosted runner), and the PR code only runs inside the container.
+name: certora
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      confs:
+        description: "Space-separated conf names (see certora/confs/) or 'all'"
+        required: false
+        default: "ConsistentState"
+
+permissions:
+  contents: read
+  pull-requests: write
+  packages: read
+
+concurrency:
+  group: certora-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/lista-dao/certora-local:latest
+  # SMT solving is memory hungry; keep in sync with the runner host's RAM.
+  CONTAINER_MEM: 6g
+  JAVA_HEAP: -Xmx4g
+
+jobs:
+  verify:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/certora') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: [self-hosted, certora]
+    timeout-minutes: 360
+    steps:
+      - name: Parse command
+        id: cmd
+        env:
+          # Passed via env (not inline interpolation) to avoid shell injection
+          # from comment bodies.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          INPUT_CONFS: ${{ inputs.confs }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            args="$INPUT_CONFS"
+          else
+            args="$(printf '%s\n' "$COMMENT_BODY" | head -1 | sed 's|^/certora||')"
+          fi
+          args=$(echo $args)  # trim/collapse whitespace
+          [ -n "$args" ] || args="all"
+          if ! printf '%s' "$args" | grep -Eq '^[A-Za-z0-9_. -]+$'; then
+            echo "invalid characters in conf list: $args" >&2; exit 1
+          fi
+          echo "confs=$args" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        env:
+          CONFS: ${{ steps.cmd.outputs.confs }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.reactions.createForIssueComment({
+              owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
+            });
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: context.issue.number,
+              body: `🔬 Certora verification started for \`${process.env.CONFS}\` — [watch the run](${runUrl}). ` +
+                    `Heavy specs can take 1h+ per conf.`,
+            });
+
+      - name: Checkout PR merge result
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || github.ref }}
+          submodules: recursive
+          fetch-depth: 1
+          clean: true
+
+      - name: Expand and validate conf list
+        id: expand
+        env:
+          CONFS: ${{ steps.cmd.outputs.confs }}
+        run: |
+          cd certora/confs
+          available=$(ls *.conf | sed 's/\.conf$//')
+          if [ "$CONFS" = "all" ]; then
+            list="$available"
+          else
+            list=""
+            for n in $CONFS; do
+              if [ -f "$n.conf" ]; then
+                list="$list $n"
+              else
+                echo "unknown=$n" >> "$GITHUB_OUTPUT"
+                echo "available<<EOF" >> "$GITHUB_OUTPUT"
+                echo "$available" >> "$GITHUB_OUTPUT"
+                echo "EOF" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            done
+          fi
+          echo "list=$(echo $list)" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Reply usage on unknown conf
+        if: steps.expand.outputs.unknown != ''
+        uses: actions/github-script@v7
+        env:
+          UNKNOWN: ${{ steps.expand.outputs.unknown }}
+          AVAILABLE: ${{ steps.expand.outputs.available }}
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { owner, repo } = context.repo;
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: context.issue.number,
+                body: `❓ Unknown conf \`${process.env.UNKNOWN}\`. Usage: \`/certora <ConfName ...>\` or \`/certora all\`.\n` +
+                      `Available confs:\n\`\`\`\n${process.env.AVAILABLE}\n\`\`\``,
+              });
+            }
+            core.setFailed(`unknown conf: ${process.env.UNKNOWN}`);
+
+      - name: Pull prover image
+        run: docker pull "$IMAGE"
+
+      - name: Run verification
+        id: run
+        env:
+          LIST: ${{ steps.expand.outputs.list }}
+        run: |
+          set -o pipefail
+          rm -rf certora-ci emv-* .certora_internal
+          mkdir -p certora-ci/logs
+          # Localize each cloud conf for the local prover: drop the cloud
+          # `server` key, map solc binary names (solc-X.Y.Z -> solcX.Y.Z, the
+          # naming used inside the image), and give the JVM a real heap.
+          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -e JAVA_HEAP \
+            -v "$PWD":/ws -w /ws "$IMAGE" python3 - $LIST <<'EOF'
+          import json, os, sys
+          for name in sys.argv[1:]:
+              c = json.load(open(f"certora/confs/{name}.conf"))
+              c.pop("server", None)
+              if "solc" in c:
+                  c["solc"] = c["solc"].replace("solc-", "solc")
+              c["java_args"] = os.environ.get("JAVA_HEAP", "-Xmx4g")
+              json.dump(c, open(f"certora-ci/{name}.conf", "w"), indent=2)
+          EOF
+          overall=0
+          for name in $LIST; do
+            echo "::group::certoraRun $name"
+            if docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
+                 -m "$CONTAINER_MEM" -v "$PWD":/ws -w /ws "$IMAGE" \
+                 certoraRun.py "certora-ci/$name.conf" 2>&1 | tee "certora-ci/logs/$name.log"; then
+              echo "$name PASS" >> certora-ci/status.txt
+            else
+              echo "$name FAIL" >> certora-ci/status.txt
+              overall=1
+            fi
+            echo "::endgroup::"
+          done
+          echo "overall=$overall" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Summarize results
+        id: summary
+        if: always() && steps.run.conclusion != 'skipped'
+        run: |
+          {
+            echo "## Certora verification"
+            echo ""
+            echo "| conf | status | verified | violated |"
+            echo "|------|--------|----------|----------|"
+          } > certora-ci/summary.md
+          details=""
+          while read -r name status; do
+            log="certora-ci/logs/$name.log"
+            verified=$(grep -E "^Verified:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u | wc -l | tr -d ' ')
+            violated=$(grep -E "^Violated:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u | wc -l | tr -d ' ')
+            icon=$([ "$status" = "PASS" ] && echo "✅" || echo "❌")
+            echo "| $name | $icon $status | $verified | $violated |" >> certora-ci/summary.md
+            if [ "$violated" != "0" ]; then
+              details="$details\n### ❌ $name — violated rules\n\`\`\`\n$(grep -E '^Violated:' "$log" | grep -vE 'not_vacuous|not_trivial' | sort -u)\n\`\`\`"
+            fi
+          done < certora-ci/status.txt
+          [ -n "$details" ] && printf "%b\n" "$details" >> certora-ci/summary.md
+          echo "" >> certora-ci/summary.md
+          echo "_Full HTML reports (FinalResults.html with per-rule counterexamples) are attached as the run artifact._" >> certora-ci/summary.md
+          cat certora-ci/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post results to PR
+        if: always() && github.event_name == 'issue_comment' && steps.summary.conclusion == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = fs.readFileSync('certora-ci/summary.md', 'utf8') +
+              `\n[Run & artifacts](${runUrl})`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: context.issue.number, body,
+            });
+
+      - name: Upload HTML reports
+        if: always() && steps.run.conclusion != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: certora-reports-${{ github.run_id }}
+          path: |
+            emv-*/Reports/
+            certora-ci/logs/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Fail job on violations
+        if: steps.run.outputs.overall == '1'
+        run: |
+          echo "one or more confs reported violations (see summary)" >&2
+          exit 1

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -4,15 +4,18 @@
 #   /certora ConsistentState Health     run several
 #   /certora all                        run every conf in certora/confs/
 #
-# Runs on the self-hosted x86 runner using the locally-built open-source
-# Certora Prover image (ghcr.io/lista-dao/certora-local). Results are posted
-# back to the PR as a comment; full HTML reports are uploaded as an artifact.
+# Runs on GitHub-hosted runners (free for public repos, 4 vCPU / 16 GB) using
+# the locally-built open-source Certora Prover image
+# (ghcr.io/lista-dao/certora-local) — no CERTORAKEY, no Certora cloud.
+# Confs fan out as a matrix, one runner each, so wall-clock time is the
+# slowest conf rather than the sum. Results are posted back to the PR as a
+# comment; full HTML reports are uploaded as artifacts.
 #
 # Security notes:
 # - issue_comment workflows always execute the definition from the default
 #   branch, so a PR cannot tamper with this pipeline.
-# - Only OWNER/MEMBER/COLLABORATOR comments trigger a run (public repo +
-#   self-hosted runner), and the PR code only runs inside the container.
+# - Only OWNER/MEMBER/COLLABORATOR comments trigger a run; the PR code only
+#   runs inside the prover container.
 name: certora
 
 on:
@@ -36,19 +39,20 @@ concurrency:
 
 env:
   IMAGE: ghcr.io/lista-dao/certora-local:latest
-  # SMT solving is memory hungry; keep in sync with the runner host's RAM.
-  CONTAINER_MEM: 6g
-  JAVA_HEAP: -Xmx4g
+  # Hosted runners have 16 GB; leave headroom for the runner agent itself.
+  CONTAINER_MEM: 12g
+  JAVA_HEAP: -Xmx6g
 
 jobs:
-  verify:
+  prepare:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request &&
        startsWith(github.event.comment.body, '/certora') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
-    runs-on: [self-hosted, certora]
-    timeout-minutes: 360
+    runs-on: ubuntu-latest
+    outputs:
+      confs: ${{ steps.expand.outputs.json }}
     steps:
       - name: Parse command
         id: cmd
@@ -70,31 +74,12 @@ jobs:
           fi
           echo "confs=$args" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Acknowledge comment
-        if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        env:
-          CONFS: ${{ steps.cmd.outputs.confs }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            await github.rest.reactions.createForIssueComment({
-              owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
-            });
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: context.issue.number,
-              body: `🔬 Certora verification started for \`${process.env.CONFS}\` — [watch the run](${runUrl}). ` +
-                    `Heavy specs can take 1h+ per conf.`,
-            });
-
-      - name: Checkout PR merge result
+      # Cheap checkout (no submodules) just to list/validate conf names.
+      - name: Checkout (confs only)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || github.ref }}
-          submodules: recursive
           fetch-depth: 1
-          clean: true
 
       - name: Expand and validate conf list
         id: expand
@@ -112,14 +97,16 @@ jobs:
                 list="$list $n"
               else
                 echo "unknown=$n" >> "$GITHUB_OUTPUT"
-                echo "available<<EOF" >> "$GITHUB_OUTPUT"
-                echo "$available" >> "$GITHUB_OUTPUT"
-                echo "EOF" >> "$GITHUB_OUTPUT"
+                {
+                  echo "available<<EOF"
+                  echo "$available"
+                  echo "EOF"
+                } >> "$GITHUB_OUTPUT"
                 exit 0
               fi
             done
           fi
-          echo "list=$(echo $list)" | tee -a "$GITHUB_OUTPUT"
+          echo "json=$(echo $list | tr ' ' '\n' | jq -R . | jq -cs .)" | tee -a "$GITHUB_OUTPUT"
 
       - name: Reply usage on unknown conf
         if: steps.expand.outputs.unknown != ''
@@ -139,99 +126,145 @@ jobs:
             }
             core.setFailed(`unknown conf: ${process.env.UNKNOWN}`);
 
-      - name: Pull prover image
-        run: docker pull "$IMAGE"
-
-      - name: Run verification
-        id: run
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
         env:
-          LIST: ${{ steps.expand.outputs.list }}
+          CONFS: ${{ steps.cmd.outputs.confs }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.reactions.createForIssueComment({
+              owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
+            });
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: context.issue.number,
+              body: `🔬 Certora verification started for \`${process.env.CONFS}\` — [watch the run](${runUrl}). ` +
+                    `Confs run in parallel; heavy specs can take 1-3h.`,
+            });
+
+  verify:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        conf: ${{ fromJSON(needs.prepare.outputs.confs) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    steps:
+      - name: Checkout PR merge result
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || github.ref }}
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Pull prover image
+        run: |
+          docker login ghcr.io -u "${{ github.actor }}" -p "${{ github.token }}"
+          docker pull "$IMAGE"
+
+      - name: Run certoraRun (${{ matrix.conf }})
+        env:
+          NAME: ${{ matrix.conf }}
         run: |
           set -o pipefail
-          rm -rf certora-ci emv-* .certora_internal
           mkdir -p certora-ci/logs
-          # Localize each cloud conf for the local prover: drop the cloud
+          # Localize the cloud conf for the local prover: drop the cloud
           # `server` key, map solc binary names (solc-X.Y.Z -> solcX.Y.Z, the
           # naming used inside the image), and give the JVM a real heap.
-          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -e JAVA_HEAP \
-            -v "$PWD":/ws -w /ws "$IMAGE" python3 - $LIST <<'EOF'
-          import json, os, sys
-          for name in sys.argv[1:]:
-              c = json.load(open(f"certora/confs/{name}.conf"))
-              c.pop("server", None)
-              if "solc" in c:
-                  c["solc"] = c["solc"].replace("solc-", "solc")
-              c["java_args"] = os.environ.get("JAVA_HEAP", "-Xmx4g")
-              json.dump(c, open(f"certora-ci/{name}.conf", "w"), indent=2)
+          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -e JAVA_HEAP -e NAME \
+            -v "$PWD":/ws -w /ws "$IMAGE" python3 - <<'EOF'
+          import json, os
+          name = os.environ["NAME"]
+          c = json.load(open(f"certora/confs/{name}.conf"))
+          c.pop("server", None)
+          if "solc" in c:
+              c["solc"] = c["solc"].replace("solc-", "solc")
+          c["java_args"] = os.environ.get("JAVA_HEAP", "-Xmx6g")
+          json.dump(c, open(f"certora-ci/{name}.conf", "w"), indent=2)
           EOF
-          overall=0
-          for name in $LIST; do
-            echo "::group::certoraRun $name"
-            if docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
-                 -m "$CONTAINER_MEM" -v "$PWD":/ws -w /ws "$IMAGE" \
-                 certoraRun.py "certora-ci/$name.conf" 2>&1 | tee "certora-ci/logs/$name.log"; then
-              echo "$name PASS" >> certora-ci/status.txt
-            else
-              echo "$name FAIL" >> certora-ci/status.txt
-              overall=1
-            fi
-            echo "::endgroup::"
-          done
-          echo "overall=$overall" | tee -a "$GITHUB_OUTPUT"
+          status=PASS
+          docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
+            -m "$CONTAINER_MEM" -v "$PWD":/ws -w /ws "$IMAGE" \
+            certoraRun.py "certora-ci/$NAME.conf" 2>&1 | tee "certora-ci/logs/$NAME.log" || status=FAIL
+          log="certora-ci/logs/$NAME.log"
+          verified=$(grep -E "^Verified:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u | wc -l | tr -d ' ')
+          violated=$(grep -E "^Violated:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u | wc -l | tr -d ' ')
+          {
+            echo "$NAME $status $verified $violated"
+            grep -E "^Violated:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u || true
+          } > "certora-ci/result-$NAME.txt"
+          [ "$status" = "PASS" ] || { echo "conf $NAME reported violations or errors" >&2; exit 1; }
 
-      - name: Summarize results
-        id: summary
-        if: always() && steps.run.conclusion != 'skipped'
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: certora-${{ matrix.conf }}-${{ github.run_id }}
+          path: |
+            emv-*/Reports/
+            certora-ci/logs/
+            certora-ci/result-*.txt
+          retention-days: 14
+          if-no-files-found: warn
+
+  report:
+    needs: [prepare, verify]
+    if: always() && needs.prepare.result == 'success' && needs.verify.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: certora-*-${{ github.run_id }}
+          merge-multiple: true
+
+      - name: Aggregate summary
+        id: agg
         run: |
           {
             echo "## Certora verification"
             echo ""
             echo "| conf | status | verified | violated |"
             echo "|------|--------|----------|----------|"
-          } > certora-ci/summary.md
+          } > summary.md
+          overall=0
           details=""
-          while read -r name status; do
-            log="certora-ci/logs/$name.log"
-            verified=$(grep -E "^Verified:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u | wc -l | tr -d ' ')
-            violated=$(grep -E "^Violated:" "$log" | grep -vE "not_vacuous|not_trivial" | sort -u | wc -l | tr -d ' ')
+          for f in certora-ci/result-*.txt; do
+            [ -f "$f" ] || continue
+            read -r name status verified violated < "$f"
             icon=$([ "$status" = "PASS" ] && echo "✅" || echo "❌")
-            echo "| $name | $icon $status | $verified | $violated |" >> certora-ci/summary.md
-            if [ "$violated" != "0" ]; then
-              details="$details\n### ❌ $name — violated rules\n\`\`\`\n$(grep -E '^Violated:' "$log" | grep -vE 'not_vacuous|not_trivial' | sort -u)\n\`\`\`"
+            echo "| $name | $icon $status | $verified | $violated |" >> summary.md
+            if [ "$status" != "PASS" ]; then
+              overall=1
+              body=$(tail -n +2 "$f")
+              [ -n "$body" ] && details="$details\n### ❌ $name — violated rules\n\`\`\`\n$body\n\`\`\`"
             fi
-          done < certora-ci/status.txt
-          [ -n "$details" ] && printf "%b\n" "$details" >> certora-ci/summary.md
-          echo "" >> certora-ci/summary.md
-          echo "_Full HTML reports (FinalResults.html with per-rule counterexamples) are attached as the run artifact._" >> certora-ci/summary.md
-          cat certora-ci/summary.md >> "$GITHUB_STEP_SUMMARY"
+          done
+          [ -n "$details" ] && printf "%b\n" "$details" >> summary.md
+          echo "" >> summary.md
+          echo "_Full HTML reports (FinalResults.html with per-rule counterexamples) are attached as run artifacts, one per conf._" >> summary.md
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "overall=$overall" | tee -a "$GITHUB_OUTPUT"
 
       - name: Post results to PR
-        if: always() && github.event_name == 'issue_comment' && steps.summary.conclusion == 'success'
+        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const body = fs.readFileSync('certora-ci/summary.md', 'utf8') +
+            const body = fs.readFileSync('summary.md', 'utf8') +
               `\n[Run & artifacts](${runUrl})`;
             await github.rest.issues.createComment({
               owner, repo, issue_number: context.issue.number, body,
             });
 
-      - name: Upload HTML reports
-        if: always() && steps.run.conclusion != 'skipped'
-        uses: actions/upload-artifact@v4
-        with:
-          name: certora-reports-${{ github.run_id }}
-          path: |
-            emv-*/Reports/
-            certora-ci/logs/
-          retention-days: 14
-          if-no-files-found: warn
-
-      - name: Fail job on violations
-        if: steps.run.outputs.overall == '1'
+      - name: Fail on violations
+        if: steps.agg.outputs.overall == '1'
         run: |
           echo "one or more confs reported violations (see summary)" >&2
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ node_modules
 # Compiler files
 cache/
 out/
+out-certora/
+
+# Certora prover artifacts
+.certora_internal/
+emv-*-certora-*/
 
 # Ignores development broadcast logs
 !/broadcast

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out-certora/
 # Certora prover artifacts
 .certora_internal/
 emv-*-certora-*/
+certora-ci/
 
 # Ignores development broadcast logs
 !/broadcast

--- a/certora/README.md
+++ b/certora/README.md
@@ -1,0 +1,390 @@
+> **Moolah note.** This suite was migrated from Morpho Blue to verify the Moolah protocol
+> (`src/moolah/`), which is a fork of Morpho Blue. Harnesses now extend `Moolah`
+> (`MoolahHarness`) and callbacks are `onMoolah*`. The rule documentation below is inherited
+> from Morpho Blue and still describes the shared core logic; see the
+> [**Migration status**](#migration-status) section at the end for what has and hasn't been
+> adapted to Moolah yet.
+
+This folder contains the verification of the Morpho Blue protocol using CVL, Certora's Verification Language.
+
+The core concepts of the Morpho Blue protocol are described in the Morpho Blue whitepaper.
+These concepts have been verified using CVL.
+We first give a [high-level description](#high-level-description) of the verification and then describe the [folder and file structure](#folder-and-file-structure) of the specification files.
+
+# High-level description
+
+The Morpho Blue protocol allows users to take out collateralized loans on ERC20 tokens.
+
+## ERC20 tokens and transfers
+
+For a given market, Morpho Blue relies on the fact that the tokens involved respect the ERC20 standard.
+In particular, in case of a transfer, it is assumed that the balance of Morpho Blue increases or decreases (depending if it's the recipient or the sender) of the amount transferred.
+
+The file [Transfer.spec](specs/Transfer.spec) defines a summary of the transfer functions.
+This summary is taken as the reference implementation to check that the balance of the Morpho Blue contract changes as expected.
+
+```solidity
+function summarySafeTransferFrom(address token, address from, address to, uint256 amount) {
+    if (from == currentContract) {
+        balance[token] = require_uint256(balance[token] - amount);
+    }
+    if (to == currentContract) {
+        balance[token] = require_uint256(balance[token] + amount);
+    }
+}
+```
+
+where `balance` is the ERC20 balance of the Morpho Blue contract.
+
+The verification is done for the most common implementations of the ERC20 standard, for which we distinguish three different implementations:
+
+- [ERC20Standard](dispatch/ERC20Standard.sol) which respects the standard and reverts in case of insufficient funds or in case of insufficient allowance.
+- [ERC20NoRevert](dispatch/ERC20NoRevert.sol) which respects the standard but does not revert (and returns false instead).
+- [ERC20USDT](dispatch/ERC20USDT.sol) which does not strictly respect the standard because it omits the return value of the `transfer` and `transferFrom` functions.
+
+Additionally, Morpho Blue always goes through a custom transfer library to handle ERC20 tokens, notably in all the above cases.
+This library reverts when the transfer is not successful, and this is checked for the case of insufficient funds or insufficient allowance.
+The use of the library can make it difficult for the provers, so the summary is sometimes used in other specification files to ease the verification of rules that rely on the transfer of tokens.
+
+## Markets
+
+The Morpho Blue contract is a singleton contract that defines different markets.
+Markets on Morpho Blue depend on a pair of assets, the loan token that is supplied and borrowed, and the collateral token.
+Taking out a loan requires to deposit some collateral, which stays idle in the contract.
+Additionally, every loan token that is not borrowed also stays idle in the contract.
+This is verified by the following property:
+
+```solidity
+invariant idleAmountLessThanBalance(address token)
+    idleAmount[token] <= balance[token]
+```
+
+where `idleAmount` is the sum over all the markets of: the collateral amounts plus the supplied amounts minus the borrowed amounts.
+In effect, this means that funds can only leave the contract through borrows and withdrawals.
+
+Additionally, it is checked that on a given market the borrowed amounts cannot exceed the supplied amounts.
+
+```solidity
+invariant borrowLessThanSupply(MorphoHarness.Id id)
+    totalBorrowAssets(id) <= totalSupplyAssets(id);
+```
+
+This property, along with the previous one ensures that other markets can only impact the balance positively.
+Said otherwise, markets are independent: tokens from a given market cannot be impacted by operations done in another market.
+
+## Shares
+
+When supplying on Morpho Blue, interest is earned over time, and the distribution is implemented through a shares mechanism.
+Shares increase in value as interest is accrued.
+The share mechanism is implemented symmetrically for the borrow side: a share of borrow increasing in value over time represents additional owed interest.
+The rule `accrueInterestIncreasesSupplyExchangeRate` checks this property for the supply side with the following statement.
+
+```solidity
+    // Check that the exchange rate increases: assetsBefore/sharesBefore <= assetsAfter/sharesAfter
+    assert assetsBefore * sharesAfter <= assetsAfter * sharesBefore;
+```
+
+where `assetsBefore` and `sharesBefore` represents respectively the supplied assets and the supplied shares before accruing the interest. Similarly, `assetsAfter` and `sharesAfter` represent the supplied assets and shares after an interest accrual.
+
+The accounting of the shares mechanism relies on another variable to store the total number of shares, in order to compute what is the relative part of each user.
+This variable needs to be kept up to date at each corresponding interaction, and it is checked that this accounting is done properly.
+For example, for the supply side, this is done by the following invariant.
+
+```solidity
+invariant sumSupplySharesCorrect(MorphoHarness.Id id)
+    to_mathint(totalSupplyShares(id)) == sumSupplyShares[id];
+```
+
+where `sumSupplyShares` only exists in the specification, and is defined to be automatically updated whenever any of the shares of the users are modified.
+
+## Positions health and liquidations
+
+To ensure proper collateralization, a liquidation system is put in place, where unhealthy positions can be liquidated.
+A position is said to be healthy if the ratio of the borrowed value over collateral value is smaller than the liquidation loan-to-value (LLTV) of that market.
+This leaves a safety buffer before the position can be insolvent, where the aforementioned ratio is above 1.
+To ensure that liquidators have the time to interact with unhealthy positions, it is formally verified that this buffer is respected and that it leaves room for healthy liquidations to happen.
+Notably, it is verified that in the absence of accrued interest, which is the case when creating a new position or when interacting multiple times in the same block, a position cannot be made unhealthy.
+
+Let's define bad debt of a position as the amount borrowed when it is backed by no collateral.
+Morpho Blue automatically realizes the bad debt when liquidating a position, by transferring it to the lenders.
+In effect, this means that there is no bad debt on Morpho Blue, which is verified by the following invariant.
+
+```solidity
+invariant alwaysCollateralized(MorphoHarness.Id id, address borrower)
+    borrowShares(id, borrower) != 0 => collateral(id, borrower) != 0;
+```
+
+More generally, this means that the result of liquidating a position multiple times eventually leads to a healthy position (possibly empty).
+
+## Authorization
+
+Morpho Blue also defines primitive authorization system, where users can authorize an account to fully manage their position.
+This allows to rebuild more granular control of the position on top by authorizing an immutable contract with limited capabilities.
+The authorization is verified to be sound in the sense that no user can modify the position of another user without proper authorization (except when liquidating).
+
+Let's detail the rule that makes sure that the supply side stays consistent.
+
+```solidity
+rule userCannotLoseSupplyShares(env e, method f, calldataarg data)
+filtered { f -> !f.isView }
+{
+    MorphoHarness.Id id;
+    address user;
+
+    // Assume that the e.msg.sender is not authorized.
+    require !isAuthorized(user, e.msg.sender);
+    require user != e.msg.sender;
+
+    mathint sharesBefore = supplyShares(id, user);
+
+    f(e, data);
+
+    mathint sharesAfter = supplyShares(id, user);
+
+    assert sharesAfter >= sharesBefore;
+}
+```
+
+In the previous rule, an arbitrary function of Morpho Blue `f` is called with arbitrary `data`.
+Shares of `user` on the market identified by `id` are recorded before and after this call.
+In this way, it is checked that the supply shares are increasing when the caller of the function is neither the owner of those shares (`user != e.msg.sender`) nor authorized (`!isAuthorized(user, e.msg.sender)`).
+
+## Other safety properties
+
+### Enabled LLTV and IRM
+
+Creating a market is permissionless on Morpho Blue, but some parameters should fall into the range of admitted values.
+Notably, the LLTV value should be enabled beforehand.
+The following rule checks that no market can ever exist with a LLTV that had not been previously approved.
+
+```solidity
+invariant onlyEnabledLltv(MorphoHarness.MarketParams marketParams)
+    isCreated(libId(marketParams)) => isLltvEnabled(marketParams.lltv);
+```
+
+Similarly, the interest rate model (IRM) used for the market must have been previously whitelisted.
+
+### Range of the fee
+
+The governance can choose to set a fee to a given market.
+Fees are guaranteed to never exceed 25% of the interest accrued, and this is verified by the following rule.
+
+```solidity
+invariant feeInRange(MorphoHarness.Id id)
+    fee(id) <= maxFee();
+```
+
+### Sanity checks and input validation
+
+The formal verification is also taking care of other sanity checks, some of which are needed properties to verify other rules.
+For example, the following rule checks that the variable storing the last update time is no more than the current time.
+This is a sanity check, but it is also useful to ensure that there will be no underflow when computing the time elapsed since the last update.
+
+```solidity
+rule noTimeTravel(method f, env e, calldataarg args)
+filtered { f -> !f.isView }
+{
+    MorphoHarness.Id id;
+    // Assume the property before the interaction.
+    require lastUpdate(id) <= e.block.timestamp;
+    f(e, args);
+    assert lastUpdate(id) <= e.block.timestamp;
+}
+```
+
+Additional rules are verified to ensure that the sanitization of inputs is done correctly.
+
+```solidity
+rule supplyInputValidation(env e, MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    supply@withrevert(e, marketParams, assets, shares, onBehalf, data);
+    assert !exactlyOneZero(assets, shares) || onBehalf == 0 => lastReverted;
+}
+```
+
+The previous rule checks that the `supply` function reverts whenever the `onBehalf` parameter is the address zero, or when either both `assets` and `shares` are zero or both are non-zero.
+
+## Liveness properties
+
+On top of verifying that the protocol is secured, the verification also proves that it is usable.
+Such properties are called liveness properties, and it is notably checked that the accounting is done when an interaction goes through.
+As an example, the `withdrawChangesTokensAndShares` rule checks that calling the `withdraw` function successfully will decrease the shares of the concerned account and increase the balance of the receiver.
+
+Other liveness properties are verified as well.
+Notably, it's also verified that it is always possible to exit a position without concern for the oracle.
+This is done through the verification of two rules: the `canRepayAll` rule and the `canWithdrawCollateralAll` rule.
+The `canRepayAll` rule ensures that it is always possible to repay the full debt of a position, leaving the account without any outstanding debt.
+The `canWithdrawCollateralAll` rule ensures that in the case where the account has no outstanding debt, then it is possible to withdraw the full collateral.
+
+## Protection against common attack vectors
+
+Other common and known attack vectors are verified to not be possible on the Morpho Blue protocol.
+
+### Reentrancy
+
+Reentrancy is a common attack vector that happens when a call to a contract allows, when in a temporary state, to call the same contract again.
+The state of the contract usually refers to the storage variables, which can typically hold values that are meant to be used only after the full execution of the current function.
+The Morpho Blue contract is verified to not be vulnerable to this kind of reentrancy attack thanks to the rule `reentrancySafe`.
+
+### Extraction of value
+
+The Morpho Blue protocol uses a conservative approach to handle arithmetic operations.
+Rounding is done such that potential (small) errors are in favor of the protocol, which ensures that it is not possible to extract value from other users.
+
+The rule `supplyWithdraw` handles the simple scenario of a supply followed by a withdraw, and has the following check.
+
+```solidity
+assert withdrawnAssets <= suppliedAssets;
+```
+
+The rule `withdrawAssetsAccounting` is more general and defines `ownedAssets` as the assets that the user owns, rounding in favor of the protocol.
+This rule has the following check to ensure that no more than the owned assets can be withdrawn.
+
+```solidity
+assert withdrawnAssets <= ownedAssets;
+```
+
+# Folder and file structure
+
+The [`certora/specs`](specs) folder contains the following files:
+
+- [`AccrueInterest.spec`](specs/AccrueInterest.spec) checks that the main functions accrue interest at the start of the interaction.
+  This is done by ensuring that accruing interest before calling the function does not change the outcome compared to just calling the function.
+  View functions do not necessarily respect this property (for example, `totalSupplyShares`), and are filtered out.
+- [`AssetsAccounting.spec`](specs/AssetsAccounting.spec) checks that when exiting a position the user cannot get more than what was owed.
+  Similarly, when entering a position, the assets owned as a result are no greater than what was given.
+- [`ConsistentState.spec`](specs/ConsistentState.spec) checks that the state (storage) of the Morpho contract is consistent.
+  This includes checking that the accounting of the total amount and shares is correct, that markets are independent from each other, that only enabled IRMs and LLTVs can be used, and that users cannot have their position made worse by an unauthorized account.
+- [`ExactMath.spec`](specs/ExactMath.spec) checks precise properties when taking into account exact multiplication and division.
+  Notably, this file specifies that using supply and withdraw in the same block cannot yield more funds than at the start.
+- [`ExchangeRate.spec`](specs/ExchangeRate.spec) checks that the exchange rate between shares and assets evolves predictably over time.
+- [`Health.spec`](specs/Health.spec) checks properties about the health of the positions.
+  Notably, debt positions always have some collateral thanks to the bad debt realization mechanism.
+- [`LibSummary.spec`](specs/LibSummary.spec) checks the summarization of the library functions that are used in other specification files.
+- [`LiquidateBuffer.spec`](specs/LiquidateBuffer.spec) checks that there is a buffer for liquidatable positions, before they are insolvent, such that liquidation leads to healthier position and cannot lead to bad debt.
+- [`Liveness.spec`](specs/Liveness.spec) checks that main functions change the owner of funds and the amount of shares as expected, and that it's always possible to exit a position.
+- [`Reentrancy.spec`](specs/Reentrancy.spec) checks that the contract is immune to a particular class of reentrancy issues.
+- [`Reverts.spec`](specs/Reverts.spec) checks the condition for reverts and that inputs are correctly validated.
+- [`StayHealthy.spec`](specs/Health.spec) checks that functions cannot render an account unhealthy.
+- [`Transfer.spec`](specs/Transfer.spec) checks the summarization of the safe transfer library functions that are used in other specification files.
+
+The [`certora/confs`](confs) folder contains a configuration file for each corresponding specification file.
+
+The [`certora/helpers`](helpers) folder contains contracts that enable the verification of Morpho Blue.
+Notably, this allows handling the fact that library functions should be called from a contract to be verified independently, and it allows defining needed getters.
+
+The [`certora/dispatch`](dispatch) folder contains different contracts similar to the ones that are expected to be called from Morpho Blue.
+
+# Getting started
+
+## Compiling the harnesses
+
+```bash
+FOUNDRY_PROFILE=certora forge build
+```
+
+This compiles the harnesses in `certora/` against the Moolah source in `src/`, using the
+repository's `remappings.txt`. solc 0.8.34 with `via_ir` is required (auto-managed by foundry).
+
+## Running the prover
+
+Install `certora-cli` package with `pip install certora-cli`.
+To verify specification files, pass to `certoraRun` the corresponding configuration file in the [`certora/confs`](confs) folder.
+It requires having set the `CERTORAKEY` environment variable to a valid Certora key.
+You can also pass additional arguments, notably to verify a specific rule.
+For example, at the root of the repository:
+
+```
+certoraRun certora/confs/ConsistentState.conf --rule borrowLessThanSupply
+```
+
+`certoraRun` picks up `remappings.txt`/`foundry.toml` from the project root to resolve the
+Moolah import tree. The confs pin `solc-0.8.34` and `solc_via_ir: true` to match Moolah's
+own build settings; make sure a `solc-0.8.34` binary is on PATH:
+
+```bash
+solc-select install 0.8.34
+ln -sf ~/.solc-select/artifacts/solc-0.8.34/solc-0.8.34 ~/.local/bin/solc-0.8.34
+```
+
+To compile + typecheck a spec locally without running the cloud prover (no `CERTORAKEY`
+needed), add `--compilation_steps_only`:
+
+```bash
+certoraRun certora/confs/ConsistentState.conf --compilation_steps_only
+```
+
+# Migration status
+
+This is a **scaffolding migration**. The Solidity harnesses compile against Moolah, and **all
+14 confs pass CVL compilation + typecheck locally** (`--compilation_steps_only`). Typecheck is
+necessary but **not sufficient** — the rules have not been run through the prover, so none are
+*verified* against Moolah yet (that needs `CERTORAKEY` and likely per-rule tuning).
+
+CVL rules were re-pointed from Morpho Blue (`MorphoHarness` → `MoolahHarness`, `onMorpho*` →
+`onMoolah*`). Getting them to typecheck also required dropping Morpho-only API:
+
+- **`extSloads` removed.** Moolah has no `extSloads(bytes32[])`; the `NONDET DELETE` summary
+  was removed from every spec that declared it.
+- **`Reverts.spec` owner → role.** Moolah has no `owner()`/`setOwner` (it uses AccessControl).
+  The `setOwner` rule was dropped and the `MANAGER`-gated setters (`enableIrm`, `enableLltv`,
+  `setFee`, `setFeeRecipient`) re-expressed against `hasRole(MANAGER, sender)`, with their exact
+  `<=>` revert conditions relaxed to one-directional `=>` (sound under Moolah's extra requires;
+  the reverse direction needs prover confirmation).
+
+## Proxy / upgradeability handling (done)
+
+Because Moolah is a UUPS-upgradeable proxy contract, the upgrade/initialize machinery is
+handled as follows (this is the standard Certora practice for upgradeable contracts):
+
+- **Filtered out of generic invariants.** [`ProxyFilters.spec`](specs/ProxyFilters.spec) defines
+  `isUpgradeOrInit(f)`, and every parametric (`method f`) rule excludes it via
+  `filtered { f -> ... && !isUpgradeOrInit(f) }`. This stops the prover from havocing the whole
+  state through `upgradeToAndCall`/`initialize` and reporting spurious counterexamples. The
+  filter also covers the harness-only helpers below.
+- **Verified by dedicated rules.** [`AccessControl.spec`](specs/AccessControl.spec) checks the
+  authorization gates directly: `onlyAdminCanAuthorizeUpgrade`, `onlyPauserCanPause`,
+  `onlyManagerCanUnpause`, `onlyManagerCanSetMinLoanValue`. The upgrade rule targets
+  `_authorizeUpgrade` (via a harness wrapper) rather than `upgradeToAndCall`, whose `onlyProxy`
+  guard reverts unconditionally on the directly-verified implementation and would otherwise make
+  the rule vacuous.
+- **Initialized starting state.** Moolah's constructor calls `_disableInitializers()`, so the
+  real `initialize` can never run on the directly-verified implementation (the prover would start
+  from an all-zero, role-less state). `MoolahHarness.setUpInitializedState(...)` reproduces the
+  post-`initialize` state (roles + `minLoanValue`) so rules can assume a sane, initialized
+  contract. (Alternative, heavier approach: a *munged* copy of `Moolah.sol` with
+  `_disableInitializers()` removed so the real `initialize` is exercised — not used here.)
+
+## Broker & provider exclusion (done)
+
+Moolah lets a market be managed by a **LendingBroker** or fronted by a **Provider**. Both divert
+the normal market flow and reach into external contracts, so both are **scoped out of
+verification for now** (in [`ProxyFilters.spec`](specs/ProxyFilters.spec)), using the same
+two-part pattern:
+
+- **Broker.** Once `brokers[id]` is set, the broker replaces the supply/borrow/repay flow and
+  the health check pulls the position's debt from the broker via an external call
+  (`PriceLib._getBrokerTotalDebt`). `isBrokerFunction(f)` filters the broker-only entry points
+  (`setMarketBroker`, `liquidateBrokerPosition`) out of parametric rules, and a `Sload` hook on
+  `brokers[id]` assumes it is `0`, so `borrow`/`repay`/`_isHealthy`/`_getPrice` take the
+  non-broker path and make no broker calls.
+- **Provider.** Once `providers[id][token]` is set, a provider may act in place of the user in
+  `borrow`/`withdraw`/`supplyCollateral` (authorization branches) and `liquidate` calls
+  `IProvider(provider).liquidate(...)` (an external call). `isProviderFunction(f)` filters
+  `setProvider` (which itself calls `IProvider(provider).TOKEN()`) out of parametric rules, and a
+  `Sload` hook on `providers[id][token]` assumes it is `0`, so the provider branches take the
+  standard authorization path and `liquidate` makes no provider call.
+
+Both are **assumptions that scope verification to plain (non-broker, non-provider) markets** —
+they do not prove anything about broker- or provider-managed markets.
+
+## Still to do
+
+- **Broker/provider markets themselves.** Verifying the broker- and provider-managed flows
+  (rather than excluding them) is future work and needs dedicated specs.
+- **Access control depth.** Beyond the gates above, rules inherited from Morpho Blue that assume
+  a single `owner` model should be revisited against Moolah's role model (`DEFAULT_ADMIN_ROLE`,
+  `MANAGER`, `PAUSER`).
+- **Oracle / `PriceLib` price model** and the **liquidation whitelist** are new relative to
+  Morpho Blue and are not covered by the migrated specs.
+- **Per-rule review.** Each spec should be re-checked against Moolah's actual function set and
+  semantics; method blocks may reference functions whose signatures or behavior diverged.

--- a/certora/README.md
+++ b/certora/README.md
@@ -391,8 +391,9 @@ they do not prove anything about broker- or provider-managed markets.
 
 # Running the prover from a PR (CI)
 
-Verification runs on a self-hosted runner using the open-source Certora Prover
-image (`ghcr.io/lista-dao/certora-local`) — fully local, no CERTORAKEY, no cloud.
+Verification runs on GitHub-hosted runners (free for public repos, 4 vCPU /
+16 GB each) using the open-source Certora Prover image
+(`ghcr.io/lista-dao/certora-local`) — no CERTORAKEY, no Certora cloud.
 The workflow is `.github/workflows/certora.yml`.
 
 ## Usage
@@ -408,31 +409,36 @@ Comment on any PR (requires write access to the repo):
 The bot reacts with 👀, replies with a link to the run, and when done posts a
 result table (per conf: ✅/❌, verified/violated rule counts, violated rule
 names). Full HTML reports (`FinalResults.html`, one row per rule/invariant
-with counterexample call traces) are attached to the run as the
-`certora-reports-*` artifact. Any violation turns the check red.
+with counterexample call traces) are attached to the run as one
+`certora-<conf>-*` artifact per conf. Any violation turns the check red.
 
 Manual runs: Actions → certora → *Run workflow* (works on any branch that
 contains the workflow file; the comment command only works once the workflow
 is on `master`).
 
-Expect roughly an hour per heavy conf (`ConsistentState` ≈ 73 min on a 6 GB
-container); confs run sequentially on the runner.
+Confs fan out as a matrix — each conf gets its own runner and they all run in
+parallel, so wall-clock time is the slowest conf, not the sum. Expect roughly
+1–3 h for heavy confs (`ConsistentState` ≈ 73 min on a comparable 4-core box);
+the hosted-runner hard limit is 6 h per conf — if a conf hits it (e.g.
+`StayHealthy`-class specs), split it with a `"rule": [...]` filter.
 
 Note: the CI localizes the cloud confs on the fly (drops `server`, renames
 `solc-X.Y.Z` to the image's `solcX.Y.Z`, adds a JVM heap) — the files in
 `certora/confs/` stay in cloud format and still work with `certoraRun` +
 CERTORAKEY if needed.
 
-## Runner / image operations
+## Operations
 
-- The runner is registered under Settings → Actions → Runners with the
-  `certora` label, and needs `git` and `docker` installed. Verification runs
-  as the runner's uid inside the container; the workspace stays owned by the
-  runner user.
+- Hosted runners are free only while this repo is public; if it ever goes
+  private, minutes are billed (and drop to 2-core machines) — revisit the
+  runner strategy then.
+- The workflow pulls `ghcr.io/lista-dao/certora-local:latest` with the
+  workflow's `GITHUB_TOKEN`; the GHCR package must stay public or keep this
+  repo granted read access in its package settings.
 - Update the prover image by rebuilding it (see the certora-docker project)
   and pushing to `ghcr.io/lista-dao/certora-local:latest`; jobs pull on every
   run.
 - Memory/heap knobs live in the workflow's `env` block (`CONTAINER_MEM`,
-  `JAVA_HEAP`) — raise them together if the runner host has RAM to spare.
+  `JAVA_HEAP`), sized for the 16 GB hosted runners.
 - If a PR has merge conflicts, the `refs/pull/N/merge` checkout fails —
   resolve conflicts first, then re-comment.

--- a/certora/README.md
+++ b/certora/README.md
@@ -388,3 +388,51 @@ they do not prove anything about broker- or provider-managed markets.
   Morpho Blue and are not covered by the migrated specs.
 - **Per-rule review.** Each spec should be re-checked against Moolah's actual function set and
   semantics; method blocks may reference functions whose signatures or behavior diverged.
+
+# Running the prover from a PR (CI)
+
+Verification runs on a self-hosted runner using the open-source Certora Prover
+image (`ghcr.io/lista-dao/certora-local`) — fully local, no CERTORAKEY, no cloud.
+The workflow is `.github/workflows/certora.yml`.
+
+## Usage
+
+Comment on any PR (requires write access to the repo):
+
+```
+/certora ConsistentState            # one conf
+/certora ConsistentState Health     # several confs
+/certora all                        # every conf in certora/confs/
+```
+
+The bot reacts with 👀, replies with a link to the run, and when done posts a
+result table (per conf: ✅/❌, verified/violated rule counts, violated rule
+names). Full HTML reports (`FinalResults.html`, one row per rule/invariant
+with counterexample call traces) are attached to the run as the
+`certora-reports-*` artifact. Any violation turns the check red.
+
+Manual runs: Actions → certora → *Run workflow* (works on any branch that
+contains the workflow file; the comment command only works once the workflow
+is on `master`).
+
+Expect roughly an hour per heavy conf (`ConsistentState` ≈ 73 min on a 6 GB
+container); confs run sequentially on the runner.
+
+Note: the CI localizes the cloud confs on the fly (drops `server`, renames
+`solc-X.Y.Z` to the image's `solcX.Y.Z`, adds a JVM heap) — the files in
+`certora/confs/` stay in cloud format and still work with `certoraRun` +
+CERTORAKEY if needed.
+
+## Runner / image operations
+
+- The runner is registered under Settings → Actions → Runners with the
+  `certora` label, and needs `git` and `docker` installed. Verification runs
+  as the runner's uid inside the container; the workspace stays owned by the
+  runner user.
+- Update the prover image by rebuilding it (see the certora-docker project)
+  and pushing to `ghcr.io/lista-dao/certora-local:latest`; jobs pull on every
+  run.
+- Memory/heap knobs live in the workflow's `env` block (`CONTAINER_MEM`,
+  `JAVA_HEAP`) — raise them together if the runner host has RAM to spare.
+- If a PR has merge conflicts, the `refs/pull/N/merge` checkout fails —
+  resolve conflicts first, then re-comment.

--- a/certora/confs/AccessControl.conf
+++ b/certora/confs/AccessControl.conf
@@ -1,0 +1,12 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/AccessControl.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Access Control"
+}

--- a/certora/confs/AccrueInterest.conf
+++ b/certora/confs/AccrueInterest.conf
@@ -1,0 +1,18 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/AccrueInterest.spec",
+  "prover_args": [
+    "-depth 3",
+    "-mediumTimeout 30",
+    "-smt_hashingScheme plaininjectivity"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Accrue Interest"
+}

--- a/certora/confs/AssetsAccounting.conf
+++ b/certora/confs/AssetsAccounting.conf
@@ -1,0 +1,13 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/AssetsAccounting.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Assets Accounting"
+}

--- a/certora/confs/ConsistentState.conf
+++ b/certora/confs/ConsistentState.conf
@@ -1,0 +1,13 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/ConsistentState.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Consistent State"
+}

--- a/certora/confs/ExactMath.conf
+++ b/certora/confs/ExactMath.conf
@@ -1,0 +1,21 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/ExactMath.spec",
+  "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 5",
+    "-timeout 3600",
+    "-backendStrategy singlerace",
+    "-smt_nonLinearArithmetic true",
+    "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:lia2]"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Exact Math"
+}

--- a/certora/confs/ExchangeRate.conf
+++ b/certora/confs/ExchangeRate.conf
@@ -1,0 +1,17 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/ExchangeRate.spec",
+  "prover_args": [
+    "-smt_hashingScheme plaininjectivity",
+    "-smt_easy_LIA true"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Exchange Rate"
+}

--- a/certora/confs/Health.conf
+++ b/certora/confs/Health.conf
@@ -1,0 +1,17 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol",
+    "src/moolah/mocks/OracleMock.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/Health.spec",
+  "prover_args": [
+    "-smt_hashingScheme plaininjectivity"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Health"
+}

--- a/certora/confs/LibSummary.conf
+++ b/certora/confs/LibSummary.conf
@@ -1,0 +1,16 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/LibSummary.spec",
+  "prover_args": [
+    "-smt_bitVectorTheory true"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Lib Summary"
+}

--- a/certora/confs/LiquidateBuffer.conf
+++ b/certora/confs/LiquidateBuffer.conf
@@ -1,0 +1,23 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/LiquidateBuffer.spec",
+  "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 20",
+    "-timeout 3600",
+    "-backendStrategy singlerace",
+    "-smt_nonLinearArithmetic true",
+    "-destructiveOptimizations twostage",
+    "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
+  ],
+  "multi_assert_check": true,
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Liquidate Buffer"
+}

--- a/certora/confs/Liveness.conf
+++ b/certora/confs/Liveness.conf
@@ -1,0 +1,13 @@
+{
+  "files": [
+    "certora/helpers/MoolahInternalAccess.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahInternalAccess:certora/specs/Liveness.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Liveness"
+}

--- a/certora/confs/Reentrancy.conf
+++ b/certora/confs/Reentrancy.conf
@@ -1,0 +1,15 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/Reentrancy.spec",
+  "prover_args": [
+    "-enableStorageSplitting false"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Reentrancy"
+}

--- a/certora/confs/Reverts.conf
+++ b/certora/confs/Reverts.conf
@@ -1,0 +1,13 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/Reverts.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Reverts"
+}

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -1,0 +1,18 @@
+{
+  "files": [
+    "certora/helpers/MoolahHarness.sol",
+    "certora/helpers/Util.sol",
+    "src/moolah/mocks/OracleMock.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "MoolahHarness:certora/specs/StayHealthy.spec",
+  "prover_args": [
+    "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
+  ],
+  "multi_assert_check": true,
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Stay Healthy"
+}

--- a/certora/confs/Transfer.conf
+++ b/certora/confs/Transfer.conf
@@ -1,0 +1,15 @@
+{
+  "files": [
+    "certora/helpers/TransferHarness.sol",
+    "certora/dispatch/ERC20Standard.sol",
+    "certora/dispatch/ERC20USDT.sol",
+    "certora/dispatch/ERC20NoRevert.sol"
+  ],
+  "solc": "solc-0.8.34",
+  "solc_via_ir": true,
+  "optimistic_loop": true,
+  "verify": "TransferHarness:certora/specs/Transfer.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Moolah Transfer"
+}

--- a/certora/dispatch/ERC20NoRevert.sol
+++ b/certora/dispatch/ERC20NoRevert.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+contract ERC20NoRevert {
+  address public owner;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function _transfer(address _from, address _to, uint256 _amount) internal returns (bool) {
+    if (balanceOf[_from] < _amount) {
+      return false;
+    }
+    balanceOf[_from] -= _amount;
+    balanceOf[_to] += _amount;
+    return true;
+  }
+
+  function transfer(address _to, uint256 _amount) public returns (bool) {
+    return _transfer(msg.sender, _to, _amount);
+  }
+
+  function transferFrom(address _from, address _to, uint256 _amount) public returns (bool) {
+    if (allowance[_from][msg.sender] < _amount) {
+      return false;
+    }
+    allowance[_from][msg.sender] -= _amount;
+    return _transfer(_from, _to, _amount);
+  }
+
+  function approve(address _spender, uint256 _amount) public {
+    allowance[msg.sender][_spender] = _amount;
+  }
+
+  function mint(address _receiver, uint256 _amount) public onlyOwner {
+    balanceOf[_receiver] += _amount;
+    totalSupply += _amount;
+  }
+}

--- a/certora/dispatch/ERC20Standard.sol
+++ b/certora/dispatch/ERC20Standard.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+contract ERC20Standard {
+  address public owner;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function _transfer(address _from, address _to, uint256 _amount) internal returns (bool) {
+    balanceOf[_from] -= _amount;
+    balanceOf[_to] += _amount;
+    return true;
+  }
+
+  function transfer(address _to, uint256 _amount) public returns (bool) {
+    return _transfer(msg.sender, _to, _amount);
+  }
+
+  function transferFrom(address _from, address _to, uint256 _amount) public returns (bool) {
+    allowance[_from][msg.sender] -= _amount;
+    return _transfer(_from, _to, _amount);
+  }
+
+  function approve(address _spender, uint256 _amount) public {
+    allowance[msg.sender][_spender] = _amount;
+  }
+
+  function mint(address _receiver, uint256 _amount) public onlyOwner {
+    balanceOf[_receiver] += _amount;
+    totalSupply += _amount;
+  }
+}

--- a/certora/dispatch/ERC20USDT.sol
+++ b/certora/dispatch/ERC20USDT.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+contract ERC20USDT {
+  address public owner;
+  uint256 public totalSupply;
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  function _transfer(address _from, address _to, uint256 _amount) internal {
+    balanceOf[_from] -= _amount;
+    balanceOf[_to] += _amount;
+  }
+
+  function transfer(address _to, uint256 _amount) public {
+    _transfer(msg.sender, _to, _amount);
+  }
+
+  function transferFrom(address _from, address _to, uint256 _amount) public {
+    if (allowance[_from][msg.sender] < type(uint256).max) {
+      allowance[_from][msg.sender] -= _amount;
+    }
+    _transfer(_from, _to, _amount);
+  }
+
+  function approve(address _spender, uint256 _amount) public {
+    require(!((_amount != 0) && (allowance[msg.sender][_spender] != 0)));
+
+    allowance[msg.sender][_spender] = _amount;
+  }
+
+  function mint(address _receiver, uint256 _amount) public onlyOwner {
+    balanceOf[_receiver] += _amount;
+    totalSupply += _amount;
+  }
+}

--- a/certora/helpers/MoolahHarness.sol
+++ b/certora/helpers/MoolahHarness.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "moolah/Moolah.sol";
+import "moolah/libraries/SharesMathLib.sol";
+import "moolah/libraries/MarketParamsLib.sol";
+
+contract MoolahHarness is Moolah {
+  using MarketParamsLib for MarketParams;
+
+  // NOTE: Moolah is an upgradeable (UUPS) contract. Its constructor only calls
+  // `_disableInitializers()`, and state is configured via
+  // `initialize(admin, manager, pauser, minLoanValue)` — there is no
+  // `constructor(address newOwner)` like Morpho Blue. The harness therefore inherits the
+  // no-arg constructor; initialization for verification (roles, minLoanValue, ...) must be
+  // arranged on the Certora side. See certora/README.md.
+
+  function idToMarketParams_(Id id) external view returns (MarketParams memory) {
+    return idToMarketParams[id];
+  }
+
+  function market_(Id id) external view returns (Market memory) {
+    return market[id];
+  }
+
+  function position_(Id id, address user) external view returns (Position memory) {
+    return position[id][user];
+  }
+
+  function totalSupplyAssets(Id id) external view returns (uint256) {
+    return market[id].totalSupplyAssets;
+  }
+
+  function totalSupplyShares(Id id) external view returns (uint256) {
+    return market[id].totalSupplyShares;
+  }
+
+  function totalBorrowAssets(Id id) external view returns (uint256) {
+    return market[id].totalBorrowAssets;
+  }
+
+  function totalBorrowShares(Id id) external view returns (uint256) {
+    return market[id].totalBorrowShares;
+  }
+
+  function supplyShares(Id id, address account) external view returns (uint256) {
+    return position[id][account].supplyShares;
+  }
+
+  function borrowShares(Id id, address account) external view returns (uint256) {
+    return position[id][account].borrowShares;
+  }
+
+  function collateral(Id id, address account) external view returns (uint256) {
+    return position[id][account].collateral;
+  }
+
+  function lastUpdate(Id id) external view returns (uint256) {
+    return market[id].lastUpdate;
+  }
+
+  function fee(Id id) external view returns (uint256) {
+    return market[id].fee;
+  }
+
+  function virtualTotalSupplyAssets(Id id) external view returns (uint256) {
+    return market[id].totalSupplyAssets + SharesMathLib.VIRTUAL_ASSETS;
+  }
+
+  function virtualTotalSupplyShares(Id id) external view returns (uint256) {
+    return market[id].totalSupplyShares + SharesMathLib.VIRTUAL_SHARES;
+  }
+
+  function virtualTotalBorrowAssets(Id id) external view returns (uint256) {
+    return market[id].totalBorrowAssets + SharesMathLib.VIRTUAL_ASSETS;
+  }
+
+  function virtualTotalBorrowShares(Id id) external view returns (uint256) {
+    return market[id].totalBorrowShares + SharesMathLib.VIRTUAL_SHARES;
+  }
+
+  function isHealthy(MarketParams memory marketParams, address user) external view returns (bool) {
+    return _isHealthy(marketParams, marketParams.id(), user);
+  }
+
+  // Verification-time initializer. Moolah's real `initialize(...)` is guarded by the
+  // `initializer` modifier, which the implementation constructor permanently disables via
+  // `_disableInitializers()` — so the prover cannot reach an initialized state through it.
+  // This helper reproduces the post-`initialize` state (roles + minLoanValue) directly, so
+  // rules can start from a sane, initialized contract instead of an all-zero one. It is NOT
+  // part of Moolah and exists only for verification; it must be excluded from parametric
+  // `method f` rules (see certora/specs/ProxyFilters.spec :: isUpgradeOrInit).
+  function setUpInitializedState(address admin, address manager, address pauser, uint256 minLoanValue_) external {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+    _grantRole(PAUSER, pauser);
+    minLoanValue = minLoanValue_;
+  }
+
+  // Exposes the UUPS upgrade-authorization gate. `upgradeToAndCall` itself carries an
+  // `onlyProxy` guard that always reverts when the implementation is verified directly (no
+  // proxy in the scene), which would make any upgrade-auth rule vacuous. This wrapper lets
+  // the prover reason about `_authorizeUpgrade` (restricted to DEFAULT_ADMIN_ROLE) directly.
+  // See certora/specs/AccessControl.spec :: onlyAdminCanAuthorizeUpgrade.
+  function authorizeUpgrade_(address newImplementation) external {
+    _authorizeUpgrade(newImplementation);
+  }
+
+  // Exposes the (private-backed) ReentrancyGuard status. The `nonReentrant` guard reverts when
+  // `_status == ENTERED`; on the directly-verified implementation that storage is never
+  // initialized, so the prover may pick ENTERED and spuriously revert every guarded function.
+  // Liveness rules `require !reentrancyGuardEntered_()` (and !paused()) to assume a normal
+  // between-transactions state. See certora/specs/Liveness.spec.
+  function reentrancyGuardEntered_() external view returns (bool) {
+    return _reentrancyGuardEntered();
+  }
+}

--- a/certora/helpers/MoolahInternalAccess.sol
+++ b/certora/helpers/MoolahInternalAccess.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import "./MoolahHarness.sol";
+
+contract MoolahInternalAccess is MoolahHarness {
+  function update(Id id, uint256 timestamp) external {
+    market[id].lastUpdate = uint128(timestamp);
+  }
+
+  function increaseInterest(Id id, uint128 interest) external {
+    market[id].totalBorrowAssets += interest;
+    market[id].totalSupplyAssets += interest;
+  }
+}

--- a/certora/helpers/TransferHarness.sol
+++ b/certora/helpers/TransferHarness.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.12;
+
+import "moolah/libraries/SafeTransferLib.sol";
+import "moolah/interfaces/IERC20.sol";
+
+interface IERC20Extended is IERC20 {
+  function balanceOf(address) external view returns (uint256);
+  function allowance(address, address) external view returns (uint256);
+  function totalSupply() external view returns (uint256);
+}
+
+contract TransferHarness {
+  using SafeTransferLib for IERC20;
+
+  function libSafeTransferFrom(address token, address from, address to, uint256 value) external {
+    IERC20(token).safeTransferFrom(from, to, value);
+  }
+
+  function libSafeTransfer(address token, address to, uint256 value) external {
+    IERC20(token).safeTransfer(to, value);
+  }
+
+  function balanceOf(address token, address user) external view returns (uint256) {
+    return IERC20Extended(token).balanceOf(user);
+  }
+
+  function allowance(address token, address owner, address spender) external view returns (uint256) {
+    return IERC20Extended(token).allowance(owner, spender);
+  }
+
+  function totalSupply(address token) external view returns (uint256) {
+    return IERC20Extended(token).totalSupply();
+  }
+}

--- a/certora/helpers/Util.sol
+++ b/certora/helpers/Util.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.34;
+
+import { Id, MarketParams, MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+import "moolah/libraries/MathLib.sol";
+import "moolah/libraries/ConstantsLib.sol";
+import "moolah/libraries/UtilsLib.sol";
+
+contract Util {
+  using MarketParamsLib for MarketParams;
+  using MathLib for uint256;
+
+  function wad() external pure returns (uint256) {
+    return WAD;
+  }
+
+  function maxFee() external pure returns (uint256) {
+    return MAX_FEE;
+  }
+
+  function oraclePriceScale() external pure returns (uint256) {
+    return ORACLE_PRICE_SCALE;
+  }
+
+  function lif(uint256 lltv) external pure returns (uint256) {
+    return UtilsLib.min(MAX_LIQUIDATION_INCENTIVE_FACTOR, WAD.wDivDown(WAD - LIQUIDATION_CURSOR.wMulDown(WAD - lltv)));
+  }
+
+  function libId(MarketParams memory marketParams) external pure returns (Id) {
+    return marketParams.id();
+  }
+
+  function refId(MarketParams memory marketParams) external pure returns (Id marketParamsId) {
+    marketParamsId = Id.wrap(keccak256(abi.encode(marketParams)));
+  }
+
+  function libMulDivUp(uint256 x, uint256 y, uint256 d) external pure returns (uint256) {
+    return MathLib.mulDivUp(x, y, d);
+  }
+
+  function libMulDivDown(uint256 x, uint256 y, uint256 d) external pure returns (uint256) {
+    return MathLib.mulDivDown(x, y, d);
+  }
+
+  function libMin(uint256 x, uint256 y) external pure returns (uint256) {
+    return UtilsLib.min(x, y);
+  }
+}

--- a/certora/specs/AccessControl.spec
+++ b/certora/specs/AccessControl.spec
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Access-control / upgradeability rules specific to Moolah (Morpho Blue has none of these).
+// The generic invariants in the other specs filter the upgrade/admin operations out via
+// ProxyFilters.spec; this spec verifies their authorization gates directly.
+
+methods {
+    function hasRole(bytes32, address) external returns bool envfree;
+    function DEFAULT_ADMIN_ROLE() external returns bytes32 envfree;
+    function MANAGER() external returns bytes32 envfree;
+    function PAUSER() external returns bytes32 envfree;
+}
+
+// Only an account holding DEFAULT_ADMIN_ROLE may authorize a UUPS implementation upgrade.
+// We target the `_authorizeUpgrade` gate (via the harness wrapper) rather than
+// `upgradeToAndCall`, whose `onlyProxy` guard reverts unconditionally on the directly-verified
+// implementation and would make this rule vacuous.
+rule onlyAdminCanAuthorizeUpgrade(env e, address newImplementation) {
+    authorizeUpgrade_@withrevert(e, newImplementation);
+    assert !lastReverted => hasRole(DEFAULT_ADMIN_ROLE(), e.msg.sender);
+}
+
+// Only PAUSER may pause the contract.
+rule onlyPauserCanPause(env e) {
+    pause@withrevert(e);
+    assert !lastReverted => hasRole(PAUSER(), e.msg.sender);
+}
+
+// Only MANAGER may unpause the contract.
+rule onlyManagerCanUnpause(env e) {
+    unpause@withrevert(e);
+    assert !lastReverted => hasRole(MANAGER(), e.msg.sender);
+}
+
+// Only MANAGER may change the minimum loan value.
+rule onlyManagerCanSetMinLoanValue(env e, uint256 newValue) {
+    setMinLoanValue@withrevert(e, newValue);
+    assert !lastReverted => hasRole(MANAGER(), e.msg.sender);
+}

--- a/certora/specs/AccrueInterest.spec
+++ b/certora/specs/AccrueInterest.spec
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import "ProxyFilters.spec";
+
+methods {
+
+    function Util.maxFee() external returns uint256 envfree;
+
+    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal returns uint256 => ghostMulDivDown(a, b, c);
+    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal returns uint256 => ghostMulDivUp(a, b, c);
+    function MathLib.wTaylorCompounded(uint256 a, uint256 b) internal returns uint256 => ghostTaylorCompounded(a, b);
+    // We assume here that all external functions will not access storage, since we cannot show commutativity otherwise.
+    // We also need to assume that the price and borrow rate return always the same value (and do not depend on msg.origin), so we use ghost functions for them.
+    function _.borrowRate(MoolahHarness.MarketParams marketParams, MoolahHarness.Market market) external with (env e) => ghostBorrowRate(marketParams.irm, e.block.timestamp) expect uint256;
+    function _.price() external with (env e) => ghostOraclePrice(e.block.timestamp) expect uint256;
+    function _.transfer(address to, uint256 amount) external => ghostTransfer(to, amount) expect bool;
+    function _.transferFrom(address from, address to, uint256 amount) external => ghostTransferFrom(from, to, amount) expect bool;
+    function _.onMoolahLiquidate(uint256, bytes) external => NONDET;
+    function _.onMoolahRepay(uint256, bytes) external => NONDET;
+    function _.onMoolahSupply(uint256, bytes) external => NONDET;
+    function _.onMoolahSupplyCollateral(uint256, bytes) external => NONDET;
+    function _.onMoolahFlashLoan(uint256, bytes) external => NONDET;
+}
+
+ghost ghostMulDivUp(uint256, uint256, uint256) returns uint256;
+ghost ghostMulDivDown(uint256, uint256, uint256) returns uint256;
+ghost ghostTaylorCompounded(uint256, uint256) returns uint256;
+ghost ghostBorrowRate(address, uint256) returns uint256;
+ghost ghostOraclePrice(uint256) returns uint256;
+ghost ghostTransfer(address, uint256) returns bool;
+ghost ghostTransferFrom(address, address, uint256) returns bool;
+
+
+// Check that calling accrueInterest first has no effect.
+// This is because supply should call accrueInterest itself.
+rule supplyAccruesInterest(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    // Safe require because timestamps cannot realistically be that large.
+    require e.block.timestamp < 2^128;
+
+    storage init = lastStorage;
+
+    accrueInterest(e, marketParams);
+    supply(e, marketParams, assets, shares, onBehalf, data);
+    storage afterBoth = lastStorage;
+
+    supply(e, marketParams, assets, shares, onBehalf, data) at init;
+    storage afterOne = lastStorage;
+
+    assert afterBoth == afterOne;
+}
+
+// Check that calling accrueInterest first has no effect.
+// This is because withdraw should call accrueInterest itself.
+rule withdrawAccruesInterest(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    // Safe require because timestamps cannot realistically be that large.
+    require e.block.timestamp < 2^128;
+
+    storage init = lastStorage;
+
+    accrueInterest(e, marketParams);
+    withdraw(e, marketParams, assets, shares, onBehalf, receiver);
+    storage afterBoth = lastStorage;
+
+    withdraw(e, marketParams, assets, shares, onBehalf, receiver) at init;
+    storage afterOne = lastStorage;
+
+    assert afterBoth == afterOne;
+}
+
+// Check that calling accrueInterest first has no effect.
+// This is because borrow should call accrueInterest itself.
+rule borrowAccruesInterest(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    // Safe require because timestamps cannot realistically be that large.
+    require e.block.timestamp < 2^128;
+
+    storage init = lastStorage;
+
+    accrueInterest(e, marketParams);
+    borrow(e, marketParams, assets, shares, onBehalf, receiver);
+    storage afterBoth = lastStorage;
+
+    borrow(e, marketParams, assets, shares, onBehalf, receiver) at init;
+    storage afterOne = lastStorage;
+
+    assert afterBoth == afterOne;
+}
+
+// Check that calling accrueInterest first has no effect.
+// This is because repay should call accrueInterest itself.
+rule repayAccruesInterest(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    // Safe require because timestamps cannot realistically be that large.
+    require e.block.timestamp < 2^128;
+
+    storage init = lastStorage;
+
+    accrueInterest(e, marketParams);
+    repay(e, marketParams, assets, shares, onBehalf, data);
+    storage afterBoth = lastStorage;
+
+    repay(e, marketParams, assets, shares, onBehalf, data) at init;
+    storage afterOne = lastStorage;
+
+    assert afterBoth == afterOne;
+}
+
+// Show that accrueInterest commutes with other state changing rules.
+// We exclude view functions, because:
+// (a) we cannot check the return value and for storage commutativity is trivial, and
+// (b) most view functions, e.g. totalSupplyShares, are not commutative, i.e. they return a different value if called before accrueInterest is called.
+// We also exclude setFeeRecipient, as it is known to be not commutative.
+rule accrueInterestCommutesExceptForSetFeeRecipient(method f, calldataarg args)
+filtered {
+    f -> !f.isView && !isExcludedOp(f) && f.selector != sig:setFeeRecipient(address).selector
+}
+{
+    env e1;
+    env e2;
+    MoolahHarness.MarketParams marketParams;
+
+    // Assume interactions to happen at the same block.
+    require e1.block.timestamp == e2.block.timestamp;
+    // Safe require because timestamps cannot realistically be that large.
+    require e1.block.timestamp < 2^128;
+
+    storage init = lastStorage;
+
+    accrueInterest(e1, marketParams);
+    f@withrevert(e2, args);
+    bool revert1 = lastReverted;
+    storage store1 = lastStorage;
+
+
+    f@withrevert(e2, args) at init;
+    bool revert2 = lastReverted;
+    accrueInterest(e1, marketParams);
+    storage store2 = lastStorage;
+
+    assert revert1 <=> revert2;
+    assert store1 == store2;
+}

--- a/certora/specs/AssetsAccounting.spec
+++ b/certora/specs/AssetsAccounting.spec
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function supplyShares(MoolahHarness.Id, address) external returns uint256 envfree;
+    function borrowShares(MoolahHarness.Id, address) external returns uint256 envfree;
+    function collateral(MoolahHarness.Id, address) external returns uint256 envfree;
+    function totalSupplyShares(MoolahHarness.Id) external returns uint256 envfree;
+    function totalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalSupplyAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalSupplyShares(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function lastUpdate(MoolahHarness.Id) external returns uint256 envfree;
+
+    function Util.libMulDivDown(uint256, uint256, uint256) external returns uint256 envfree;
+    function Util.libMulDivUp(uint256, uint256, uint256) external returns uint256 envfree;
+    function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+}
+
+function expectedSupplyAssets(MoolahHarness.Id id, address user) returns uint256 {
+    uint256 userShares = supplyShares(id, user);
+    uint256 totalSupplyAssets = virtualTotalSupplyAssets(id);
+    uint256 totalSupplyShares = virtualTotalSupplyShares(id);
+
+    return Util.libMulDivDown(userShares, totalSupplyAssets, totalSupplyShares);
+}
+
+function expectedBorrowAssets(MoolahHarness.Id id, address user) returns uint256 {
+    uint256 userShares = borrowShares(id, user);
+    uint256 totalBorrowAssets = virtualTotalBorrowAssets(id);
+    uint256 totalBorrowShares = virtualTotalBorrowShares(id);
+
+    return Util.libMulDivUp(userShares, totalBorrowAssets, totalBorrowShares);
+}
+
+// Check that the assets supplied are greater than the increase in owned assets.
+rule supplyAssetsAccounting(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    // Assume no interest as it would increase the total supply assets.
+    require lastUpdate(id) == e.block.timestamp;
+    // Safe require because of the sumSupplySharesCorrect invariant.
+    require supplyShares(id, onBehalf) <= totalSupplyShares(id);
+
+    uint256 ownedAssetsBefore = expectedSupplyAssets(id, onBehalf);
+
+    uint256 suppliedAssets;
+    suppliedAssets, _ = supply(e, marketParams, assets, shares, onBehalf, data);
+
+    uint256 ownedAssets = expectedSupplyAssets(id, onBehalf);
+
+    assert ownedAssetsBefore + suppliedAssets >= to_mathint(ownedAssets);
+}
+
+// Check that the assets withdrawn are less than the assets owned initially.
+rule withdrawAssetsAccounting(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    // Assume no interest as it would increase the total supply assets.
+    require lastUpdate(id) == e.block.timestamp;
+
+    uint256 ownedAssets = expectedSupplyAssets(id, onBehalf);
+
+    uint256 withdrawnAssets;
+    withdrawnAssets, _ = withdraw(e, marketParams, assets, shares, onBehalf, receiver);
+
+    assert withdrawnAssets <= ownedAssets;
+}
+
+// Check that the increase of owed assets are greater than the borrowed assets.
+rule borrowAssetsAccounting(env e, MoolahHarness.MarketParams marketParams, uint256 shares, address onBehalf, address receiver) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    // Assume no interest as it would increase the total borrowed assets.
+    require lastUpdate(id) == e.block.timestamp;
+    // Safe require because of the sumBorrowSharesCorrect invariant.
+    require borrowShares(id, onBehalf) <= totalBorrowShares(id);
+
+    uint256 owedAssetsBefore = expectedBorrowAssets(id, onBehalf);
+
+    // The borrow call is restricted to shares as input to make it easier on the prover.
+    uint256 borrowedAssets;
+    borrowedAssets, _ = borrow(e, marketParams, 0, shares, onBehalf, receiver);
+
+    uint256 owedAssets = expectedBorrowAssets(id, onBehalf);
+
+    assert owedAssetsBefore + borrowedAssets <= to_mathint(owedAssets);
+}
+
+// Check that the assets repaid are greater than the assets owed initially.
+rule repayAssetsAccounting(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    // Assume no interest as it would increase the total borrowed assets.
+    require lastUpdate(id) == e.block.timestamp;
+
+    uint256 owedAssets = expectedBorrowAssets(id, onBehalf);
+
+    uint256 repaidAssets;
+    repaidAssets, _ = repay(e, marketParams, assets, shares, onBehalf, data);
+
+    // Assume a full repay.
+    require borrowShares(id, onBehalf) == 0;
+
+    assert repaidAssets >= owedAssets;
+}
+
+// Check that the collateral assets supplied are equal to the increase of owned assets.
+rule supplyCollateralAssetsAccounting(env e, MoolahHarness.MarketParams marketParams, uint256 suppliedAssets, address onBehalf, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    uint256 ownedAssetsBefore = collateral(id, onBehalf);
+
+    supplyCollateral(e, marketParams, suppliedAssets, onBehalf, data);
+
+    uint256 ownedAssets = collateral(id, onBehalf);
+
+    assert ownedAssetsBefore + suppliedAssets == to_mathint(ownedAssets);
+}
+
+// Check that the collateral assets withdrawn are less than the assets owned initially.
+rule withdrawCollateralAssetsAccounting(env e, MoolahHarness.MarketParams marketParams, uint256 withdrawnAssets, address onBehalf, address receiver) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    uint256 ownedAssets = collateral(id, onBehalf);
+
+    withdrawCollateral(e, marketParams, withdrawnAssets, onBehalf, receiver);
+
+    assert withdrawnAssets <= ownedAssets;
+}

--- a/certora/specs/ConsistentState.spec
+++ b/certora/specs/ConsistentState.spec
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function supplyShares(MoolahHarness.Id, address) external returns (uint256) envfree;
+    function borrowShares(MoolahHarness.Id, address) external returns (uint256) envfree;
+    function collateral(MoolahHarness.Id, address) external returns (uint256) envfree;
+    function totalSupplyAssets(MoolahHarness.Id) external returns (uint256) envfree;
+    function totalSupplyShares(MoolahHarness.Id) external returns (uint256) envfree;
+    function totalBorrowAssets(MoolahHarness.Id) external returns (uint256) envfree;
+    function totalBorrowShares(MoolahHarness.Id) external returns (uint256) envfree;
+    function fee(MoolahHarness.Id) external returns (uint256) envfree;
+    function defaultMarketFee() external returns (uint256) envfree;
+    function lastUpdate(MoolahHarness.Id) external returns (uint256) envfree;
+    function isIrmEnabled(address) external returns (bool) envfree;
+    function isLltvEnabled(uint256) external returns (bool) envfree;
+    function isAuthorized(address, address) external returns (bool) envfree;
+    function idToMarketParams_(MoolahHarness.Id) external returns (MoolahHarness.MarketParams) envfree;
+    function nonce(address) external returns (uint256) envfree;
+
+    function Util.maxFee() external returns (uint256) envfree;
+    function Util.wad() external returns (uint256) envfree;
+    function Util.libId(MoolahHarness.MarketParams) external returns (MoolahHarness.Id) envfree;
+
+    function _.borrowRate(MoolahHarness.MarketParams, MoolahHarness.Market) external => HAVOC_ECF;
+
+    function SafeTransferLib.safeTransfer(address token, address to, uint256 value) internal => summarySafeTransferFrom(token, currentContract, to, value);
+    function SafeTransferLib.safeTransferFrom(address token, address from, address to, uint256 value) internal => summarySafeTransferFrom(token, from, to, value);
+}
+
+persistent ghost mapping(MoolahHarness.Id => mathint) sumSupplyShares {
+    init_state axiom (forall MoolahHarness.Id id. sumSupplyShares[id] == 0);
+}
+
+persistent ghost mapping(MoolahHarness.Id => mathint) sumBorrowShares {
+    init_state axiom (forall MoolahHarness.Id id. sumBorrowShares[id] == 0);
+}
+
+persistent ghost mapping(MoolahHarness.Id => mathint) sumCollateral {
+    init_state axiom (forall MoolahHarness.Id id. sumCollateral[id] == 0);
+}
+
+persistent ghost mapping(address => mathint) balance {
+    init_state axiom (forall address token. balance[token] == 0);
+}
+
+persistent ghost mapping(address => mathint) idleAmount {
+    init_state axiom (forall address token. idleAmount[token] == 0);
+}
+
+hook Sstore position[KEY MoolahHarness.Id id][KEY address owner].supplyShares uint256 newShares (uint256 oldShares) {
+    sumSupplyShares[id] = sumSupplyShares[id] - oldShares + newShares;
+}
+
+hook Sstore position[KEY MoolahHarness.Id id][KEY address owner].borrowShares uint128 newShares (uint128 oldShares) {
+    sumBorrowShares[id] = sumBorrowShares[id] - oldShares + newShares;
+}
+
+hook Sstore position[KEY MoolahHarness.Id id][KEY address owner].collateral uint128 newAmount (uint128 oldAmount) {
+    sumCollateral[id] = sumCollateral[id] - oldAmount + newAmount;
+    idleAmount[idToMarketParams_(id).collateralToken] = idleAmount[idToMarketParams_(id).collateralToken] - oldAmount + newAmount;
+}
+
+hook Sstore market[KEY MoolahHarness.Id id].totalSupplyAssets uint128 newAmount (uint128 oldAmount) {
+    idleAmount[idToMarketParams_(id).loanToken] = idleAmount[idToMarketParams_(id).loanToken] - oldAmount + newAmount;
+}
+
+hook Sstore market[KEY MoolahHarness.Id id].totalBorrowAssets uint128 newAmount (uint128 oldAmount) {
+    idleAmount[idToMarketParams_(id).loanToken] = idleAmount[idToMarketParams_(id).loanToken] + oldAmount - newAmount;
+}
+
+function summarySafeTransferFrom(address token, address from, address to, uint256 amount) {
+    if (from == currentContract) {
+        // Safe require because the reference implementation would revert.
+        balance[token] = require_uint256(balance[token] - amount);
+    }
+    if (to == currentContract) {
+        // Safe require because the reference implementation would revert.
+        balance[token] = require_uint256(balance[token] + amount);
+    }
+}
+
+definition isCreated(MoolahHarness.Id id) returns bool = lastUpdate(id) != 0;
+
+// The fee assigned to newly created markets (defaultMarketFee) is bounded by setDefaultMarketFee
+// (require newFee <= MAX_FEE). Needed to make feeInRange inductive across createMarket.
+invariant defaultMarketFeeInRange()
+    defaultMarketFee() <= Util.maxFee()
+    filtered { f -> !isExcludedOp(f) }
+
+// Check that the fee is always lower than the max fee constant.
+invariant feeInRange(MoolahHarness.Id id)
+    fee(id) <= Util.maxFee()
+    filtered { f -> !isExcludedOp(f) }
+    {
+        // createMarket sets market[id].fee = defaultMarketFee, which is itself bounded.
+        preserved createMarket(MoolahHarness.MarketParams marketParams) with (env e) {
+            requireInvariant defaultMarketFeeInRange();
+        }
+    }
+
+// Check that the accounting of totalSupplyShares is correct.
+invariant sumSupplySharesCorrect(MoolahHarness.Id id)
+    to_mathint(totalSupplyShares(id)) == sumSupplyShares[id]
+    filtered { f -> !isExcludedOp(f) }
+
+// Check that the accounting of totalBorrowShares is correct.
+invariant sumBorrowSharesCorrect(MoolahHarness.Id id)
+    to_mathint(totalBorrowShares(id)) == sumBorrowShares[id]
+    filtered { f -> !isExcludedOp(f) }
+
+// Check that a market only allows borrows up to the total supply.
+// This invariant shows that markets are independent, tokens from one market cannot be taken by interacting with another market.
+invariant borrowLessThanSupply(MoolahHarness.Id id)
+    totalBorrowAssets(id) <= totalSupplyAssets(id)
+    filtered { f -> !isExcludedOp(f) }
+
+// Check correctness of applying idToMarketParams() to an identifier.
+invariant hashOfMarketParamsOf(MoolahHarness.Id id)
+    isCreated(id) => Util.libId(idToMarketParams_(id)) == id
+    filtered { f -> !isExcludedOp(f) }
+
+// Check correctness of applying id() to a market params.
+// This invariant is useful in the following rule, to link an id back to a market.
+invariant marketParamsOfHashOf(MoolahHarness.MarketParams marketParams)
+    isCreated(Util.libId(marketParams)) => idToMarketParams_(Util.libId(marketParams)) == marketParams
+    filtered { f -> !isExcludedOp(f) }
+
+// Check that the idle amount on the singleton is greater to the sum amount, that is the sum over all the markets of the total supply plus the total collateral minus the total borrow.
+invariant idleAmountLessThanBalance(address token)
+    idleAmount[token] <= balance[token]
+    filtered { f -> !isExcludedOp(f) }
+    {
+        // Safe requires on the sender because the contract cannot call the function itself.
+        preserved supply(MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+        preserved withdraw(MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+        preserved borrow(MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+        preserved repay(MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+        preserved supplyCollateral(MoolahHarness.MarketParams marketParams, uint256 assets, address onBehalf, bytes data) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+        preserved withdrawCollateral(MoolahHarness.MarketParams marketParams, uint256 assets, address onBehalf, address receiver) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+        preserved liquidate(MoolahHarness.MarketParams marketParams, address _b, uint256 shares, uint256 receiver, bytes data) with (env e) {
+            requireInvariant marketParamsOfHashOf(marketParams);
+            require e.msg.sender != currentContract;
+        }
+    }
+
+// Check that a market can only exist if its LLTV is enabled.
+invariant onlyEnabledLltv(MoolahHarness.MarketParams marketParams)
+    isCreated(Util.libId(marketParams)) => isLltvEnabled(marketParams.lltv)
+    filtered { f -> !isExcludedOp(f) }
+
+invariant lltvSmallerThanWad(uint256 lltv)
+    isLltvEnabled(lltv) => lltv <= Util.wad()
+    filtered { f -> !isExcludedOp(f) }
+
+// Check that a market can only exist if its IRM is enabled.
+invariant onlyEnabledIrm(MoolahHarness.MarketParams marketParams)
+    isCreated(Util.libId(marketParams)) => isIrmEnabled(marketParams.irm)
+    filtered { f -> !isExcludedOp(f) }
+
+// Check the pseudo-injectivity of the hashing function id().
+rule libIdUnique() {
+    MoolahHarness.MarketParams marketParams1;
+    MoolahHarness.MarketParams marketParams2;
+
+    // Assume that arguments are the same.
+    require Util.libId(marketParams1) == Util.libId(marketParams2);
+
+    assert marketParams1 == marketParams2;
+}
+
+// Check that only the user is able to change who is authorized to manage his position.
+rule onlyUserCanAuthorizeWithoutSig(env e, method f, calldataarg data) filtered { f -> !f.isView && !isExcludedOp(f) && f.selector != sig:setAuthorizationWithSig(MoolahHarness.Authorization memory, MoolahHarness.Signature calldata).selector } {
+    address user;
+    address someone;
+
+    // Assume that it is another user that is interacting with Morpho.
+    require user != e.msg.sender;
+
+    bool authorizedBefore = isAuthorized(user, someone);
+
+    f(e, data);
+
+    bool authorizedAfter = isAuthorized(user, someone);
+
+    assert authorizedAfter == authorizedBefore;
+}
+
+// Check that only authorized users are able to decrease supply shares of a position.
+rule userCannotLoseSupplyShares(env e, method f, calldataarg data) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+    address user;
+
+    // Assume that the e.msg.sender is not authorized.
+    require !isAuthorized(user, e.msg.sender);
+    require user != e.msg.sender;
+
+    mathint sharesBefore = supplyShares(id, user);
+
+    f(e, data);
+
+    mathint sharesAfter = supplyShares(id, user);
+
+    assert sharesAfter >= sharesBefore;
+}
+
+// Check that only authorized users are able to increase the borrow shares of a position.
+rule userCannotGainBorrowShares(env e, method f, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+    address user;
+
+    // Assume that the e.msg.sender is not authorized.
+    require !isAuthorized(user, e.msg.sender);
+    require user != e.msg.sender;
+
+    mathint sharesBefore = borrowShares(id, user);
+
+    f(e, args);
+
+    mathint sharesAfter = borrowShares(id, user);
+
+    assert sharesAfter <= sharesBefore;
+}
+
+// Check that users cannot lose collateral by unauthorized parties except in case of a liquidation.
+rule userCannotLoseCollateralExceptLiquidate(env e, method f, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) && f.selector != sig:liquidate(MoolahHarness.MarketParams, address, uint256, uint256, bytes).selector } {
+    MoolahHarness.Id id;
+    address user;
+
+    // Assume that the e.msg.sender is not authorized.
+    require !isAuthorized(user, e.msg.sender);
+    require user != e.msg.sender;
+
+    mathint collateralBefore = collateral(id, user);
+
+    f(e, args);
+
+    mathint collateralAfter = collateral(id, user);
+
+    assert collateralAfter >= collateralBefore;
+}
+
+// Check that users cannot lose collateral by unauthorized parties if they have no outstanding debt.
+rule userWithoutBorrowCannotLoseCollateral(env e, method f, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+    address user;
+
+    // Assume that the e.msg.sender is not authorized.
+    require !isAuthorized(user, e.msg.sender);
+    require user != e.msg.sender;
+
+    // Assume that the user has no outstanding debt.
+    require borrowShares(id, user) == 0;
+
+    mathint collateralBefore = collateral(id, user);
+
+    f(e, args);
+
+    mathint collateralAfter = collateral(id, user);
+
+    assert collateralAfter >= collateralBefore;
+}
+
+// Invariant checking that the last updated time is never greater than the current time.
+rule noTimeTravel(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+
+    // Assume the property before the interaction.
+    require lastUpdate(id) <= e.block.timestamp;
+
+    f(e, args);
+
+    assert lastUpdate(id) <= e.block.timestamp;
+}
+
+// Invariant checking that the last updated time is never zero.
+rule lastUpdateNonZero(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+
+    // Assume the timestamp is not extremely far in the future.
+    require e.block.timestamp <= max_uint128;
+
+    // Assume the property before the interaction.
+    require lastUpdate(id) != 0;
+
+    f(e, args);
+
+    assert lastUpdate(id) != 0;
+}
+
+// Invariant checking that the last updated time never decreases.
+rule lastUpdateCannotDecrease(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+
+    // Assume the timestamp is not extremely far in the future.
+    require e.block.timestamp <= max_uint128;
+    uint256 lastUpdateBefore = lastUpdate(id);
+
+    f(e, args);
+
+    uint256 lastUpdateAfter = lastUpdate(id);
+    assert lastUpdateAfter >= lastUpdateBefore;
+}
+
+// Invariant checking that IRM cannot be disabled once enabled.
+rule irmCannotBeDisabled(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    address irm;
+
+    // Assume the property before the interaction.
+    require isIrmEnabled(irm);
+
+    f(e, args);
+
+    assert isIrmEnabled(irm);
+}
+
+// Invariant checking that LLTV cannot be disabled once enabled.
+rule lltvCannotBeDisabled(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    uint256 lltv;
+
+    // Assume the property before the interaction.
+    require isLltvEnabled(lltv);
+
+    f(e, args);
+
+    assert isLltvEnabled(lltv);
+}
+
+// Invariant checking that market parameters for a created market cannot change.
+rule idToMarketParamsForCreatedMarketCannotChange(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    MoolahHarness.Id id;
+
+    // Assume the market is created.
+    require isCreated(id);
+    MoolahHarness.MarketParams itmpBefore = idToMarketParams_(id);
+
+    f(e, args);
+
+    MoolahHarness.MarketParams itmpAfter = idToMarketParams_(id);
+    assert itmpBefore == itmpAfter;
+}
+
+rule nonceCannotDecrease(method f, env e, calldataarg args) filtered { f -> !f.isView && !isExcludedOp(f) } {
+    address user;
+
+    uint256 nonceBefore = nonce(user);
+
+    f(e, args);
+
+    uint256 nonceAfter = nonce(user);
+    assert(nonceAfter == nonceBefore || nonceAfter == nonceBefore + 1);
+}

--- a/certora/specs/ExactMath.spec
+++ b/certora/specs/ExactMath.spec
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function feeRecipient() external returns address envfree;
+    function supplyShares(MoolahHarness.Id, address) external returns uint256 envfree;
+    function borrowShares(MoolahHarness.Id, address) external returns uint256 envfree;
+    function virtualTotalSupplyAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalSupplyShares(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function lastUpdate(MoolahHarness.Id) external returns uint256 envfree;
+    function fee(MoolahHarness.Id) external returns uint256 envfree;
+
+    function Util.maxFee() external returns uint256 envfree;
+    function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+
+    function SafeTransferLib.safeTransfer(address token, address to, uint256 value) internal => NONDET;
+    function SafeTransferLib.safeTransferFrom(address token, address from, address to, uint256 value) internal => NONDET;
+    function _.onMoolahSupply(uint256 assets, bytes data) external => HAVOC_ECF;
+}
+
+// Check that when not accruing interest, and when repaying all, the borrow exchange rate is at least reset to the initial exchange rate.
+// More details on the purpose of this rule in ExchangeRate.spec.
+rule repayAllResetsBorrowExchangeRate(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+    // Safe require because this invariant is checked in ConsistentState.spec
+    require fee(id) <= Util.maxFee();
+
+    mathint assetsBefore = virtualTotalBorrowAssets(id);
+    mathint sharesBefore = virtualTotalBorrowShares(id);
+
+    // Assume no interest as it would increase the borrowed assets.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint repaidAssets;
+    repaidAssets, _ = repay(e, marketParams, assets, shares, onBehalf, data);
+
+    // Check the case where the market is fully repaid.
+    require repaidAssets >= assetsBefore;
+
+    mathint assetsAfter = virtualTotalBorrowAssets(id);
+    mathint sharesAfter = virtualTotalBorrowShares(id);
+
+    assert assetsAfter == 1;
+    // There are at least as many shares as virtual shares, by definition of virtualTotalBorrowShares.
+}
+
+// There should be no profit from supply followed immediately by withdraw.
+rule supplyWithdraw() {
+    MoolahHarness.MarketParams marketParams;
+    MoolahHarness.Id id = Util.libId(marketParams);
+    env e1;
+    env e2;
+    address onBehalf;
+
+    // Assume that interactions happen at the same block.
+    require e1.block.timestamp == e2.block.timestamp;
+    // Assume that the user starts without any supply position.
+    require supplyShares(id, onBehalf) == 0;
+    // Assume that the user is not the fee recipient, otherwise the gain can come from the fee.
+    require onBehalf != feeRecipient();
+    // Safe require because timestamps cannot realistically be that large.
+    require e1.block.timestamp < 2^128;
+
+    uint256 supplyAssets; uint256 supplyShares; bytes data;
+    uint256 suppliedAssets;
+    uint256 suppliedShares;
+    suppliedAssets, suppliedShares = supply(e1, marketParams, supplyAssets, supplyShares, onBehalf, data);
+
+    // Hints for the prover.
+    assert suppliedAssets * (virtualTotalSupplyShares(id) - suppliedShares) >= suppliedShares * (virtualTotalSupplyAssets(id) - suppliedAssets);
+    assert suppliedAssets * virtualTotalSupplyShares(id) >= suppliedShares * virtualTotalSupplyAssets(id);
+
+    uint256 withdrawAssets; uint256 withdrawShares; address receiver;
+    uint256 withdrawnAssets;
+    withdrawnAssets, _ = withdraw(e2, marketParams, withdrawAssets, withdrawShares, onBehalf, receiver);
+
+    assert withdrawnAssets <= suppliedAssets;
+}
+
+// There should be no profit from borrow followed immediately by repaying all.
+rule borrowRepay() {
+    MoolahHarness.MarketParams marketParams;
+    MoolahHarness.Id id = Util.libId(marketParams);
+    address onBehalf;
+    env e1;
+    env e2;
+
+    // Assume interactions happen at the same block.
+    require e1.block.timestamp == e2.block.timestamp;
+    // Assume that the user starts without any borrow position.
+    require borrowShares(id, onBehalf) == 0;
+    // Safe require because timestamps cannot realistically be that large.
+    require e1.block.timestamp < 2^128;
+
+    uint256 borrowAssets; uint256 borrowShares; address receiver;
+    uint256 borrowedAssets;
+    uint256 borrowedShares;
+    borrowedAssets, borrowedShares = borrow(e2, marketParams, borrowAssets, borrowShares, onBehalf, receiver);
+
+    // Hints for the prover.
+    assert borrowedAssets * (virtualTotalBorrowShares(id) - borrowedShares) <= borrowedShares * (virtualTotalBorrowAssets(id) - borrowedAssets);
+    assert borrowedAssets * virtualTotalBorrowShares(id) <= borrowedShares * virtualTotalBorrowAssets(id);
+
+    bytes data;
+    uint256 repaidAssets;
+    repaidAssets, _ = repay(e1, marketParams, 0, borrowedShares, onBehalf, data);
+
+    assert borrowedAssets <= repaidAssets;
+}

--- a/certora/specs/ExchangeRate.spec
+++ b/certora/specs/ExchangeRate.spec
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function collateral(MoolahHarness.Id, address) external returns uint256 envfree;
+    function virtualTotalSupplyAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalSupplyShares(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function fee(MoolahHarness.Id) external returns uint256 envfree;
+    function defaultMarketFee() external returns uint256 envfree;
+    function lastUpdate(MoolahHarness.Id) external returns uint256 envfree;
+
+    function Util.maxFee() external returns uint256 envfree;
+    function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+
+    function UtilsLib.min(uint256 x, uint256 y) internal returns uint256 => summaryMin(x, y);
+    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivDown(a, b, c);
+    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivUp(a, b, c);
+    function MathLib.wTaylorCompounded(uint256, uint256) internal returns uint256 => NONDET;
+
+    function _.borrowRate(MoolahHarness.MarketParams, MoolahHarness.Market) external => HAVOC_ECF;
+
+}
+
+invariant defaultMarketFeeInRange()
+    defaultMarketFee() <= Util.maxFee()
+    filtered { f -> !isExcludedOp(f) }
+
+invariant feeInRange(MoolahHarness.Id id)
+    fee(id) <= Util.maxFee()
+    filtered { f -> !isExcludedOp(f) }
+    {
+        // createMarket sets market[id].fee = defaultMarketFee, which is itself bounded.
+        preserved createMarket(MoolahHarness.MarketParams marketParams) with (env e) {
+            requireInvariant defaultMarketFeeInRange();
+        }
+    }
+
+function summaryMin(uint256 x, uint256 y) returns uint256 {
+    return x < y ? x : y;
+}
+
+// This is a simple overapproximative summary, stating that it rounds in the right direction.
+function summaryMulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
+    uint256 result;
+    // Safe require that is checked by the specification in LibSummary.spec.
+    require result * d >= x * y;
+    return result;
+}
+
+// This is a simple overapproximative summary, stating that it rounds in the right direction.
+function summaryMulDivDown(uint256 x, uint256 y, uint256 d) returns uint256 {
+    uint256 result;
+    // Safe require that is checked by the specification in LibSummary.spec.
+    require result * d <= x * y;
+    return result;
+}
+
+// Check that accrueInterest increases the value of supply shares.
+rule accrueInterestIncreasesSupplyExchangeRate(env e, MoolahHarness.MarketParams marketParams) {
+    MoolahHarness.Id id;
+    requireInvariant feeInRange(id);
+
+    mathint assetsBefore = virtualTotalSupplyAssets(id);
+    mathint sharesBefore = virtualTotalSupplyShares(id);
+
+    // The check is done for every market, not just for id.
+    accrueInterest(e, marketParams);
+
+    mathint assetsAfter = virtualTotalSupplyAssets(id);
+    mathint sharesAfter = virtualTotalSupplyShares(id);
+
+    // Check that the exchange rate increases: assetsBefore/sharesBefore <= assetsAfter/sharesAfter.
+    assert assetsBefore * sharesAfter <= assetsAfter * sharesBefore;
+}
+
+// Check that accrueInterest increases the value of borrow shares.
+rule accrueInterestIncreasesBorrowExchangeRate(env e, MoolahHarness.MarketParams marketParams) {
+    MoolahHarness.Id id;
+    requireInvariant feeInRange(id);
+
+    mathint assetsBefore = virtualTotalBorrowAssets(id);
+    mathint sharesBefore = virtualTotalBorrowShares(id);
+
+    // The check is done for every marketParams, not just for id.
+    accrueInterest(e, marketParams);
+
+    mathint assetsAfter = virtualTotalBorrowAssets(id);
+    mathint sharesAfter = virtualTotalBorrowShares(id);
+
+    // Check that the exchange rate increases: assetsBefore/sharesBefore <= assetsAfter/sharesAfter.
+    assert assetsBefore * sharesAfter <= assetsAfter * sharesBefore;
+}
+
+
+// Check that except when not accruing interest and except for liquidate, every function increases the value of supply shares.
+rule onlyLiquidateCanDecreaseSupplyExchangeRate(env e, method f, calldataarg args)
+filtered {
+    f -> !f.isView && !isExcludedOp(f) && f.selector != sig:liquidate(MoolahHarness.MarketParams, address, uint256, uint256, bytes).selector
+}
+{
+    MoolahHarness.Id id;
+    requireInvariant feeInRange(id);
+
+    mathint assetsBefore = virtualTotalSupplyAssets(id);
+    mathint sharesBefore = virtualTotalSupplyShares(id);
+
+    // Interest is checked separately by the rules above.
+    // Here we assume interest has already been accumulated for this block.
+    require lastUpdate(id) == e.block.timestamp;
+
+    f(e, args);
+
+    mathint assetsAfter = virtualTotalSupplyAssets(id);
+    mathint sharesAfter = virtualTotalSupplyShares(id);
+
+    // Check that the exchange rate increases: assetsBefore/sharesBefore <= assetsAfter/sharesAfter
+    assert assetsBefore * sharesAfter <= assetsAfter * sharesBefore;
+}
+
+// Check that when not realizing bad debt in liquidate, the value of supply shares increases.
+rule liquidateWithoutBadDebtRealizationIncreasesSupplyExchangeRate(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, uint256 repaidShares, bytes data)
+{
+    MoolahHarness.Id id;
+    requireInvariant feeInRange(id);
+
+    mathint assetsBefore = virtualTotalSupplyAssets(id);
+    mathint sharesBefore = virtualTotalSupplyShares(id);
+
+    // Interest is checked separately by the rules above.
+    // Here we assume interest has already been accumulated for this block.
+    require lastUpdate(id) == e.block.timestamp;
+
+    liquidate(e, marketParams, borrower, seizedAssets, repaidShares, data);
+
+    mathint assetsAfter = virtualTotalSupplyAssets(id);
+    mathint sharesAfter = virtualTotalSupplyShares(id);
+
+    // Trick to ensure that no bad debt realization happened.
+    require collateral(id, borrower) != 0;
+
+    // Check that the exchange rate increases: assetsBefore/sharesBefore <= assetsAfter/sharesAfter
+    assert assetsBefore * sharesAfter <= assetsAfter * sharesBefore;
+}
+
+// Check that except when not accruing interest, every function is decreasing the value of borrow shares.
+// The repay function is checked separately, see below.
+// The liquidate function is checked separately, see below.
+rule onlyAccrueInterestCanIncreaseBorrowExchangeRate(env e, method f, calldataarg args)
+filtered {
+    f -> !f.isView && !isExcludedOp(f) &&
+    f.selector != sig:repay(MoolahHarness.MarketParams, uint256, uint256, address, bytes).selector &&
+    f.selector != sig:liquidate(MoolahHarness.MarketParams, address, uint256, uint256, bytes).selector
+}
+{
+    MoolahHarness.Id id;
+    requireInvariant feeInRange(id);
+
+    // Interest would increase borrow exchange rate, so we need to assume that no time passes.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint assetsBefore = virtualTotalBorrowAssets(id);
+    mathint sharesBefore = virtualTotalBorrowShares(id);
+
+    f(e, args);
+
+    mathint assetsAfter = virtualTotalBorrowAssets(id);
+    mathint sharesAfter = virtualTotalBorrowShares(id);
+
+    // Check that the exchange rate decreases: assetsBefore/sharesBefore >= assetsAfter/sharesAfter
+    assert assetsBefore * sharesAfter >= assetsAfter * sharesBefore;
+}
+
+// Check that when not accruing interest, repay is decreasing the value of borrow shares.
+// Check the case where it would not repay more than the total assets.
+// The other case requires exact math (ie not over-approximating mulDivUp and mulDivDown), so it is checked separately in ExactMath.spec.
+rule repayDecreasesBorrowExchangeRate(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data)
+{
+    MoolahHarness.Id id = Util.libId(marketParams);
+    requireInvariant feeInRange(id);
+
+    mathint assetsBefore = virtualTotalBorrowAssets(id);
+    mathint sharesBefore = virtualTotalBorrowShares(id);
+
+    // Interest would increase borrow exchange rate, so we need to assume that no time passes.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint repaidAssets;
+    repaidAssets, _ = repay(e, marketParams, assets, shares, onBehalf, data);
+
+    // Check the case where it would not repay more than the total assets.
+    require repaidAssets < assetsBefore;
+
+    mathint assetsAfter = virtualTotalBorrowAssets(id);
+    mathint sharesAfter = virtualTotalBorrowShares(id);
+
+    assert assetsAfter == assetsBefore - repaidAssets;
+    // Check that the exchange rate decreases: assetsBefore/sharesBefore >= assetsAfter/sharesAfter
+    assert assetsBefore * sharesAfter >= assetsAfter * sharesBefore;
+}
+
+rule liquidateDecreasesBorrowExchangeRate(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, uint256 repaidShares, bytes data)
+{
+    require data.length == 0;
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    mathint assetsBefore = virtualTotalBorrowAssets(id);
+    mathint sharesBefore = virtualTotalBorrowShares(id);
+
+    // Interest would increase borrow exchange rate, so we need to assume that no time passes.
+    require lastUpdate(id) == e.block.timestamp;
+
+    liquidate(e, marketParams, borrower, seizedAssets, repaidShares, data);
+
+    mathint assetsAfter = virtualTotalBorrowAssets(id);
+    mathint sharesAfter = virtualTotalBorrowShares(id);
+
+    require assetsAfter != 1;
+
+    // Check that the exchange rate decreases: assetsBefore/sharesBefore >= assetsAfter/sharesAfter
+    assert assetsBefore * sharesAfter >= assetsAfter * sharesBefore;
+}

--- a/certora/specs/Health.spec
+++ b/certora/specs/Health.spec
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function totalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function totalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function lastUpdate(MoolahHarness.Id) external returns uint256 envfree;
+    function borrowShares(MoolahHarness.Id, address) external returns uint256 envfree;
+    function collateral(MoolahHarness.Id, address) external returns uint256 envfree;
+    function isAuthorized(address, address user) external returns bool envfree;
+    function lastUpdate(MoolahHarness.Id) external returns uint256 envfree;
+
+    function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+    function isHealthy(MoolahHarness.MarketParams, address user) external returns bool envfree;
+
+    function _.price() external => CONSTANT;
+    function UtilsLib.min(uint256 a, uint256 b) internal returns uint256 => summaryMin(a, b);
+}
+
+function summaryMin(uint256 a, uint256 b) returns uint256 {
+    return a < b ? a : b;
+}
+
+// Check that users cannot lose collateral by unauthorized parties except in case of an unhealthy position.
+rule healthyUserCannotLoseCollateral(env e, method f, calldataarg data)
+filtered { f -> !f.isView && !isExcludedOp(f) }
+{
+    MoolahHarness.MarketParams marketParams;
+    MoolahHarness.Id id = Util.libId(marketParams);
+    address user;
+
+    // Assume that the e.msg.sender is not authorized.
+    require !isAuthorized(user, e.msg.sender);
+    require user != e.msg.sender;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+    // Assume that the user is healthy.
+    require isHealthy(marketParams, user);
+
+    uint256 collateralBefore = collateral(id, user);
+
+    f(e, data);
+
+    assert collateral(id, user) >= collateralBefore;
+}
+
+// Check that users without collateral also have no debt.
+// This invariant ensures that bad debt realization cannot be bypassed.
+invariant alwaysCollateralized(MoolahHarness.Id id, address borrower)
+    borrowShares(id, borrower) != 0 => collateral(id, borrower) != 0
+    filtered { f -> !isExcludedOp(f) }
+
+// Checks that passing a seized amount input to liquidate leads to repaid shares S and repaid amount A such that liquidating instead with shares S also repays the amount A.
+rule liquidateEquivalentInputDebtAndInputCollateral(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    // Assume no interest accrual to ease the verification.
+    require lastUpdate(id) == e.block.timestamp;
+
+    storage init = lastStorage;
+    uint256 sharesBefore = borrowShares(id, borrower);
+
+    uint256 repaidAssets1;
+    _, repaidAssets1 = liquidate(e, marketParams, borrower, seizedAssets, 0, data);
+    // Omit the bad debt realization case.
+    require collateral(id, borrower) != 0;
+    uint256 sharesAfter = borrowShares(id, borrower);
+    uint256 repaidShares1 = assert_uint256(sharesBefore - sharesAfter);
+
+    uint256 repaidAssets2;
+    _, repaidAssets2 = liquidate(e, marketParams, borrower, 0, repaidShares1, data) at init;
+
+    assert repaidAssets1 == repaidAssets2;
+}

--- a/certora/specs/Health.spec
+++ b/certora/specs/Health.spec
@@ -18,8 +18,16 @@ methods {
     function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
     function isHealthy(MoolahHarness.MarketParams, address user) external returns bool envfree;
 
-    function _.price() external => CONSTANT;
+    function _.peek(address token) external => ghostPrice[calledContract][token] expect uint256;
+    function _.decimals() external => ghostDecimals[calledContract] expect uint8;
     function UtilsLib.min(uint256 a, uint256 b) internal returns uint256 => summaryMin(a, b);
+}
+
+// Oracle price per (oracle, token), stable within a rule.
+ghost mapping(address => mapping(address => uint256)) ghostPrice;
+
+ghost mapping(address => uint8) ghostDecimals {
+    axiom forall address token. ghostDecimals[token] <= 18;
 }
 
 function summaryMin(uint256 a, uint256 b) returns uint256 {

--- a/certora/specs/LibSummary.spec
+++ b/certora/specs/LibSummary.spec
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function Util.libMulDivUp(uint256, uint256, uint256) external returns uint256 envfree;
+    function Util.libMulDivDown(uint256, uint256, uint256) external returns uint256 envfree;
+    function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+    function Util.refId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+    function Util.libMin(uint256 x, uint256 y) external returns uint256 envfree;
+}
+
+// Check the summary of MathLib.mulDivUp required by ExchangeRate.spec
+rule checkSummaryMulDivUp(uint256 x, uint256 y, uint256 d) {
+    uint256 result = Util.libMulDivUp(x, y, d);
+    assert result * d >= x * y;
+}
+
+// Check the summary of MathLib.mulDivDown required by ExchangeRate.spec
+rule checkSummaryMulDivDown(uint256 x, uint256 y, uint256 d) {
+    uint256 result = Util.libMulDivDown(x, y, d);
+    assert result * d <= x * y;
+}
+
+// Check the summary of MarketParamsLib.id required by Liveness.spec
+rule checkSummaryId(MoolahHarness.MarketParams marketParams) {
+    assert Util.libId(marketParams) == Util.refId(marketParams);
+}
+
+rule checkSummaryMin(uint256 x, uint256 y) {
+    uint256 refMin = x < y ? x : y;
+    assert Util.libMin(x, y) == refMin;
+}

--- a/certora/specs/LiquidateBuffer.spec
+++ b/certora/specs/LiquidateBuffer.spec
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function lastUpdate(MoolahHarness.Id) external returns (uint256) envfree;
+    function borrowShares(MoolahHarness.Id, address) external returns (uint256) envfree;
+    function collateral(MoolahHarness.Id, address) external returns (uint256) envfree;
+    function totalBorrowShares(MoolahHarness.Id) external returns (uint256) envfree;
+    function totalBorrowAssets(MoolahHarness.Id) external returns (uint256) envfree;
+    function virtualTotalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function virtualTotalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+
+    function Util.libId(MoolahHarness.MarketParams) external returns (MoolahHarness.Id) envfree;
+    function Util.lif(uint256) external returns (uint256) envfree;
+    function Util.oraclePriceScale() external returns (uint256) envfree;
+    function Util.wad() external returns (uint256) envfree;
+
+    function Moolah._isHealthy(MoolahHarness.MarketParams memory, MoolahHarness.Id, address) internal returns (bool) => NONDET;
+    function Moolah._accrueInterest(MoolahHarness.MarketParams memory, MoolahHarness.Id) internal => NONDET;
+
+    // Moolah prices collateral via _getPrice (peek-based PriceLib), not Morpho's oracle.price().
+    // Summarize it to a single constant so the liquidation price matches the rule's precondition.
+    function MoolahHarness._getPrice(MoolahHarness.MarketParams memory, address) internal returns (uint256) => constantPrice;
+}
+
+persistent ghost uint256 constantPrice;
+
+// Check that for a position with LTV < 1 / LIF, its health improves after a liquidation.
+rule liquidateImprovePosition(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssetsInput, uint256 repaidSharesInput, bytes data) {
+    // Assume no callback.
+    require data.length == 0;
+
+    MoolahHarness.Id id = Util.libId(marketParams);
+
+    // We place ourselves at the last block for getting the following variables.
+    require lastUpdate(id) == e.block.timestamp;
+
+    uint256 borrowerShares = borrowShares(id, borrower);
+    // Safe require because of the sumBorrowSharesCorrect invariant.
+    require borrowerShares <= totalBorrowShares(id);
+
+    uint256 borrowerCollateral = collateral(id, borrower);
+    uint256 lif = Util.lif(marketParams.lltv);
+    uint256 virtualTotalAssets = virtualTotalBorrowAssets(id);
+    uint256 virtualTotalShares = virtualTotalBorrowShares(id);
+
+    // Let borrowerAssets = borrowerShares * virtualTotalAssets / virtualTotalShares
+    // and borrowerCollateralQuoted = borrowerCollateral * constantPrice / Util.oraclePriceScale()
+    // then the following line is the assumption borrowerAssets / borrowerCollateralQuoted < 1 / LIF.
+    require borrowerCollateral * constantPrice * virtualTotalShares * Util.wad() > borrowerShares * Util.oraclePriceScale() * virtualTotalAssets * lif;
+
+    uint256 seizedAssets;
+    (seizedAssets, _) = liquidate(e, marketParams, borrower, seizedAssetsInput, repaidSharesInput, data);
+
+    uint256 newBorrowerShares = borrowShares(id, borrower);
+    uint256 newBorrowerCollateral = collateral(id, borrower);
+    uint256 repaidShares = assert_uint256(borrowerShares - newBorrowerShares);
+    uint256 newVirtualTotalAssets = virtualTotalBorrowAssets(id);
+    uint256 newVirtualTotalShares = virtualTotalBorrowShares(id);
+
+    // Hint for the prover to show that there is no bad debt realization.
+    assert newBorrowerCollateral != 0;
+    // Hint for the prover about the ratio used to close the position.
+    assert repaidShares * borrowerCollateral >= seizedAssets * borrowerShares;
+    // Prove that the ratio of shares of debt over collateral is smaller after the liquidation.
+    assert borrowerShares * newBorrowerCollateral >= newBorrowerShares * borrowerCollateral;
+    // Prove that the value of borrow shares is smaller after the liquidation.
+    // Note that this is only shown for the case where there are still borrow positions on the markets.
+    assert totalBorrowAssets(id) > 0 => newVirtualTotalShares * virtualTotalAssets >= newVirtualTotalAssets * virtualTotalShares;
+}

--- a/certora/specs/Liveness.spec
+++ b/certora/specs/Liveness.spec
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+    function supplyShares(MoolahInternalAccess.Id, address) external returns uint256 envfree;
+    function borrowShares(MoolahInternalAccess.Id, address) external returns uint256 envfree;
+    function collateral(MoolahInternalAccess.Id, address) external returns uint256 envfree;
+    function totalSupplyAssets(MoolahInternalAccess.Id) external returns uint256 envfree;
+    function totalSupplyShares(MoolahInternalAccess.Id) external returns uint256 envfree;
+    function totalBorrowAssets(MoolahInternalAccess.Id) external returns uint256 envfree;
+    function totalBorrowShares(MoolahInternalAccess.Id) external returns uint256 envfree;
+    function fee(MoolahInternalAccess.Id) external returns uint256 envfree;
+    function lastUpdate(MoolahInternalAccess.Id) external returns uint256 envfree;
+    function nonce(address) external returns uint256 envfree;
+    function isAuthorized(address, address) external returns bool envfree;
+    function paused() external returns bool envfree;
+    function reentrancyGuardEntered_() external returns bool envfree;
+
+    function Util.libId(MoolahInternalAccess.MarketParams) external returns MoolahInternalAccess.Id envfree;
+    function Util.refId(MoolahInternalAccess.MarketParams) external returns MoolahInternalAccess.Id envfree;
+
+    function _._accrueInterest(MoolahInternalAccess.MarketParams memory marketParams, MoolahInternalAccess.Id id) internal with (env e) => summaryAccrueInterest(e, marketParams, id) expect void;
+
+    function MarketParamsLib.id(MoolahInternalAccess.MarketParams memory marketParams) internal returns MoolahInternalAccess.Id => summaryId(marketParams);
+    function SafeTransferLib.safeTransfer(address token, address to, uint256 value) internal => summarySafeTransferFrom(token, currentContract, to, value);
+    function SafeTransferLib.safeTransferFrom(address token, address from, address to, uint256 value) internal => summarySafeTransferFrom(token, from, to, value);
+}
+
+persistent ghost mapping(address => mathint) balance {
+    init_state axiom (forall address token. balance[token] == 0);
+}
+
+function summaryId(MoolahInternalAccess.MarketParams marketParams) returns MoolahInternalAccess.Id {
+    return Util.refId(marketParams);
+}
+
+function summarySafeTransferFrom(address token, address from, address to, uint256 amount) {
+    if (from == currentContract) {
+        // Safe require because the reference implementation would revert.
+        balance[token] = require_uint256(balance[token] - amount);
+    }
+    if (to == currentContract) {
+        // Safe require because the reference implementation would revert.
+        balance[token] = require_uint256(balance[token] + amount);
+    }
+}
+
+function min(mathint a, mathint b) returns mathint {
+    return a < b ? a : b;
+}
+
+// Assume no fee.
+// Summarize the accrue interest to avoid having to deal with reverts with absurdly high borrow rates.
+function summaryAccrueInterest(env e, MoolahInternalAccess.MarketParams marketParams, MoolahInternalAccess.Id id) {
+    // Safe require because timestamps cannot realistically be that large.
+    require e.block.timestamp < 2^128;
+    if (e.block.timestamp != lastUpdate(id) && totalBorrowAssets(id) != 0) {
+        uint128 interest;
+        uint256 supply = totalSupplyAssets(id);
+        // Safe require because tokens should have bounded supply.
+        require interest + supply < 2^128;
+        uint256 borrow = totalBorrowAssets(id);
+        // Safe require because it is verified in borrowLessThanSupply.
+        require borrow <= supply;
+        increaseInterest(e, id, interest);
+    }
+
+    update(e, id, e.block.timestamp);
+}
+
+definition isCreated(MoolahInternalAccess.Id id) returns bool =
+    lastUpdate(id) != 0;
+
+// Check that tokens and shares are properly accounted following a supply.
+rule supplyChangesTokensAndShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Safe require because Morpho cannot call such functions by itself.
+    require currentContract != e.msg.sender;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint sharesBefore = supplyShares(id, onBehalf);
+    mathint balanceBefore = balance[marketParams.loanToken];
+    mathint liquidityBefore = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    uint256 suppliedAssets;
+    uint256 suppliedShares;
+    suppliedAssets, suppliedShares = supply(e, marketParams, assets, shares, onBehalf, data);
+
+    mathint sharesAfter = supplyShares(id, onBehalf);
+    mathint balanceAfter = balance[marketParams.loanToken];
+    mathint liquidityAfter = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    assert assets != 0 => suppliedAssets == assets;
+    assert shares != 0 => suppliedShares == shares;
+    assert sharesAfter == sharesBefore + suppliedShares;
+    assert balanceAfter == balanceBefore + suppliedAssets;
+    assert liquidityAfter == liquidityBefore + suppliedAssets;
+}
+
+// Check that you can supply non-zero tokens by passing shares.
+rule canSupplyByPassingShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 shares, address onBehalf, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    uint256 suppliedAssets;
+    suppliedAssets, _ = supply(e, marketParams, 0, shares, onBehalf, data);
+
+    satisfy suppliedAssets != 0;
+}
+
+// Check that tokens and shares are properly accounted following a withdraw.
+rule withdrawChangesTokensAndShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Assume that Morpho is not the receiver.
+    require currentContract != receiver;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint sharesBefore = supplyShares(id, onBehalf);
+    mathint balanceBefore = balance[marketParams.loanToken];
+    mathint liquidityBefore = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    uint256 withdrawnAssets;
+    uint256 withdrawnShares;
+    withdrawnAssets, withdrawnShares = withdraw(e, marketParams, assets, shares, onBehalf, receiver);
+
+    mathint sharesAfter = supplyShares(id, onBehalf);
+    mathint balanceAfter = balance[marketParams.loanToken];
+    mathint liquidityAfter = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    assert assets != 0 => withdrawnAssets == assets;
+    assert shares != 0 => withdrawnShares == shares;
+    assert sharesAfter == sharesBefore - withdrawnShares;
+    assert balanceAfter == balanceBefore - withdrawnAssets;
+    assert liquidityAfter == liquidityBefore - withdrawnAssets;
+}
+
+// Check that you can withdraw non-zero tokens by passing shares.
+rule canWithdrawByPassingShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 shares, address onBehalf, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    uint256 withdrawnAssets;
+    withdrawnAssets, _ = withdraw(e, marketParams, 0, shares, onBehalf, receiver);
+
+    satisfy withdrawnAssets != 0;
+}
+
+// Check that tokens and shares are properly accounted following a borrow.
+rule borrowChangesTokensAndShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Assume that Morpho is not the receiver.
+    require currentContract != receiver;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint sharesBefore = borrowShares(id, onBehalf);
+    mathint balanceBefore = balance[marketParams.loanToken];
+    mathint liquidityBefore = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    uint256 borrowedAssets;
+    uint256 borrowedShares;
+    borrowedAssets, borrowedShares = borrow(e, marketParams, assets, shares, onBehalf, receiver);
+
+    mathint sharesAfter = borrowShares(id, onBehalf);
+    mathint balanceAfter = balance[marketParams.loanToken];
+    mathint liquidityAfter = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    assert assets != 0 => borrowedAssets == assets;
+    assert shares != 0 => borrowedShares == shares;
+    assert sharesAfter == sharesBefore + borrowedShares;
+    assert balanceAfter == balanceBefore - borrowedAssets;
+    assert liquidityAfter == liquidityBefore - borrowedAssets;
+}
+
+// Check that you can borrow non-zero tokens by passing shares.
+rule canBorrowByPassingShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 shares, address onBehalf, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    uint256 borrowedAssets;
+    borrowedAssets, _ = borrow(e, marketParams, 0, shares, onBehalf, receiver);
+
+    satisfy borrowedAssets != 0;
+}
+
+// Check that tokens and shares are properly accounted following a repay.
+rule repayChangesTokensAndShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Safe require because Morpho cannot call such functions by itself.
+    require currentContract != e.msg.sender;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint sharesBefore = borrowShares(id, onBehalf);
+    mathint balanceBefore = balance[marketParams.loanToken];
+    mathint liquidityBefore = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    mathint borrowAssetsBefore = totalBorrowAssets(id);
+
+    uint256 repaidAssets;
+    uint256 repaidShares;
+    repaidAssets, repaidShares = repay(e, marketParams, assets, shares, onBehalf, data);
+
+    mathint sharesAfter = borrowShares(id, onBehalf);
+    mathint balanceAfter = balance[marketParams.loanToken];
+    mathint liquidityAfter = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    assert assets != 0 => repaidAssets == assets;
+    assert shares != 0 => repaidShares == shares;
+    assert sharesAfter == sharesBefore - repaidShares;
+    assert balanceAfter == balanceBefore + repaidAssets;
+    // Taking the min to handle the zeroFloorSub in the code.
+    assert liquidityAfter == liquidityBefore + min(repaidAssets, borrowAssetsBefore);
+}
+
+// Check that you can repay non-zero tokens by passing shares.
+rule canRepayByPassingShares(env e, MoolahInternalAccess.MarketParams marketParams, uint256 shares, address onBehalf, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    uint256 repaidAssets;
+    repaidAssets, _ = repay(e, marketParams, 0, shares, onBehalf, data);
+
+    satisfy repaidAssets != 0;
+}
+
+// Check that tokens and balances are properly accounted following a supplyCollateral.
+rule supplyCollateralChangesTokensAndBalance(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, address onBehalf, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Safe require because Morpho cannot call such functions by itself.
+    require currentContract != e.msg.sender;
+
+    mathint collateralBefore = collateral(id, onBehalf);
+    mathint balanceBefore = balance[marketParams.collateralToken];
+
+    supplyCollateral(e, marketParams, assets, onBehalf, data);
+
+    mathint collateralAfter = collateral(id, onBehalf);
+    mathint balanceAfter = balance[marketParams.collateralToken];
+
+    assert collateralAfter == collateralBefore + assets;
+    assert balanceAfter == balanceBefore + assets;
+}
+
+// Check that tokens and balances are properly accounted following a withdrawCollateral.
+rule withdrawCollateralChangesTokensAndBalance(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, address onBehalf, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Assume that Morpho is not the receiver.
+    require currentContract != receiver;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint collateralBefore = collateral(id, onBehalf);
+    mathint balanceBefore = balance[marketParams.collateralToken];
+
+    withdrawCollateral(e, marketParams, assets, onBehalf, receiver);
+
+    mathint collateralAfter = collateral(id, onBehalf);
+    mathint balanceAfter = balance[marketParams.collateralToken];
+
+    assert collateralAfter == collateralBefore - assets;
+    assert balanceAfter == balanceBefore - assets;
+}
+
+// Check that tokens are properly accounted following a liquidate.
+rule liquidateChangesTokens(env e, MoolahInternalAccess.MarketParams marketParams, address borrower, uint256 seized, uint256 repaidShares, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Safe require because Morpho cannot call such functions by itself.
+    require currentContract != e.msg.sender;
+    // Assumption to simplify the balance specification in the rest of this rule.
+    require marketParams.loanToken != marketParams.collateralToken;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    mathint collateralBefore = collateral(id, borrower);
+    mathint balanceLoanBefore = balance[marketParams.loanToken];
+    mathint balanceCollateralBefore = balance[marketParams.collateralToken];
+    mathint liquidityBefore = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    mathint borrowLoanAssetsBefore = totalBorrowAssets(id);
+
+    uint256 seizedAssets;
+    uint256 repaidAssets;
+    seizedAssets, repaidAssets = liquidate(e, marketParams, borrower, seized, repaidShares, data);
+
+    mathint collateralAfter = collateral(id, borrower);
+    mathint balanceLoanAfter = balance[marketParams.loanToken];
+    mathint balanceCollateralAfter = balance[marketParams.collateralToken];
+    mathint liquidityAfter = totalSupplyAssets(id) - totalBorrowAssets(id);
+
+    assert seized != 0 => seizedAssets == seized;
+    assert collateralBefore > to_mathint(seizedAssets) => collateralAfter == collateralBefore - seizedAssets;
+    assert balanceLoanAfter == balanceLoanBefore + repaidAssets;
+    assert balanceCollateralAfter == balanceCollateralBefore - seizedAssets;
+    // Taking the min to handle the zeroFloorSub in the code.
+    assert liquidityAfter == liquidityBefore + min(repaidAssets, borrowLoanAssetsBefore);
+}
+
+// Check that you can liquidate non-zero tokens by passing shares.
+rule canLiquidateByPassingShares(env e, MoolahInternalAccess.MarketParams marketParams, address borrower, uint256 repaidShares, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    uint256 seizedAssets;
+    uint256 repaidAssets;
+    seizedAssets, repaidAssets = liquidate(e, marketParams, borrower, 0, repaidShares,  data);
+
+    satisfy seizedAssets != 0 && repaidAssets != 0;
+}
+
+// Check that nonce and authorization are properly updated with calling setAuthorizationWithSig.
+rule setAuthorizationWithSigChangesNonceAndAuthorizes(env e, MoolahInternalAccess.Authorization authorization, MoolahInternalAccess.Signature signature) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    mathint nonceBefore = nonce(authorization.authorizer);
+
+    setAuthorizationWithSig(e, authorization, signature);
+
+    mathint nonceAfter = nonce(authorization.authorizer);
+
+    assert nonceAfter == nonceBefore + 1;
+    assert isAuthorized(authorization.authorizer, authorization.authorized) == authorization.isAuthorized;
+}
+
+// Check that one can always repay the debt in full.
+rule canRepayAll(env e, MoolahInternalAccess.MarketParams marketParams, uint256 shares, bytes data) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Assume no callback, which still allows to repay all.
+    require data.length == 0;
+
+    // Assume a full repay.
+    require shares == borrowShares(id, e.msg.sender);
+    // Omit sanity checks.
+    require isCreated(id);
+    require e.msg.sender != 0;
+    require e.msg.value == 0;
+    require shares > 0;
+    // Safe require because of the noTimeTravel rule.
+    require lastUpdate(id) <= e.block.timestamp;
+    // Safe require because of the sumBorrowSharesCorrect invariant.
+    require shares <= totalBorrowShares(id);
+
+    // Accrue interest first to ensure that the accrued interest is reasonable (next require).
+    // Safe because of the AccrueInterest.repayAccruesInterest rule
+    summaryAccrueInterest(e, marketParams, id);
+
+    // Assume that the invariant about tokens total supply is respected.
+    require totalBorrowAssets(id) < 10^35;
+
+    repay@withrevert(e, marketParams, 0, shares, e.msg.sender, data);
+
+    assert !lastReverted;
+}
+
+// Check the one can always withdraw all, under the condition that there are no outstanding debt on the market.
+rule canWithdrawAll(env e, MoolahInternalAccess.MarketParams marketParams, uint256 shares, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Assume a full withdraw.
+    require shares == supplyShares(id, e.msg.sender);
+    // Omit sanity checks.
+    require isCreated(id);
+    require e.msg.sender != 0;
+    require receiver != 0;
+    require e.msg.value == 0;
+    require shares > 0;
+    // Assume no outstanding debt on the market.
+    require totalBorrowAssets(id) == 0;
+    // Safe require because of the noTimeTravel rule.
+    require lastUpdate(id) <= e.block.timestamp;
+    // Safe require because of the sumSupplySharesCorrect invariant.
+    require shares <= totalSupplyShares(id);
+
+    withdraw@withrevert(e, marketParams, 0, shares, e.msg.sender, receiver);
+
+    assert !lastReverted;
+}
+
+// Check that a user can always withdraw all, under the condition that this user does not have an outstanding debt.
+// Combined with the canRepayAll rule, this ensures that a borrower can always fully exit a market.
+rule canWithdrawCollateralAll(env e, MoolahInternalAccess.MarketParams marketParams, uint256 assets, address receiver) {
+    // Assume a normal between-transactions state (not paused, reentrancy guard not entered);
+    // otherwise the upgradeable guards revert from arbitrary uninitialized storage.
+    require !paused();
+    require !reentrancyGuardEntered_();
+    MoolahInternalAccess.Id id = Util.libId(marketParams);
+
+    // Ensure a full withdrawCollateral.
+    require assets == collateral(id, e.msg.sender);
+    // Omit sanity checks.
+    require isCreated(id);
+    require receiver != 0;
+    require e.msg.value == 0;
+    require assets > 0;
+    // Safe require because of the noTimeTravel rule.
+    require lastUpdate(id) <= e.block.timestamp;
+    // Assume that the user does not have an outstanding debt.
+    require borrowShares(id, e.msg.sender) == 0;
+
+    withdrawCollateral@withrevert(e, marketParams, assets, e.msg.sender, receiver);
+
+    assert !lastReverted;
+}

--- a/certora/specs/ProxyFilters.spec
+++ b/certora/specs/ProxyFilters.spec
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared method filters for Moolah's proxy / upgradeability machinery.
+//
+// Unlike Morpho Blue, Moolah is a UUPS-upgradeable contract (UUPSUpgradeable +
+// AccessControlEnumerableUpgradeable + Pausable + ReentrancyGuard). The functions captured
+// below either replace the implementation or reset contract state, so they must be excluded
+// from generic parametric (`method f`) invariants — otherwise the prover surfaces spurious
+// counterexamples in which an upgrade/initialize havocs the whole state. These operations are
+// instead checked by dedicated rules (see AccessControl.spec).
+//
+//   - upgradeToAndCall    : UUPS upgrade entry point; delegatecalls a new implementation.
+//   - initialize          : one-shot initializer; would reset roles/state.
+//   - setUpInitializedState: harness-only helper (MoolahHarness) that seeds an initialized
+//                            state for verification; not part of Moolah.
+//   - authorizeUpgrade_   : harness-only wrapper over _authorizeUpgrade; not part of Moolah.
+
+definition isUpgradeOrInit(method f) returns bool =
+    f.selector == sig:upgradeToAndCall(address,bytes).selector ||
+    f.selector == sig:initialize(address,address,address,uint256).selector ||
+    f.selector == sig:setUpInitializedState(address,address,address,uint256).selector ||
+    f.selector == sig:authorizeUpgrade_(address).selector;
+
+// Role administration inherited from AccessControlEnumerableUpgradeable. Filter these out of
+// accounting/health invariants (they never touch market/position state), but keep them in
+// rules that reason about access control itself.
+definition isAccessControl(method f) returns bool =
+    f.selector == sig:grantRole(bytes32,address).selector ||
+    f.selector == sig:revokeRole(bytes32,address).selector ||
+    f.selector == sig:renounceRole(bytes32,address).selector;
+
+// Broker exclusion. Moolah lets a market be managed by a LendingBroker: when a broker is set
+// for a market id, the broker REPLACES the normal supply/borrow/repay flow and the health
+// computation pulls the position's debt from the broker (PriceLib._getBrokerTotalDebt) via an
+// external call. Verifying broker-managed markets is out of scope for now (large surface, many
+// external calls → prover havoc). We exclude brokers in two ways:
+//   1. isBrokerFunction filters the broker-only entry points out of parametric `method f` rules.
+//   2. The Sload hook below assumes no market has a broker, so every broker branch in
+//      borrow/repay/_isHealthy/_getPrice takes the non-broker path and makes no broker calls.
+// (Providers use the same pattern and can be excluded analogously if needed.)
+definition isBrokerFunction(method f) returns bool =
+    f.selector == sig:setMarketBroker(MoolahHarness.Id, address, bool).selector ||
+    f.selector == sig:liquidateBrokerPosition(MoolahHarness.MarketParams, address, uint256).selector;
+
+hook Sload address broker brokers[KEY MoolahHarness.Id id] {
+    require broker == 0;
+}
+
+// Provider exclusion. Moolah also lets a Provider sit in front of a market's loan/collateral
+// token: when providers[id][token] is set, the provider may act in place of the user in
+// borrow/withdraw/supplyCollateral (authorization branches, no external call) and, in
+// liquidate, Moolah calls IProvider(provider).liquidate(id, borrower) (an external call). We
+// scope provider-managed markets out the same way as brokers:
+//   1. isProviderFunction filters the admin entry point (setProvider, which also calls
+//      IProvider(provider).TOKEN()) out of parametric `method f` rules.
+//   2. The Sload hook below assumes no market has a provider, so the provider branches take the
+//      standard (non-provider) authorization path and liquidate makes no provider call.
+definition isProviderFunction(method f) returns bool =
+    f.selector == sig:setProvider(MoolahHarness.Id, address, bool).selector;
+
+hook Sload address provider providers[KEY MoolahHarness.Id id][KEY address token] {
+    require provider == 0;
+}
+
+// Whitelist batch admin: loops over dynamic arrays and only touches the liquidation whitelist
+// (never supply/borrow/collateral accounting). Excluding it keeps the generic rules/invariants
+// free of loop-unwinding noise — the prover would otherwise unroll its nested loops and fail the
+// unwinding condition (see also "optimistic_loop" in the confs, which covers the remaining
+// library loops such as EnumerableSet).
+definition isWhitelistBatch(method f) returns bool =
+    f.selector == sig:batchToggleLiquidationWhitelist(MoolahHarness.Id[], address[][], bool).selector;
+
+// Combined exclusion: proxy/upgrade/init + broker + provider entry points + whitelist batch. Use
+// this in the `filtered` clause of every parametric rule AND every invariant — invariants check
+// preservation across all methods, so without it the prover runs upgradeToAndCall/initialize/
+// setMarketBroker/setProvider/liquidateBrokerPosition/batchToggleLiquidationWhitelist against the
+// invariant and reports spurious havoc breaks (or loop-unwinding failures).
+definition isExcludedOp(method f) returns bool =
+    isUpgradeOrInit(f) || isBrokerFunction(f) || isProviderFunction(f) || isWhitelistBatch(f);

--- a/certora/specs/Reentrancy.spec
+++ b/certora/specs/Reentrancy.spec
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import "ProxyFilters.spec";
+
+methods {
+
+    function _.borrowRate(MoolahHarness.MarketParams marketParams, MoolahHarness.Market) external => summaryBorrowRate() expect uint256;
+}
+
+persistent ghost bool delegateCall;
+persistent ghost bool callIsBorrowRate;
+// True when storage has been accessed with either a SSTORE or a SLOAD.
+persistent ghost bool hasAccessedStorage;
+// True when a CALL has been done after storage has been accessed.
+persistent ghost bool hasCallAfterAccessingStorage;
+// True when storage has been accessed, after which an external call is made, followed by accessing storage again.
+persistent ghost bool hasReentrancyUnsafeCall;
+
+function summaryBorrowRate() returns uint256 {
+    uint256 result;
+    callIsBorrowRate = true;
+    return result;
+}
+
+hook ALL_SSTORE(uint loc, uint v) {
+    hasAccessedStorage = true;
+    hasReentrancyUnsafeCall = hasCallAfterAccessingStorage;
+}
+
+hook ALL_SLOAD(uint loc) uint v {
+    hasAccessedStorage = true;
+    hasReentrancyUnsafeCall = hasCallAfterAccessingStorage;
+}
+
+hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    if (callIsBorrowRate) {
+        // The calls to borrow rate are trusted and don't count.
+        callIsBorrowRate = false;
+    } else {
+        hasCallAfterAccessingStorage = hasAccessedStorage;
+    }
+}
+
+hook DELEGATECALL(uint g, address addr, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    delegateCall = true;
+}
+
+// Check that no function is accessing storage, then making an external CALL other than to the IRM, and accessing storage again.
+rule reentrancySafe(method f, env e, calldataarg data) filtered { f -> !isExcludedOp(f) } {
+    // Set up the initial state.
+    require !callIsBorrowRate;
+    require !hasAccessedStorage && !hasCallAfterAccessingStorage && !hasReentrancyUnsafeCall;
+    f(e, data);
+    assert !hasReentrancyUnsafeCall;
+}
+
+// Check that the contract performs no delegatecalls outside its UUPS upgrade path.
+// NOTE: unlike Morpho Blue, Moolah is upgradeable, so `upgradeToAndCall` legitimately
+// delegatecalls the new implementation; it is filtered out and checked in AccessControl.spec.
+rule noDelegateCalls(method f, env e, calldataarg data) filtered { f -> !isExcludedOp(f) } {
+    // Set up the initial state.
+    require !delegateCall;
+    f(e, data);
+    assert !delegateCall;
+}

--- a/certora/specs/Reverts.spec
+++ b/certora/specs/Reverts.spec
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Moolah replaces Morpho Blue's single-`owner` permission model with OpenZeppelin
+// AccessControl roles. The admin setters below are guarded by `onlyRole(MANAGER)` (there is no
+// `owner()` / `setOwner`). The owner-model rules have therefore been re-expressed against
+// `hasRole(MANAGER, sender)`, and their original exact `<=>` revert conditions were relaxed to
+// the one-directional `=>` (necessary-condition) form: Moolah's setters may carry extra
+// requires (pausing, role bookkeeping, ...), and `=>` stays sound under any additional revert
+// cause. The reverse direction (authorized + valid input never reverts) is intentionally not
+// asserted here and should be confirmed with the prover when adapting per-rule.
+
+import "ProxyFilters.spec";
+
+using Util as Util;
+
+methods {
+
+    function hasRole(bytes32, address) external returns bool envfree;
+    function MANAGER() external returns bytes32 envfree;
+    function feeRecipient() external returns address envfree;
+    function totalSupplyAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function totalBorrowAssets(MoolahHarness.Id) external returns uint256 envfree;
+    function totalSupplyShares(MoolahHarness.Id) external returns uint256 envfree;
+    function totalBorrowShares(MoolahHarness.Id) external returns uint256 envfree;
+    function lastUpdate(MoolahHarness.Id) external returns uint256 envfree;
+    function isIrmEnabled(address) external returns bool envfree;
+    function isLltvEnabled(uint256) external returns bool envfree;
+    function isAuthorized(address, address) external returns bool envfree;
+    function nonce(address) external returns uint256 envfree;
+
+    function Util.libId(MoolahHarness.MarketParams) external returns MoolahHarness.Id envfree;
+
+    function Util.maxFee() external returns uint256 envfree;
+    function Util.wad() external returns uint256 envfree;
+}
+
+definition isCreated(MoolahHarness.Id id) returns bool =
+    (lastUpdate(id) != 0);
+
+persistent ghost mapping(MoolahHarness.Id => mathint) sumCollateral
+{
+    init_state axiom (forall MoolahHarness.Id id. sumCollateral[id] == 0);
+}
+hook Sstore position[KEY MoolahHarness.Id id][KEY address owner].collateral uint128 newAmount (uint128 oldAmount) {
+    sumCollateral[id] = sumCollateral[id] - oldAmount + newAmount;
+}
+
+definition emptyMarket(MoolahHarness.Id id) returns bool =
+    totalSupplyAssets(id) == 0 &&
+    totalSupplyShares(id) == 0 &&
+    totalBorrowAssets(id) == 0 &&
+    totalBorrowShares(id) == 0 &&
+    sumCollateral[id] == 0;
+
+definition exactlyOneZero(uint256 assets, uint256 shares) returns bool =
+    (assets == 0 && shares != 0) || (assets != 0 && shares == 0);
+
+// This invariant catches bugs when not checking that the market is created with lastUpdate.
+invariant notCreatedIsEmpty(MoolahHarness.Id id)
+    !isCreated(id) => emptyMarket(id)
+    filtered { f -> !isExcludedOp(f) }
+{
+    preserved with (env e) {
+        // Safe require because timestamps cannot realistically be that large.
+        require e.block.timestamp < 2^128;
+    }
+}
+
+// Useful to ensure that authorized parties are not the zero address and so we can omit the sanity check in this case.
+invariant zeroDoesNotAuthorize(address authorized)
+    !isAuthorized(0, authorized)
+    filtered { f -> !isExcludedOp(f) }
+{
+    preserved setAuthorization(address _authorized, bool _newAuthorization) with (env e) {
+        // Safe require because no one controls the zero address.
+        require e.msg.sender != 0;
+    }
+}
+
+// Check the (necessary) revert conditions for the enableIrm function (MANAGER-gated).
+rule enableIrmRevertCondition(env e, address irm) {
+    bool senderIsManager = hasRole(MANAGER(), e.msg.sender);
+    bool oldIsIrmEnabled = isIrmEnabled(irm);
+    enableIrm@withrevert(e, irm);
+    assert e.msg.value != 0 || !senderIsManager || oldIsIrmEnabled => lastReverted;
+}
+
+// Check the (necessary) revert conditions for the enableLltv function (MANAGER-gated).
+rule enableLltvRevertCondition(env e, uint256 lltv) {
+    bool senderIsManager = hasRole(MANAGER(), e.msg.sender);
+    uint256 wad = Util.wad();
+    bool oldIsLltvEnabled = isLltvEnabled(lltv);
+    enableLltv@withrevert(e, lltv);
+    assert !senderIsManager || lltv > wad || oldIsLltvEnabled => lastReverted;
+}
+
+// Check that setFee reverts when its inputs are not validated (MANAGER-gated).
+// setFee can also revert if the accrueInterest reverts.
+rule setFeeInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 newFee) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+    bool wasCreated = isCreated(id);
+    setFee@withrevert(e, marketParams, newFee);
+    bool hasReverted = lastReverted;
+    assert e.msg.value != 0 || !hasRole(MANAGER(), e.msg.sender) || !wasCreated || newFee > Util.maxFee() => hasReverted;
+}
+
+// Check the (necessary) revert conditions for the setFeeRecipient function (MANAGER-gated).
+rule setFeeRecipientRevertCondition(env e, address newFeeRecipient) {
+    bool senderIsManager = hasRole(MANAGER(), e.msg.sender);
+    address oldFeeRecipient = feeRecipient();
+    setFeeRecipient@withrevert(e, newFeeRecipient);
+    assert e.msg.value != 0 || !senderIsManager || newFeeRecipient == oldFeeRecipient => lastReverted;
+}
+
+// Check that createMarket reverts when its input are not validated.
+rule createMarketInputValidation(env e, MoolahHarness.MarketParams marketParams) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+    bool irmEnabled = isIrmEnabled(marketParams.irm);
+    bool lltvEnabled = isLltvEnabled(marketParams.lltv);
+    bool wasCreated = isCreated(id);
+    createMarket@withrevert(e, marketParams);
+    assert e.msg.value != 0 || !irmEnabled || !lltvEnabled || wasCreated => lastReverted;
+}
+
+// Check that supply reverts when its input are not validated.
+rule supplyInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    supply@withrevert(e, marketParams, assets, shares, onBehalf, data);
+    assert !exactlyOneZero(assets, shares) || onBehalf == 0 => lastReverted;
+}
+
+// Check that withdraw reverts when its inputs are not validated.
+rule withdrawInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    // Safe require because no one controls the zero address.
+    require e.msg.sender != 0;
+    requireInvariant zeroDoesNotAuthorize(e.msg.sender);
+    withdraw@withrevert(e, marketParams, assets, shares, onBehalf, receiver);
+    assert !exactlyOneZero(assets, shares) || onBehalf == 0 || receiver == 0 => lastReverted;
+}
+
+// Check that borrow reverts when its inputs are not validated.
+rule borrowInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) {
+    // Safe require because no one controls the zero address.
+    require e.msg.sender != 0;
+    requireInvariant zeroDoesNotAuthorize(e.msg.sender);
+    borrow@withrevert(e, marketParams, assets, shares, onBehalf, receiver);
+    assert !exactlyOneZero(assets, shares) || onBehalf == 0  || receiver == 0 => lastReverted;
+}
+
+// Check that repay reverts when its inputs are not validated.
+rule repayInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) {
+    repay@withrevert(e, marketParams, assets, shares, onBehalf, data);
+    assert !exactlyOneZero(assets, shares) || onBehalf == 0 => lastReverted;
+}
+
+// Check that supplyCollateral reverts when its inputs are not validated.
+rule supplyCollateralInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 assets, address onBehalf, bytes data) {
+    supplyCollateral@withrevert(e, marketParams, assets, onBehalf, data);
+    assert assets == 0 || onBehalf == 0 => lastReverted;
+}
+
+// Check that withdrawCollateral reverts when its inputs are not validated.
+rule withdrawCollateralInputValidation(env e, MoolahHarness.MarketParams marketParams, uint256 assets, address onBehalf, address receiver) {
+    // Safe require because no one controls the zero address.
+    require e.msg.sender != 0;
+    requireInvariant zeroDoesNotAuthorize(e.msg.sender);
+    withdrawCollateral@withrevert(e, marketParams, assets, onBehalf, receiver);
+    assert assets == 0 || onBehalf == 0 || receiver == 0 => lastReverted;
+}
+
+// Check that flashLoan reverts when its inputs are not validated.
+rule flashLoanInputValidation(env e, address token, uint256 assets, bytes data) {
+    flashLoan@withrevert(e, token, assets, data);
+    assert assets == 0 => lastReverted;
+}
+
+// Check that liquidate reverts when its inputs are not validated.
+rule liquidateInputValidation(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, uint256 repaidShares, bytes data) {
+    liquidate@withrevert(e, marketParams, borrower, seizedAssets, repaidShares, data);
+    assert !exactlyOneZero(seizedAssets, repaidShares) => lastReverted;
+}
+
+// Check that setAuthorizationWithSig reverts when its inputs are not validated.
+rule setAuthorizationWithSigInputValidation(env e, MoolahHarness.Authorization authorization, MoolahHarness.Signature signature) {
+    uint256 nonceBefore = nonce(authorization.authorizer);
+    setAuthorizationWithSig@withrevert(e, authorization, signature);
+    assert e.block.timestamp > authorization.deadline || authorization.nonce != nonceBefore => lastReverted;
+}
+
+// Check that accrueInterest reverts when its inputs are not validated.
+rule accrueInterestInputValidation(env e, MoolahHarness.MarketParams marketParams) {
+    bool wasCreated = isCreated(Util.libId(marketParams));
+    accrueInterest@withrevert(e, marketParams);
+    assert !wasCreated => lastReverted;
+}

--- a/certora/specs/StayHealthy.spec
+++ b/certora/specs/StayHealthy.spec
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import "Health.spec";
+import "ProxyFilters.spec";
+
+function mulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
+    assert d != 0;
+    return assert_uint256((x * y + (d - 1)) / d);
+}
+
+// Check that without accruing interest, no interaction can put an healthy account into an unhealthy one.
+// The liquidate function times out in this rule, but has been checked separately.
+rule stayHealthy(env e, method f, calldataarg data)
+filtered {
+    f -> !f.isView && !isExcludedOp(f) &&
+    f.selector != sig:liquidate(MoolahHarness.MarketParams, address, uint256, uint256, bytes).selector
+}
+{
+    MoolahHarness.MarketParams marketParams;
+    MoolahHarness.Id id = Util.libId(marketParams);
+    address user;
+
+    // Assume that the position is healthy before the interaction.
+    require isHealthy(marketParams, user);
+    // Safe require because of the invariants onlyEnabledLltv and lltvSmallerThanWad in ConsistentState.spec.
+    require marketParams.lltv < 10^18;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    f(e, data);
+
+    // Safe require because of the invariant sumBorrowSharesCorrect.
+    require borrowShares(id, user) <= totalBorrowShares(id);
+
+    assert isHealthy(marketParams, user);
+}
+
+// The liquidate case for the stayHealthy rule, assuming no bad debt realization, otherwise it times out.
+// This particular rule makes the following assumptions:
+//   - the market of the liquidation is the market of the user, see the *DifferentMarkets rule,
+//   - there is still some borrow on the market after liquidation, see the *LastBorrow rule.
+rule stayHealthyLiquidate(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+    address user;
+
+    // Assume the invariant initially.
+    require isHealthy(marketParams, user);
+
+    uint256 debtSharesBefore = borrowShares(id, user);
+    uint256 debtAssetsBefore = mulDivUp(debtSharesBefore, virtualTotalBorrowAssets(id), virtualTotalBorrowShares(id));
+    // Safe require because of the invariants onlyEnabledLltv and lltvSmallerThanWad in ConsistentState.spec.
+    require marketParams.lltv < 10^18;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    liquidate(e, marketParams, borrower, seizedAssets, 0, data);
+
+    // Safe require because of the invariant sumBorrowSharesCorrect.
+    require borrowShares(id, user) <= totalBorrowShares(id);
+    // Assume that there is still some borrow on the market after liquidation.
+    require totalBorrowAssets(id) > 0;
+    // Assume no bad debt realization.
+    require collateral(id, borrower) > 0;
+
+    bool stillHealthy = isHealthy(marketParams, user);
+
+    assert user != borrower;
+    assert debtSharesBefore == borrowShares(id, user);
+    assert debtAssetsBefore >= mulDivUp(debtSharesBefore, virtualTotalBorrowAssets(id), virtualTotalBorrowShares(id));
+
+    assert stillHealthy;
+}
+
+rule stayHealthyLiquidateDifferentMarkets(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+    address user;
+    MoolahHarness.MarketParams liquidationMarketParams;
+
+    // Assume the invariant initially.
+    require isHealthy(marketParams, user);
+
+    // Safe require because of the invariants onlyEnabledLltv and lltvSmallerThanWad in ConsistentState.spec.
+    require marketParams.lltv < 10^18;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+    // Assume that the liquidation is on a different market.
+    require liquidationMarketParams != marketParams;
+
+    liquidate(e, liquidationMarketParams, borrower, seizedAssets, 0, data);
+
+    // Safe require because of the invariant sumBorrowSharesCorrect.
+    require borrowShares(id, user) <= totalBorrowShares(id);
+
+    assert isHealthy(marketParams, user);
+}
+
+rule stayHealthyLiquidateLastBorrow(env e, MoolahHarness.MarketParams marketParams, address borrower, uint256 seizedAssets, bytes data) {
+    MoolahHarness.Id id = Util.libId(marketParams);
+    address user;
+
+    // Assume the invariant initially.
+    require isHealthy(marketParams, user);
+
+    // Safe require because of the invariants onlyEnabledLltv and lltvSmallerThanWad in ConsistentState.spec.
+    require marketParams.lltv < 10^18;
+    // Assumption to ensure that no interest is accumulated.
+    require lastUpdate(id) == e.block.timestamp;
+
+    liquidate(e, marketParams, borrower, seizedAssets, 0, data);
+
+    // Safe require because of the invariant sumBorrowSharesCorrect.
+    require borrowShares(id, user) <= totalBorrowShares(id);
+    // Assume that there is no remaining borrow on the market after liquidation.
+    require totalBorrowAssets(id) == 0;
+
+    assert isHealthy(marketParams, user);
+}

--- a/certora/specs/Transfer.spec
+++ b/certora/specs/Transfer.spec
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+methods {
+    function libSafeTransfer(address, address, uint256) external envfree;
+    function libSafeTransferFrom(address, address, address, uint256) external envfree;
+    function balanceOf(address, address) external returns (uint256) envfree;
+    function allowance(address, address, address) external returns (uint256) envfree;
+    function totalSupply(address) external returns (uint256) envfree;
+
+    function _.transfer(address, uint256) external => DISPATCHER(true);
+    function _.transferFrom(address, address, uint256) external => DISPATCHER(true);
+    function _.balanceOf(address) external => DISPATCHER(true);
+    function _.allowance(address, address) external => DISPATCHER(true);
+    function _.totalSupply() external => DISPATCHER(true);
+}
+
+persistent ghost mapping(address => mathint) balance {
+    init_state axiom (forall address token. balance[token] == 0);
+}
+
+function summarySafeTransferFrom(address token, address from, address to, uint256 amount) {
+    if (from == currentContract) {
+        // Safe require because the reference implementation would revert.
+        balance[token] = require_uint256(balance[token] - amount);
+    }
+    if (to == currentContract) {
+        // Safe require because the reference implementation would revert.
+        balance[token] = require_uint256(balance[token] + amount);
+    }
+}
+
+// Check the functional correctness of the summary of safeTransfer.
+rule checkTransferSummary(address token, address to, uint256 amount) {
+    mathint initialBalance = balanceOf(token, currentContract);
+    // Safe require because the total supply is greater than the sum of the balance of any two accounts.
+    require to != currentContract => initialBalance + balanceOf(token, to) <= to_mathint(totalSupply(token));
+
+    libSafeTransfer(token, to, amount);
+    mathint finalBalance = balanceOf(token, currentContract);
+
+    require balance[token] == initialBalance;
+    summarySafeTransferFrom(token, currentContract, to, amount);
+    assert balance[token] == finalBalance;
+}
+
+// Check the functional correctness of the summary of safeTransferFrom.
+rule checkTransferFromSummary(address token, address from, uint256 amount) {
+    mathint initialBalance = balanceOf(token, currentContract);
+    // Safe require because the total supply is greater than the sum of the balance of any two accounts.
+    require from != currentContract => initialBalance + balanceOf(token, from) <= to_mathint(totalSupply(token));
+
+    libSafeTransferFrom(token, from, currentContract, amount);
+    mathint finalBalance = balanceOf(token, currentContract);
+
+    require balance[token] == initialBalance;
+    summarySafeTransferFrom(token, from, currentContract, amount);
+    assert balance[token] == finalBalance;
+}
+
+// Check the revert condition of the summary of safeTransfer.
+rule transferRevertCondition(address token, address to, uint256 amount) {
+    uint256 initialBalance = balanceOf(token, currentContract);
+    uint256 toInitialBalance = balanceOf(token, to);
+    // Safe require because the total supply is greater than the sum of the balance of any two accounts.
+    require to != currentContract => initialBalance + toInitialBalance <= to_mathint(totalSupply(token));
+
+    libSafeTransfer@withrevert(token, to, amount);
+
+    assert lastReverted <=> initialBalance < amount;
+}
+
+// Check the revert condition of the summary of safeTransferFrom.
+rule transferFromRevertCondition(address token, address from, address to, uint256 amount) {
+    uint256 initialBalance = balanceOf(token, from);
+    uint256 toInitialBalance = balanceOf(token, to);
+    uint256 allowance = allowance(token, from, currentContract);
+    // Safe require because the total supply is greater than the sum of the balance of any two accounts.
+    require to != from => initialBalance + toInitialBalance <= to_mathint(totalSupply(token));
+
+    libSafeTransferFrom@withrevert(token, from, to, amount);
+
+    assert lastReverted <=> initialBalance < amount || allowance < amount;
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -23,6 +23,19 @@ force = false
 build_info = false
 extra_output = []
 
+# Compiles the Certora harnesses (certora/helpers, certora/dispatch) against src/.
+# Usage: FOUNDRY_PROFILE=certora forge build
+[profile.certora]
+src = "certora"
+out = "out-certora"
+force = false
+build_info = false
+extra_output = []
+ffi = false
+optimizer_runs = 200
+bytecode_hash = "none"
+evm_version = "cancun"
+
 [rpc_endpoints]
 bsc_testnet = "${BSC_TESTNET_RPC_URL}"
 bsc = "${BSC_RPC_URL}"


### PR DESCRIPTION
## Summary

Migrates the Certora / CVL formal verification suite from the standalone [moolah-certora](https://github.com/lista-dao/moolah-certora) repo (which vendored this repo as a `lib/moolah` submodule) so the proofs live and run in-repo:

- `certora/specs/` — 16 CVL specs migrated from Morpho Blue's Certora suite
- `certora/confs/` — 14 `certoraRun` entry-point configs
- `certora/helpers/` — `MoolahHarness`, `MoolahInternalAccess`, `Util`, `TransferHarness`
- `certora/dispatch/` — ERC20 dispatch mocks (standard / no-revert / USDT-style)
- `certora/README.md` — rule documentation + migration status notes

## Path changes for the in-repo layout

- confs: `lib/moolah/src/...` → `src/...` (OracleMock in `Health.conf` / `StayHealthy.conf`)
- Harnesses already import via the `moolah/` remapping, resolved by the existing `remappings.txt` — no source changes needed
- `foundry.toml`: new `[profile.certora]` — build harnesses with `FOUNDRY_PROFILE=certora forge build` (separate `out-certora/`, does not affect the default build)
- `.gitignore`: ignore `out-certora/` and Certora prover artifacts

## Verification

- `FOUNDRY_PROFILE=certora forge build` — compiles clean
- `certoraRun certora/confs/ConsistentState.conf --compilation_steps_only` and `Health.conf` — CVL compile + typecheck pass
- The source under verification is byte-identical to the moolah-certora submodule pin (`308cc16`): only `MarketFactory.sol` (+5 lines, outside verification scope) differs on master

## Status / caveats

This is a **scaffolding migration**: all confs typecheck, but the rules have not been validated end-to-end on the cloud prover. A first `StayHealthy` run shows most rules violated — expected, since these Morpho Blue rules still need per-rule adaptation to Moolah semantics (PriceLib, minLoanValue, liquidation whitelist, AccessControl entry points). See the Migration status section in `certora/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)