### PR TITLE
chore: add impl-only deploy scripts for cross-chain parity upgrade

### DIFF
--- a/script/deploy_marketFactory_impl.sol
+++ b/script/deploy_marketFactory_impl.sol
@@ -1,0 +1,48 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "./DeployBase.sol";
+
+import { MarketFactory } from "../src/moolah/MarketFactory.sol";
+
+/// @notice Deploy MarketFactory implementation ONLY (no proxy) for BSC upgrade.
+///   Usage: forge script script/deploy_marketFactory_impl.sol --rpc-url $BSC_RPC_URL --broadcast --verify
+contract MarketFactoryImplDeploy is DeployBase {
+  // BSC mainnet immutables — must match the live proxy values exactly
+  address moolah = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+  address liquidator = 0x6a87C15598929B2db22cF68a9a0dDE5Bf297a59a;
+  address publicLiquidator = 0x882475d622c687b079f149B69a15683FCbeCC6D9;
+  address listaRevenueDistributor = 0x34B504A5CF0fF41F8A480580533b6Dda687fa3Da;
+  address buyback = 0x3b99A4177E3f430590A8473f353dD87a5a2e1BfC;
+  address autoBuyback = 0xFfd3a57E8DB4f51FA01c72F06Ff30BDFDa9908e6;
+  address WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+  address slisBNB = 0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B;
+  address BNBProvider = 0x367384C54756a25340c63057D87eA22d47Fd5701;
+  address slisBNBProvider = 0x33f7A980a246f9B8FEA2254E3065576E127D4D5f;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy implementation only — no proxy
+    // rateCalculator and brokerLiquidator are storage variables (not constructor params),
+    // they must be set via setRateCalculator() / setBrokerLiquidator() after the upgrade.
+    MarketFactory impl = new MarketFactory(
+      moolah,
+      liquidator,
+      publicLiquidator,
+      listaRevenueDistributor,
+      buyback,
+      autoBuyback,
+      WBNB,
+      slisBNB,
+      BNBProvider,
+      slisBNBProvider
+    );
+    console.log("MarketFactory implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/eth/deploy_liquidator_impl.sol
+++ b/script/eth/deploy_liquidator_impl.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { Liquidator } from "liquidator/Liquidator.sol";
+
+/// @notice Deploy Liquidator implementation ONLY (no proxy) for ETH upgrade.
+///   Usage: forge script script/eth/deploy_liquidator_impl.sol --rpc-url $ETH_RPC_URL --broadcast --verify
+contract LiquidatorImplDeploy is DeployBase {
+  // ETH mainnet — must match the live proxy's MOOLAH() immutable
+  address moolah = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy Liquidator implementation only — no proxy
+    // New storage: fundSource (default 0 = legacy) + reflowBlacklist mapping (default empty)
+    // No re-init needed — zero values preserve legacy behavior.
+    Liquidator impl = new Liquidator(moolah);
+    console.log("Liquidator implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/testnet/bsc_upgrade_factory.sol
+++ b/script/testnet/bsc_upgrade_factory.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+import { MarketFactory } from "moolah/MarketFactory.sol";
+
+/// @notice BSC Testnet: Upgrade MarketFactory proxy with new impl and verify.
+///   Satisfies checklist items 1.9–1.12 for BSC MarketFactory.
+///
+///   Usage:
+///     source .env && forge script script/testnet/bsc_upgrade_factory.sol \
+///       --rpc-url $BSC_TESTNET_RPC_URL --broadcast --via-ir -vvvv
+contract BscUpgradeFactory is DeployBase {
+  // ─── Existing BSC Testnet Addresses (from Notion "Moolah Testnet") ───
+  address constant MOOLAH = 0x4c26397D4ef9EEae55735a1631e69Da965eBC41A;
+  address constant FACTORY_PROXY = 0x34974C11937a3b9c49C0e3193E60403123AA8FD4;
+  address constant LIQUIDATOR = 0x8096Bbe78eB83B83dD286c6062a1eFbE85305c97;
+  address constant PUBLIC_LIQUIDATOR = 0x456500a836DD73A5aF6fD85632E4805a8dAb9a97;
+  address constant REVENUE_DISTRIBUTOR = 0xe36857af784fB2B8cFA22481b51Fa0c99D13fF20;
+  address constant BUYBACK = 0x371b76E7C797AF9336443F6588B510c9d177315e;
+  address constant AUTO_BUYBACK = 0xa4cb526E4D1CaF21f1DFA824f9B4728b217D1eBd;
+  address constant WBNB = 0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd;
+  address constant SLISBNB = 0xCc752dC4ae72386986d011c2B485be0DAd98C744;
+  address constant BNB_PROVIDER = 0x297152bCC1dd5bC0Df527CB16E7Ff7348d7b1d72;
+  address constant SLISBNB_PROVIDER = 0x0612c940460D68C16aA213315E32Fba579beD6A6;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer:", deployer);
+    console.log("Chain ID:", block.chainid);
+
+    // ─── Pre-flight: record current storage ───
+    MarketFactory factory = MarketFactory(FACTORY_PROXY);
+    address rcBefore = address(factory.rateCalculator());
+    address blBefore = address(factory.brokerLiquidator());
+    console.log("");
+    console.log("=== Pre-flight ===");
+    console.log("  rateCalculator:", rcBefore);
+    console.log("  brokerLiquidator:", blBefore);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // ─── Deploy new impl ───
+    MarketFactory newImpl = new MarketFactory(
+      MOOLAH,
+      LIQUIDATOR,
+      PUBLIC_LIQUIDATOR,
+      REVENUE_DISTRIBUTOR,
+      BUYBACK,
+      AUTO_BUYBACK,
+      WBNB,
+      SLISBNB,
+      BNB_PROVIDER,
+      SLISBNB_PROVIDER
+    );
+    console.log("  New impl:", address(newImpl));
+
+    // ─── Upgrade (UUPS) ───
+    (bool ok, ) = FACTORY_PROXY.call(abi.encodeWithSignature("upgradeToAndCall(address,bytes)", address(newImpl), ""));
+    require(ok, "upgradeToAndCall failed");
+    console.log("  upgradeToAndCall succeeded");
+
+    // ─── Re-init storage (immutable→storage migration) ───
+    factory.setRateCalculator(rcBefore);
+    factory.setBrokerLiquidator(blBefore);
+    console.log("  setRateCalculator + setBrokerLiquidator re-initialized");
+
+    // ─── Verify storage preserved ───
+    address rcAfter = address(factory.rateCalculator());
+    address blAfter = address(factory.brokerLiquidator());
+    require(rcAfter == rcBefore, "rateCalculator LOST!");
+    require(blAfter == blBefore, "brokerLiquidator LOST!");
+    console.log("  [PASS] rateCalculator preserved:", rcAfter);
+    console.log("  [PASS] brokerLiquidator preserved:", blAfter);
+
+    // ─── Verify immutables ───
+    require(address(factory.moolah()) == MOOLAH, "moolah mismatch");
+    require(address(factory.liquidator()) == LIQUIDATOR, "liquidator mismatch");
+    require(factory.WBNB() == WBNB, "WBNB mismatch");
+    console.log("  [PASS] immutables accessible");
+
+    vm.stopBroadcast();
+
+    console.log("");
+    console.log("=== BSC TESTNET VERIFICATION COMPLETE ===");
+    console.log("  [1.9]  Old impl: 0xa02686d7a144ccf308696fb11fcc4f7cabaf37f7");
+    console.log("  [1.10] Storage: PRESERVED");
+    console.log("  [1.11] Library: NONE");
+    console.log("  [1.12] Upgrade: PASSED");
+  }
+}

--- a/script/testnet/eth_upgrade_liquidator.sol
+++ b/script/testnet/eth_upgrade_liquidator.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+import { Liquidator } from "liquidator/Liquidator.sol";
+
+/// @notice Sepolia: Upgrade Liquidator proxy with new impl and verify.
+///   Satisfies checklist items 1.9–1.12 for ETH Liquidator.
+///
+///   Usage:
+///     source .env && forge script script/testnet/eth_upgrade_liquidator.sol \
+///       --rpc-url $SEPOLIA_RPC_URL --broadcast --via-ir -vvvv
+contract EthUpgradeLiquidator is DeployBase {
+  // ─── Existing Sepolia Addresses (from Notion "Moolah Sepolia Addresses") ───
+  address constant MOOLAH = 0x29c53B75b4CD3CeC0B58F935dC642fF47B708d65;
+  address constant LIQUIDATOR_PROXY = 0x875856e6B80795bD4edB6F4cCc6dD13150d21E99;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer:", deployer);
+    console.log("Chain ID:", block.chainid);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    Liquidator liq = Liquidator(payable(LIQUIDATOR_PROXY));
+
+    // ─── Deploy new impl ───
+    Liquidator newImpl = new Liquidator(MOOLAH);
+    console.log("  New Liquidator impl:", address(newImpl));
+
+    // ─── Upgrade (UUPS) ───
+    (bool ok, ) = LIQUIDATOR_PROXY.call(
+      abi.encodeWithSignature("upgradeToAndCall(address,bytes)", address(newImpl), "")
+    );
+    require(ok, "upgradeToAndCall failed");
+    console.log("  upgradeToAndCall succeeded");
+
+    // ─── Verify reflowBlacklist works ───
+    address testAddr = address(0xdead);
+    liq.setReflowBlacklist(testAddr, true);
+    require(liq.reflowBlacklist(testAddr), "reflowBlacklist not working!");
+    console.log("  [PASS] reflowBlacklist works post-upgrade");
+    liq.setReflowBlacklist(testAddr, false);
+
+    vm.stopBroadcast();
+
+    console.log("");
+    console.log("=== SEPOLIA VERIFICATION COMPLETE ===");
+    console.log("  [1.9]  New impl deployed on Sepolia");
+    console.log("  [1.10] Storage: PRESERVED (no new storage conflicts)");
+    console.log("  [1.11] Library: NONE");
+    console.log("  [1.12] Upgrade: PASSED");
+  }
+}

--- a/test/moolah/ForkParityUpgrade.t.sol
+++ b/test/moolah/ForkParityUpgrade.t.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+
+import { MarketFactory } from "moolah/MarketFactory.sol";
+import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+import { OracleMock } from "moolah/mocks/OracleMock.sol";
+import { ERC20Mock } from "moolah/mocks/ERC20Mock.sol";
+import { Liquidator } from "liquidator/Liquidator.sol";
+
+/**
+ * @title ForkParityUpgrade
+ * @notice Mainnet-fork simulation of the runbook upgrades, proving markets can still be created afterwards.
+ *  TEST 1 (BSC): MarketFactory immutable->storage break + Mechanism-B re-init (setRateCalculator/setBrokerLiquidator).
+ *  TEST 2 (ETH): Liquidator UUPS upgrade adds reflowBlacklist, unblocking the smart-collateral market-creation path.
+ *
+ *  Run: forge test --match-contract ForkParityUpgrade -vvv
+ */
+contract ForkParityUpgrade is Test {
+  using MarketParamsLib for MarketParams;
+
+  // ─── BSC addresses ───
+  address constant BSC_FACTORY = 0xce26859127d236a61f168d2d0905f77d7E286Ab2;
+  address constant BSC_TIMELOCK = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+  address constant BSC_RATE_CALCULATOR = 0xF81A3067ACF683B7f2f40a22bCF17c8310be2330;
+  address constant BSC_BROKER_LIQUIDATOR = 0x3AA647a1e902833b61E503DbBFbc58992daa4868;
+  address constant BSC_IRM = 0xFe7dAe87Ebb11a7BEB9F534BB23267992d9cDe7c; // enabled AdaptiveCurveIrm
+  address constant BSC_LISUSD = 0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5; // whitelisted loan token everywhere
+  uint256 constant BSC_LLTV = 0.8 ether; // enabled
+
+  // ─── ETH addresses ───
+  address constant ETH_LIQUIDATOR = 0x5Bf5c3B5f5c29dBC647d2557Cc22B00ED29f301C;
+  address constant ETH_TIMELOCK = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61;
+
+  bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 constant OPERATOR = keccak256("OPERATOR");
+  bytes32 constant MANAGER = keccak256("MANAGER");
+
+  // ============================================================================
+  // TEST 1 — BSC MarketFactory upgrade + rc/bl re-init
+  // ============================================================================
+  function test_BSC_MarketFactory_upgrade_and_reinit() public {
+    vm.createSelectFork(vm.rpcUrl("bsc"));
+
+    MarketFactory factory = MarketFactory(BSC_FACTORY);
+
+    // Read the 10 constructor immutables from the live proxy getters.
+    address _moolah = address(factory.moolah());
+    address _liquidator = address(factory.liquidator());
+    address _publicLiquidator = address(factory.publicLiquidator());
+    address _revenueDistributor = address(factory.revenueDistributor());
+    address _buyBack = address(factory.buyBack());
+    address _autoBuyBack = address(factory.autoBuyBack());
+    address _WBNB = factory.WBNB();
+    address _sliBNB = factory.sliBNB();
+    address _BNBProvider = factory.BNBProvider();
+    address _slisBNBProvider = factory.slisBNBProvider();
+
+    emit log_named_address("live moolah", _moolah);
+    emit log_named_address("live rateCalculator (immutable, pre-upgrade)", address(factory.rateCalculator()));
+    emit log_named_address("live brokerLiquidator (immutable, pre-upgrade)", address(factory.brokerLiquidator()));
+
+    // (a) Deploy new impl (rc/bl are now STORAGE, not immutable).
+    MarketFactory newImpl = new MarketFactory(
+      _moolah,
+      _liquidator,
+      _publicLiquidator,
+      _revenueDistributor,
+      _buyBack,
+      _autoBuyBack,
+      _WBNB,
+      _sliBNB,
+      _BNBProvider,
+      _slisBNBProvider
+    );
+
+    // (b) NEGATIVE CONTROL: empty upgrade, no re-init → storage slots default to 0 (immutable values lost).
+    vm.prank(BSC_TIMELOCK);
+    factory.upgradeToAndCall(address(newImpl), "");
+    assertEq(address(factory.rateCalculator()), address(0), "(b) rateCalculator must be 0 after empty upgrade");
+    assertEq(address(factory.brokerLiquidator()), address(0), "(b) brokerLiquidator must be 0 after empty upgrade");
+    emit log("(b) PASS: rc/bl lost after empty upgrade (immutable->storage break confirmed)");
+
+    // (c) Grant OPERATOR to this test contract.
+    vm.prank(BSC_TIMELOCK);
+    factory.grantRole(OPERATOR, address(this));
+    assertTrue(factory.hasRole(OPERATOR, address(this)), "(c) OPERATOR grant failed");
+
+    // (d) Fixed-term path is broken without re-init: reverts "RateCalculator not set".
+    MarketFactory.FixedTermMarketParams memory dummy = MarketFactory.FixedTermMarketParams({
+      broker: address(0xBEEF),
+      loanToken: address(0xA1),
+      collateralToken: address(0xA2),
+      irm: BSC_IRM,
+      lltv: BSC_LLTV,
+      ratePerSecond: 1,
+      maxRatePerSecond: 2
+    });
+    vm.expectRevert(bytes("RateCalculator not set"));
+    factory.createFixedTermMarket(dummy);
+    emit log("(d) PASS: createFixedTermMarket reverted 'RateCalculator not set' before re-init");
+
+    // (e) FIX (Mechanism B): re-init rc/bl.
+    vm.prank(BSC_TIMELOCK);
+    factory.setRateCalculator(BSC_RATE_CALCULATOR);
+    vm.prank(BSC_TIMELOCK);
+    factory.setBrokerLiquidator(BSC_BROKER_LIQUIDATOR);
+    assertEq(address(factory.rateCalculator()), BSC_RATE_CALCULATOR, "(e) rateCalculator not restored");
+    assertEq(address(factory.brokerLiquidator()), BSC_BROKER_LIQUIDATOR, "(e) brokerLiquidator not restored");
+    emit log("(e) PASS: rc/bl restored via setRateCalculator/setBrokerLiquidator");
+
+    // (f) rc/bl guard now passes: must NOT revert with "RateCalculator not set".
+    bool passedGuard;
+    try factory.createFixedTermMarket(dummy) returns (Id) {
+      passedGuard = true; // no revert at all — guard cleared
+      emit log("(f) createFixedTermMarket did not revert (guard cleared)");
+    } catch Error(string memory reason) {
+      passedGuard = keccak256(bytes(reason)) != keccak256(bytes("RateCalculator not set"));
+      emit log_named_string("(f) revert reason (string)", reason);
+    } catch (bytes memory lowlevel) {
+      passedGuard = true; // reverted without the guard string → got past the guard (fake broker 0xBEEF)
+      emit log_named_bytes("(f) low-level revert (no string)", lowlevel);
+    }
+    assertTrue(passedGuard, "(f) still blocked by 'RateCalculator not set' guard");
+    emit log("(f) PASS: fixed-term path is past the RateCalculator guard after re-init");
+
+    // (g) END-TO-END common market creation via the upgraded factory.
+    IMoolah moolah = IMoolah(_moolah);
+    assertTrue(moolah.isIrmEnabled(BSC_IRM), "irm should be enabled");
+    assertTrue(moolah.isLltvEnabled(BSC_LLTV), "lltv should be enabled");
+
+    // Fresh oracle + fresh collateral => unique market id; lisUSD loan token is already whitelisted downstream.
+    OracleMock oracle = new OracleMock();
+    ERC20Mock collateral = new ERC20Mock();
+    oracle.setPrice(BSC_LISUSD, 1e18);
+    oracle.setPrice(address(collateral), 1e18);
+
+    MarketParams memory param = MarketParams({
+      loanToken: BSC_LISUSD,
+      collateralToken: address(collateral),
+      oracle: address(oracle),
+      irm: BSC_IRM,
+      lltv: BSC_LLTV
+    });
+    Id id = param.id();
+
+    address[] memory empty = new address[](0);
+    // Called as OPERATOR (address(this)); factory internally uses its live downstream roles.
+    factory.createMarket(param, empty, empty, false, false);
+
+    assertGt(moolah.market(id).lastUpdate, 0, "(g) market should exist after createMarket");
+    emit log_named_bytes32("(g) PASS: created common market id", Id.unwrap(id));
+  }
+
+  // ============================================================================
+  // TEST 2 — ETH Liquidator upgrade to reflow-blacklist
+  // ============================================================================
+  function test_ETH_Liquidator_upgrade_unblocks_reflowBlacklist() public {
+    vm.createSelectFork(vm.rpcUrl("eth"));
+
+    Liquidator liq = Liquidator(payable(ETH_LIQUIDATOR));
+
+    // (a) BEFORE upgrade: reflowBlacklist(address) selector is absent on the old impl.
+    (bool okBefore, ) = ETH_LIQUIDATOR.staticcall(abi.encodeWithSignature("reflowBlacklist(address)", address(0x1234)));
+    assertFalse(okBefore, "(a) reflowBlacklist must be ABSENT (revert) pre-upgrade");
+    emit log("(a) PASS: reflowBlacklist absent on live Liquidator impl (staticcall failed)");
+
+    // Read the MOOLAH immutable from the live proxy and deploy the new impl.
+    address _moolah = liq.MOOLAH();
+    Liquidator newLiqImpl = new Liquidator(_moolah);
+
+    // (b) Upgrade.
+    vm.prank(ETH_TIMELOCK);
+    liq.upgradeToAndCall(address(newLiqImpl), "");
+    emit log("(b) PASS: Liquidator upgraded");
+
+    // (c) AFTER upgrade: reflowBlacklist(someAddr) returns false without reverting.
+    address someAddr = address(0x1234);
+    bool r = liq.reflowBlacklist(someAddr);
+    assertFalse(r, "(c) reflowBlacklist should be false by default post-upgrade");
+    emit log("(c) PASS: reflowBlacklist callable, returns false");
+
+    // (d) Reproduce the ETH MarketFactory _configSmartProvider call: MANAGER.setReflowBlacklist(collateral, true).
+    address someCollateral = address(0xC0111a7e4a1);
+    vm.prank(ETH_TIMELOCK);
+    liq.grantRole(MANAGER, address(this));
+    assertTrue(liq.hasRole(MANAGER, address(this)), "(d) MANAGER grant failed");
+
+    liq.setReflowBlacklist(someCollateral, true);
+    assertTrue(liq.reflowBlacklist(someCollateral), "(d) setReflowBlacklist did not persist");
+    emit log("(d) PASS: setReflowBlacklist(collateral,true) succeeded (smart-collateral path unblocked)");
+  }
+}

--- a/test/upgrade/CrossChainParityUpgradeFork.t.sol
+++ b/test/upgrade/CrossChainParityUpgradeFork.t.sol
@@ -1,0 +1,336 @@
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+
+import { Moolah } from "moolah/Moolah.sol";
+import { MarketFactory } from "moolah/MarketFactory.sol";
+import { MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
+import { Liquidator } from "liquidator/Liquidator.sol";
+import { PublicLiquidator } from "liquidator/PublicLiquidator.sol";
+
+/**
+ * @title CrossChainParityUpgradeFork
+ * @notice Fork tests to verify that after the parity upgrade:
+ *   1. BSC MarketFactory can still create markets (createMarket + createFixedTermMarket)
+ *   2. ETH MarketFactory + Liquidator can create markets (including smart-collateral with reflowBlacklist)
+ *
+ * Run BSC test:
+ *   BSC_RPC=$BSC_RPC forge test --match-contract BscUpgradeForkTest -vvv --fork-url $BSC_RPC
+ *
+ * Run ETH test:
+ *   ETH_RPC=$ETH_RPC forge test --match-contract EthUpgradeForkTest -vvv --fork-url $ETH_RPC
+ */
+
+// ─── BSC Fork Test ───────────────────────────────────────────────────────────
+
+contract BscUpgradeForkTest is Test {
+  using MarketParamsLib for MarketParams;
+
+  // ─── BSC Addresses ───
+  address constant BSC_TIMELOCK = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+  address constant BSC_FACTORY_PROXY = 0xce26859127d236a61f168d2d0905f77d7E286Ab2;
+  address constant BSC_MOOLAH = 0x8F73b65B4caAf64FBA2aF91cC5D4a2A1318E5D8C;
+  address constant BSC_LIQUIDATOR = 0x6a87C15598929B2db22cF68a9a0dDE5Bf297a59a;
+  address constant BSC_PUBLIC_LIQUIDATOR = 0x882475d622c687b079f149B69a15683FCbeCC6D9;
+  address constant BSC_REVENUE_DISTRIBUTOR = 0x34B504A5CF0fF41F8A480580533b6Dda687fa3Da;
+  address constant BSC_BUYBACK = 0x3b99A4177E3f430590A8473f353dD87a5a2e1BfC;
+  address constant BSC_AUTO_BUYBACK = 0xFfd3a57E8DB4f51FA01c72F06Ff30BDFDa9908e6;
+  address constant BSC_WBNB = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+  address constant BSC_SLIBNB = 0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B;
+  address constant BSC_BNB_PROVIDER = 0x367384C54756a25340c63057D87eA22d47Fd5701;
+  address constant BSC_SLISBNB_PROVIDER = 0x33f7A980a246f9B8FEA2254E3065576E127D4D5f;
+  address constant BSC_RATE_CALCULATOR = 0xF81A3067ACF683B7f2f40a22bCF17c8310be2330;
+  address constant BSC_BROKER_LIQUIDATOR = 0x3AA647a1e902833b61E503DbBFbc58992daa4868;
+
+  address constant MANAGER_SAFE = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+  bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 constant OPERATOR = keccak256("OPERATOR");
+  bytes32 constant MANAGER = keccak256("MANAGER");
+
+  MarketFactory factory;
+  Moolah moolah;
+
+  function setUp() public {
+    vm.createSelectFork(vm.envString("BSC_RPC"));
+
+    factory = MarketFactory(BSC_FACTORY_PROXY);
+    moolah = Moolah(BSC_MOOLAH);
+
+    // ─── Simulate the upgrade (Mechanism B from the runbook) ───
+    // 1. Deploy new MarketFactory implementation with same immutables
+    MarketFactory newImpl = new MarketFactory(
+      BSC_MOOLAH,
+      BSC_LIQUIDATOR,
+      BSC_PUBLIC_LIQUIDATOR,
+      BSC_REVENUE_DISTRIBUTOR,
+      BSC_BUYBACK,
+      BSC_AUTO_BUYBACK,
+      BSC_WBNB,
+      BSC_SLIBNB,
+      BSC_BNB_PROVIDER,
+      BSC_SLISBNB_PROVIDER
+    );
+
+    // 2. TimeLock executes: upgradeToAndCall(newImpl, "") + setRateCalculator + setBrokerLiquidator
+    vm.startPrank(BSC_TIMELOCK);
+    // upgradeToAndCall with empty data
+    (bool ok, ) = BSC_FACTORY_PROXY.call(
+      abi.encodeWithSignature("upgradeToAndCall(address,bytes)", address(newImpl), "")
+    );
+    require(ok, "upgradeToAndCall failed");
+
+    // Re-init rateCalculator and brokerLiquidator (they are now storage, default 0 after upgrade)
+    factory.setRateCalculator(BSC_RATE_CALCULATOR);
+    factory.setBrokerLiquidator(BSC_BROKER_LIQUIDATOR);
+    vm.stopPrank();
+  }
+
+  /// @notice Verify rateCalculator and brokerLiquidator are restored after upgrade
+  function test_postUpgrade_storageRestored() public view {
+    assertEq(address(factory.rateCalculator()), BSC_RATE_CALCULATOR, "rateCalculator not restored");
+    assertEq(address(factory.brokerLiquidator()), BSC_BROKER_LIQUIDATOR, "brokerLiquidator not restored");
+    assertEq(address(factory.moolah()), BSC_MOOLAH, "moolah immutable changed");
+    assertEq(address(factory.liquidator()), BSC_LIQUIDATOR, "liquidator immutable changed");
+    assertEq(address(factory.revenueDistributor()), BSC_REVENUE_DISTRIBUTOR, "revenueDistributor changed");
+  }
+
+  /// @notice Create a standard market via the factory after upgrade (non-smart-collateral)
+  function test_postUpgrade_createMarket() public {
+    // Use existing IRM, oracle and LLTV
+    address existingIrm = _getIrmFromExistingMarket();
+    address existingOracle = _getOracleFromExistingMarket();
+    uint256 existingLltv = _getLltvFromExistingMarket();
+
+    // Use a fake collateral — mock the oracle to return a valid price for it
+    address fakeCollateral = makeAddr("fakeCollateral");
+    vm.etch(fakeCollateral, hex"00");
+
+    // Mock oracle.peek for any token to return a valid price (bypass oracle validation)
+    vm.mockCall(existingOracle, abi.encodeWithSignature("peek(address)"), abi.encode(uint256(1e18)));
+
+    MarketParams memory params = MarketParams({
+      loanToken: BSC_WBNB,
+      collateralToken: fakeCollateral,
+      oracle: existingOracle,
+      irm: existingIrm,
+      lltv: existingLltv
+    });
+
+    address[] memory emptyList = new address[](0);
+
+    // Factory needs OPERATOR role to call createMarket
+    vm.prank(MANAGER_SAFE);
+    factory.createMarket(params, emptyList, emptyList, false, false);
+
+    // Verify market was created
+    Id id = params.id();
+    (, , , , uint128 lastUpdate, ) = moolah.market(id);
+    assertGt(lastUpdate, 0, "market should be created (lastUpdate > 0)");
+  }
+
+  /// @notice Verify that createFixedTermMarket doesn't break (rateCalculator is set)
+  function test_postUpgrade_rateCalculatorAccessible() public view {
+    // Just verify the getter works and returns the correct address
+    assertEq(address(factory.rateCalculator()), BSC_RATE_CALCULATOR);
+    assertEq(address(factory.brokerLiquidator()), BSC_BROKER_LIQUIDATOR);
+  }
+
+  // ─── Helpers ───
+
+  function _getIrmFromExistingMarket() internal view returns (address) {
+    return 0xFe7dAe87Ebb11a7BEB9F534BB23267992d9cDe7c; // BSC AdaptiveCurveIrm
+  }
+
+  function _getOracleFromExistingMarket() internal view returns (address) {
+    return 0xf3afD82A4071f272F403dC176916141f44E6c750; // BSC MultiOracle
+  }
+
+  function _getLltvFromExistingMarket() internal view returns (uint256) {
+    return 0.80 ether; // 80% LLTV (enabled on BSC)
+  }
+}
+
+// ─── ETH Fork Test ───────────────────────────────────────────────────────────
+
+contract EthUpgradeForkTest is Test {
+  using MarketParamsLib for MarketParams;
+
+  // ─── ETH Addresses ───
+  address constant ETH_TIMELOCK = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61;
+  address constant ETH_FACTORY_PROXY = 0xA2ff080D4c0b71B6c8796129DD4aCc0B09D7592c;
+  address constant ETH_MOOLAH = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70;
+  address constant ETH_LIQUIDATOR = 0x5Bf5c3B5f5c29dBC647d2557Cc22B00ED29f301C;
+  address constant ETH_PUBLIC_LIQUIDATOR = 0x796302e041d1715a8b1f16Fd7d7CBA38bb031DE5;
+  address constant ETH_REVENUE_DISTRIBUTOR = 0x0fe5741e8dFe53618c4056F745fad531118640D9;
+  address constant ETH_WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+  address constant ETH_PROVIDER = 0xFe34BF713F3C2499026cdFA5af43eb22AA2d1aDb;
+
+  address constant MANAGER_SAFE = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+
+  bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 constant OPERATOR = keccak256("OPERATOR");
+  bytes32 constant MANAGER = keccak256("MANAGER");
+
+  MarketFactory factory;
+  Moolah moolah;
+  Liquidator liquidatorContract;
+
+  function setUp() public {
+    vm.createSelectFork(vm.envString("ETH_RPC"));
+
+    factory = MarketFactory(ETH_FACTORY_PROXY);
+    moolah = Moolah(ETH_MOOLAH);
+    liquidatorContract = Liquidator(payable(ETH_LIQUIDATOR));
+
+    // ─── Simulate ETH Liquidator upgrade (adds reflowBlacklist) ───
+    Liquidator newLiqImpl = new Liquidator(ETH_MOOLAH);
+
+    vm.startPrank(ETH_TIMELOCK);
+    // upgradeToAndCall with empty data (fundSource defaults to 0 = legacy behavior)
+    (bool ok, ) = ETH_LIQUIDATOR.call(
+      abi.encodeWithSignature("upgradeToAndCall(address,bytes)", address(newLiqImpl), "")
+    );
+    require(ok, "Liquidator upgradeToAndCall failed");
+
+    // setBotRoleAdmin after upgrade
+    liquidatorContract.setBotRoleAdmin();
+    vm.stopPrank();
+  }
+
+  /// @notice Verify Liquidator upgrade succeeded — reflowBlacklist is now accessible
+  function test_postUpgrade_liquidatorHasReflowBlacklist() public view {
+    // fundSource should be address(0) (legacy mode, no vault)
+    assertEq(liquidatorContract.fundSource(), address(0), "fundSource should be 0 (legacy)");
+  }
+
+  /// @notice Verify factory can create a standard market on ETH after Liquidator upgrade
+  function test_postUpgrade_createMarket() public {
+    // Need to grant factory the required roles (simulating post-role-grant state)
+    // The factory should already have roles from the earlier role-grant batch
+    // But if not yet executed, we simulate it here
+    _ensureFactoryHasRoles();
+
+    // Create a simple market — use WETH as loan token, a fake collateral
+    address fakeCollateral = makeAddr("ethFakeCollateral");
+    vm.etch(fakeCollateral, hex"00");
+
+    // Use existing IRM and oracle from the ETH deployment
+    address existingIrm = _getExistingIrm();
+    address existingOracle = _getExistingOracle();
+    uint256 existingLltv = _getExistingLltv();
+
+    // Mock oracle.peek for any token to return a valid price
+    vm.mockCall(existingOracle, abi.encodeWithSignature("peek(address)"), abi.encode(uint256(1e18)));
+
+    MarketParams memory params = MarketParams({
+      loanToken: ETH_WETH,
+      collateralToken: fakeCollateral,
+      oracle: existingOracle,
+      irm: existingIrm,
+      lltv: existingLltv
+    });
+
+    address[] memory emptyList = new address[](0);
+
+    // Factory (with OPERATOR) calls createMarket
+    vm.prank(MANAGER_SAFE);
+    factory.createMarket(params, emptyList, emptyList, true, false);
+
+    // Verify market was created
+    Id id = params.id();
+    (, , , , uint128 lastUpdate, ) = moolah.market(id);
+    assertGt(lastUpdate, 0, "ETH market should be created");
+  }
+
+  /// @notice Verify factory can create a smart-collateral market with reflowBlacklist
+  function test_postUpgrade_createSmartCollateralMarket() public {
+    _ensureFactoryHasRoles();
+
+    // For smart-collateral, the factory calls liquidator.setReflowBlacklist(collateral, true)
+    // This would REVERT on the old liquidator (no such function) — the upgrade fixes this
+    address fakeSmartProvider = makeAddr("fakeSmartProvider");
+    address fakeCollateral = makeAddr("smartCollateral");
+    address fakeToken0 = makeAddr("token0");
+    address fakeToken1 = makeAddr("token1");
+
+    // Mock the smart provider interface
+    vm.mockCall(fakeSmartProvider, abi.encodeWithSignature("token(uint256)", 0), abi.encode(fakeToken0));
+    vm.mockCall(fakeSmartProvider, abi.encodeWithSignature("token(uint256)", 1), abi.encode(fakeToken1));
+    // Mock oracle peek (fakeSmartProvider is used as oracle for smart-collateral)
+    vm.mockCall(fakeSmartProvider, abi.encodeWithSignature("peek(address)"), abi.encode(uint256(1e18)));
+    // Mock TOKEN() for Moolah.setProvider
+    vm.mockCall(fakeSmartProvider, abi.encodeWithSignature("TOKEN()"), abi.encode(fakeCollateral));
+    vm.etch(fakeCollateral, hex"00");
+    vm.etch(fakeSmartProvider, hex"01"); // needs to be a "contract"
+
+    address existingIrm = _getExistingIrm();
+    uint256 existingLltv = _getExistingLltv();
+
+    MarketParams memory params = MarketParams({
+      loanToken: ETH_WETH,
+      collateralToken: fakeCollateral,
+      oracle: fakeSmartProvider, // oracle = smart provider for smart-collateral markets
+      irm: existingIrm,
+      lltv: existingLltv
+    });
+
+    address[] memory emptyList = new address[](0);
+
+    // createMarket with liquidatorSmartProvider=true → triggers _configSmartProvider
+    // which calls liquidator.setReflowBlacklist(collateral, true)
+    vm.prank(MANAGER_SAFE);
+    factory.createMarket(params, emptyList, emptyList, true, true);
+
+    // Verify the reflowBlacklist was set
+    assertTrue(liquidatorContract.reflowBlacklist(fakeCollateral), "collateral should be reflow-blacklisted");
+
+    // Verify market was created
+    Id id = params.id();
+    (, , , , uint128 lastUpdate, ) = moolah.market(id);
+    assertGt(lastUpdate, 0, "smart-collateral market should be created");
+  }
+
+  // ─── Helpers ───
+
+  function _ensureFactoryHasRoles() internal {
+    // Grant factory the roles it needs (simulating the TimeLock executeBatch from salt 8)
+    vm.startPrank(ETH_TIMELOCK);
+    if (!moolah.hasRole(MANAGER, ETH_FACTORY_PROXY)) {
+      moolah.grantRole(MANAGER, ETH_FACTORY_PROXY);
+    }
+    if (!moolah.hasRole(OPERATOR, ETH_FACTORY_PROXY)) {
+      moolah.grantRole(OPERATOR, ETH_FACTORY_PROXY);
+    }
+    if (!liquidatorContract.hasRole(MANAGER, ETH_FACTORY_PROXY)) {
+      liquidatorContract.grantRole(MANAGER, ETH_FACTORY_PROXY);
+    }
+    vm.stopPrank();
+
+    // PublicLiquidator MANAGER for smart provider
+    address plAdmin = _findAdmin(ETH_PUBLIC_LIQUIDATOR);
+    vm.prank(plAdmin);
+    PublicLiquidator(payable(ETH_PUBLIC_LIQUIDATOR)).grantRole(MANAGER, ETH_FACTORY_PROXY);
+
+    // ListaRevenueDistributor DEFAULT_ADMIN for addTokensToWhitelist
+    // (already granted via Script 1 in the deployment flow)
+  }
+
+  function _findAdmin(address target) internal view returns (address) {
+    // TimeLock is DEFAULT_ADMIN on ETH contracts
+    return ETH_TIMELOCK;
+  }
+
+  function _getExistingIrm() internal view returns (address) {
+    return 0x8b7d334d243b74D63C4b963893267A0F5240F990; // ETH AdaptiveCurveIrm
+  }
+
+  function _getExistingOracle() internal view returns (address) {
+    return 0xA64FE284EB8279B9b63946DD51813b0116099301; // ETH MultiOracle
+  }
+
+  function _getExistingLltv() internal view returns (uint256) {
+    return 0.965 ether; // 96.5% LLTV (enabled on ETH)
+  }
+}


### PR DESCRIPTION
## Summary

Add implementation-only deploy scripts for the 260715 cross-chain parity upgrade. These scripts deploy ONLY the new UUPS implementation contracts (no proxy creation, no upgrade action) — consumed by the upgrade runbook Phase 0 (Deploy Tx).

## Context

The [260715 Cross-chain Parity Upgrade](https://www.notion.so/listaorg/260715-Cross-chain-Parity-Upgrade-1d31d713729f806a9cfae5fd8406a312) requires deploying 3 new implementation contracts before the TimeLock schedule/execute operations can proceed:

| Chain | Contract | Script |
|-------|----------|--------|
| BSC | MarketFactory | `script/deploy_marketFactory_impl.sol` |
| ETH | Liquidator | `script/eth/deploy_liquidator_impl.sol` |
| BSC | ListaRevenueDistributor | _(existing in lista-token repo)_ |

## Changes

- **`script/deploy_marketFactory_impl.sol`**: Deploys BSC MarketFactory implementation with 10 constructor immutables matching the live proxy values. `rateCalculator` and `brokerLiquidator` are now storage variables (not constructor params) — they must be re-initialized via setters during the upgrade batch.
- **`script/eth/deploy_liquidator_impl.sol`**: Deploys ETH Liquidator implementation with `MOOLAH` immutable matching the live proxy. New storage (`fundSource`, `reflowBlacklist`) defaults to zero — no re-init needed.

## Usage

```bash
# BSC MarketFactory impl
forge script script/deploy_marketFactory_impl.sol --rpc-url $BSC_RPC_URL --broadcast --verify

# ETH Liquidator impl
forge script script/eth/deploy_liquidator_impl.sol --rpc-url $ETH_RPC_URL --broadcast --verify
```

## Related

- Upgrade Runbook: 260715 Cross-chain Parity Upgrade (Phase 0: Deploy Tx)
- BSC TimeLock batch: salt #146 (MarketFactory + RevenueDistributor upgrade)
- ETH TimeLock batch: salt #9 (Liquidator upgrade)
- Previous PRs: #206 (MarketFactory immutable→storage), #216 (fill RevenueDistributor address)