### PR TITLE
feat(broker): add fixed-term relayer-impl and lock-buffer mainnet deploy script

### DIFF
--- a/script/broker/deploy_lockBuffer_mainnet.s.sol
+++ b/script/broker/deploy_lockBuffer_mainnet.s.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { console } from "forge-std/console.sol";
+import { DeployBase } from "../DeployBase.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { BrokerInterestLockBuffer } from "../../src/utils/BrokerInterestLockBuffer.sol";
+
+interface IAccessControlLike {
+  function grantRole(bytes32 role, address account) external;
+}
+
+/// @notice Deploy the shared BrokerInterestLockBuffer implementation plus one UUPS proxy per
+/// loan-asset vault on BSC mainnet, and grant each proxy's RELAYER role to that vault's relayer.
+///
+/// The deployer is set as DEFAULT_ADMIN and MANAGER so it can grant RELAYER in this same run.
+/// Hand both roles to governance afterwards, then attach each buffer via the vault MANAGER
+/// (see the wiring runbook). Buffers are NOT attached here; vaults still see lockBuffer() == 0
+/// until the vault MANAGER calls setLockBuffer.
+///
+/// Run (PRIVATE_KEY is picked by DeployBase per chain id):
+///   PRIVATE_KEY=0x... forge script script/broker/deploy_lockBuffer_mainnet.s.sol \
+///     --rpc-url $BSC_RPC --broadcast --verify --via-ir -vvv
+contract DeployLockBuffer is DeployBase {
+  // ERC-1967 implementation slot = keccak256("eip1967.proxy.implementation") - 1 (bytes32, not an address).
+  bytes32 internal constant ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+  bytes32 internal constant RELAYER = keccak256("RELAYER");
+
+  // Smoothing window applied to each brokered-interest flush. Must be in [MIN_DURATION, MAX_DURATION]
+  // = [1 hours, 3 days] per BrokerInterestLockBuffer.
+  uint64 internal constant DURATION = 8 hours;
+
+  function run() public {
+    require(block.chainid == 56, "not BSC mainnet");
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    // Per loan asset: (vault, asset, relayer). Order: lisUSD, USD1, U, USDT, WBNB.
+    address[5] memory vaults = [
+      0xE03D86e5Baa3509AC4A059A41737bAa8169B6529,
+      0xfa27f172e0b6ebcEF9c51ABf817E2cb142FbE627,
+      0x9A17Fd5Cb8EFc25d11567e713aE795A89775a759,
+      0x6d6783C146F2B0B2774C1725297f1845dc502525,
+      0x57134a64B7cD9F9eb72F8255A671F5Bf2fe3E2d0
+    ];
+    address[5] memory assets = [
+      0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5, // lisUSD
+      0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d, // USD1
+      0xcE24439F2D9C6a2289F741120FE202248B666666, // U
+      0x55d398326f99059fF775485246999027B3197955, // USDT
+      0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c // WBNB
+    ];
+    address[5] memory relayers = [
+      0xcb2590F10728e3ffc725d7ECf88EcFd0d92c9d6a,
+      0x35720fcA79F33E3817479E0c6abFaD38ea1a9DaC,
+      0x9348923C2f0AD218A8736Ab28cfAe7D93027E73f,
+      0x2A119f506ce71cF427D5ae88540fAec580840587,
+      0xF2D18e9201d1fE752e3115c029F0f5Ef2Ec2bdbe
+    ];
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    BrokerInterestLockBuffer impl = new BrokerInterestLockBuffer();
+    require(impl.proxiableUUID() == ERC1967_IMPL_SLOT, "impl: not UUPS / wrong proxiableUUID");
+    console.log("LockBuffer impl:", address(impl));
+
+    for (uint256 i = 0; i < vaults.length; i++) {
+      bytes memory initData = abi.encodeCall(
+        BrokerInterestLockBuffer.initialize,
+        (deployer, deployer, vaults[i], assets[i], DURATION)
+      );
+      BrokerInterestLockBuffer buf = BrokerInterestLockBuffer(address(new ERC1967Proxy(address(impl), initData)));
+
+      // grant RELAYER to this vault's relayer (deployer is DEFAULT_ADMIN) — must precede setLockBuffer
+      IAccessControlLike(address(buf)).grantRole(RELAYER, relayers[i]);
+
+      require(buf.vault() == vaults[i] && buf.asset() == assets[i], "buffer init mismatch");
+      require(buf.currentLocked() == 0, "buffer not empty");
+      console.log("buffer:", address(buf));
+      console.log("   vault:", vaults[i]);
+      console.log("   asset:", assets[i]);
+      console.log("   relayer (RELAYER granted):", relayers[i]);
+    }
+
+    vm.stopBroadcast();
+  }
+}

--- a/script/broker/deploy_relayerImpl_mainnet.s.sol
+++ b/script/broker/deploy_relayerImpl_mainnet.s.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { BrokerInterestRelayer } from "../../src/broker/BrokerInterestRelayer.sol";
+
+/// @notice Deploy the NEW shared BrokerInterestRelayer implementation on BSC mainnet.
+///
+/// Run:
+///   forge script script/broker/deploy_relayerImpl_mainnet.s.sol \
+///     --rpc-url $BSC_RPC --private-key $PK --broadcast --verify --via-ir -vvv
+contract DeployRelayerImpl is Script {
+  /// @dev ERC-1967 implementation slot = keccak256("eip1967.proxy.implementation") - 1.
+  ///      A valid UUPS impl's proxiableUUID() must return exactly this, or the UUPS proxy's
+  ///      upgradeToAndCall reverts with UUPSUnsupportedProxiableUUID. (bytes32 — not an address,
+  ///      so no EIP-55 checksum applies.)
+  bytes32 internal constant ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+  function run() public {
+    require(block.chainid == 56, "not BSC mainnet");
+    vm.startBroadcast();
+    BrokerInterestRelayer impl = new BrokerInterestRelayer();
+    vm.stopBroadcast();
+
+    // sanity: confirm the deployed impl is a valid UUPS implementation (correct proxiableUUID),
+    // i.e. the 5 relayer UUPS proxies will accept it in upgradeToAndCall.
+    bytes32 uuid = impl.proxiableUUID();
+    require(uuid == ERC1967_IMPL_SLOT, "impl: not UUPS / wrong proxiableUUID");
+
+    console.log("NEW BrokerInterestRelayer impl:", address(impl));
+    console.log("  proxiableUUID OK (== ERC-1967 impl slot):");
+    console.logBytes32(uuid); // 0x360894a1...382bbc
+  }
+}


### PR DESCRIPTION
## 📄 Description
Adds the two BSC-mainnet deploy scripts needed to complete the fixed-term (audit #08 lock-buffer) rollout: the new shared BrokerInterestRelayer implementation, and the shared BrokerInterestLockBuffer implementation plus one UUPS proxy per loan-asset vault. No production contracts or on-chain state are changed by this PR — it only adds scripts under script/broker/.

## 🧠 Rationale
The fixed-term rollout requires two on-chain deployments that were not yet scripted:

New BrokerInterestRelayer impl — the 5 relayer proxies must be upgraded to an implementation that calls vault.lockBuffer() / notifyBrokerInterest so brokered interest is smoothed instead of revealed instantly.
BrokerInterestLockBuffer — one buffer per loan-asset vault (lisUSD / USD1 / U / USDT / WBNB) is the mechanism that holds and linearly releases each interest flush. Deploying these is the prerequisite for the vault-side setLockBuffer "enable switch."
Both scripts are checked-in so the deployment is reproducible, auditable, and verified on BscScan rather than run ad-hoc.

## 🧬 Changes Summary
Notable changes:

* Add script/broker/deploy_relayerImpl_mainnet.s.sol — deploys the new shared BrokerInterestRelayer implementation; asserts a valid UUPS proxiableUUID.
* Add script/broker/deploy_lockBuffer_mainnet.s.sol — deploys the shared BrokerInterestLockBuffer impl + one UUPS proxy per loan-asset vault (lisUSD / USD1 / U / USDT / WBNB), initializes each with an 8h smoothing window, and grants each proxy's RELAYER role to that vault's relayer. Uses DeployBase._deployerKey(); mainnet-guarded.
