### PR TITLE
chore: add ETH transfer role scripts for ListaRevenueDistributor and MarketFactory

### DIFF
--- a/script/eth/deploy_lendingRevenueDistributor_transferRole.sol
+++ b/script/eth/deploy_lendingRevenueDistributor_transferRole.sol
@@ -1,0 +1,42 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { LendingRevenueDistributor } from "src/revenue/LendingRevenueDistributor.sol";
+
+contract LendingRevenueDistributorTransferRoleDeploy is DeployBase {
+  LendingRevenueDistributor lendingRevenueDistributor =
+    LendingRevenueDistributor(payable(0x0fe5741e8dFe53618c4056F745fad531118640D9)); // ETH ListaRevenueDistributor proxy
+  address marketFactory = 0xA2ff080D4c0b71B6c8796129DD4aCc0B09D7592c; // ETH MarketFactory proxy
+  address managerSafe = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // Manager Safe (3/6)
+
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    console.log("MarketFactory: ", marketFactory);
+    console.log("Manager Safe: ", managerSafe);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // TX 1: Grant DEFAULT_ADMIN_ROLE to MarketFactory (Grant A)
+    lendingRevenueDistributor.grantRole(DEFAULT_ADMIN_ROLE, marketFactory);
+
+    // TX 1b-1: Grant DEFAULT_ADMIN_ROLE to Manager Safe
+    lendingRevenueDistributor.grantRole(DEFAULT_ADMIN_ROLE, managerSafe);
+
+    // TX 1b-2: Deployer renounces its own DEFAULT_ADMIN_ROLE
+    // IMPORTANT: must be AFTER granting Manager Safe, otherwise roles become unmanageable
+    lendingRevenueDistributor.renounceRole(DEFAULT_ADMIN_ROLE, deployer);
+
+    vm.stopBroadcast();
+
+    console.log("TX 1 + TX 1b done!");
+    console.log("Verify:");
+    console.log("  hasRole(DEFAULT_ADMIN_ROLE, MarketFactory) == true");
+    console.log("  hasRole(DEFAULT_ADMIN_ROLE, Manager Safe)  == true");
+    console.log("  hasRole(DEFAULT_ADMIN_ROLE, deployer)      == false");
+  }
+}

--- a/script/eth/deploy_marketFactory_transferRole.sol
+++ b/script/eth/deploy_marketFactory_transferRole.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { MarketFactory } from "../../src/moolah/MarketFactory.sol";
+
+contract MarketFactoryTransferRoleDeploy is DeployBase {
+  MarketFactory marketFactory = MarketFactory(0xA2ff080D4c0b71B6c8796129DD4aCc0B09D7592c);
+  address admin = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61; // ETH TimeLock
+
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // setup roles
+    marketFactory.grantRole(DEFAULT_ADMIN_ROLE, admin);
+    marketFactory.revokeRole(DEFAULT_ADMIN_ROLE, deployer);
+
+    vm.stopBroadcast();
+
+    console.log("setup role done!");
+  }
+}


### PR DESCRIPTION
## Summary

Add two deployer-EOA transfer role scripts for ETH mainnet, matching BSC patterns.

### New Scripts

**1. `script/eth/deploy_lendingRevenueDistributor_transferRole.sol`**

Corresponds to Runbook TX 1 + TX 1b:
- Grant `DEFAULT_ADMIN_ROLE` on ListaRevenueDistributor (`0x0fe5...40D9`) to MarketFactory (`0xA2ff...592c`)
- Grant `DEFAULT_ADMIN_ROLE` to Manager Safe (`0x8d38...B0c6`)
- Deployer renounces its own `DEFAULT_ADMIN_ROLE`

**2. `script/eth/deploy_marketFactory_transferRole.sol`**

Transfer MarketFactory admin from deployer to ETH TimeLock (gap identified in runbook):
- Grant `DEFAULT_ADMIN_ROLE` on MarketFactory (`0xA2ff...592c`) to ETH TimeLock (`0xa18a...0D61`)
- Revoke deployer's `DEFAULT_ADMIN_ROLE`

### BSC Parity

| Contract | BSC Script | ETH Script |
|----------|-----------|------------|
| LendingRevenueDistributor | `script/deploy_lendingRevenueDistributorTransferRole.sol` | `script/eth/deploy_lendingRevenueDistributor_transferRole.sol` |
| MarketFactory | `script/deploy_marketFactoryTransferRole.sol` | `script/eth/deploy_marketFactory_transferRole.sol` |