### PR TITLE
Audit/v3 lp fixes

### DIFF
--- a/src/liquidator/V3Liquidator.sol
+++ b/src/liquidator/V3Liquidator.sol
@@ -54,6 +54,13 @@ contract V3Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessCont
   /// @dev Whitelisted V3Provider contracts (collateral token = the provider itself).
   mapping(address => bool) public v3Providers;
 
+  /// @dev Pass-back of the leg amounts redeemed inside onMoolahLiquidate, so flashLiquidate can report
+  ///      the actual redeemed amount0 / amount1 in its V3Liquidation event rather than 0. Appended at
+  ///      the end of the storage layout (upgrade-safe). flashLiquidate zeroes them before each liquidate
+  ///      so a non-redeeming flash liquidation — or a stale value from an earlier call — reports 0.
+  uint256 private _redeemedAmount0;
+  uint256 private _redeemedAmount1;
+
   /* ──────────────────────────── events ────────────────────────────── */
 
   event TokenWhitelistChanged(address indexed token, bool status);
@@ -276,6 +283,11 @@ contract V3Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessCont
     address effectiveToken0Spender = params.token0Spender == address(0) ? params.token0Pair : params.token0Spender;
     address effectiveToken1Spender = params.token1Spender == address(0) ? params.token1Pair : params.token1Spender;
 
+    // Clear any stale pass-back (e.g. from an earlier flashLiquidate in the same tx). The callback
+    // fills these in only when it redeems; a non-redeeming flash liquidation reports 0 / 0.
+    _redeemedAmount0 = 0;
+    _redeemedAmount1 = 0;
+
     (uint256 _seized, uint256 _repaid) = IMoolah(MOOLAH).liquidate(
       mp,
       borrower,
@@ -301,7 +313,7 @@ contract V3Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessCont
       )
     );
 
-    emit V3Liquidation(id, params.v3Provider, borrower, _seized, _repaid, 0, 0);
+    emit V3Liquidation(id, params.v3Provider, borrower, _seized, _repaid, _redeemedAmount0, _redeemedAmount1);
   }
 
   /**
@@ -412,6 +424,10 @@ contract V3Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessCont
         d.minToken1Amt,
         address(this)
       );
+
+      // Pass the actual redeemed amounts back to flashLiquidate for the V3Liquidation event.
+      _redeemedAmount0 = amount0;
+      _redeemedAmount1 = amount1;
 
       // Swap TOKEN0 → loanToken (skip if already loanToken or no swap requested).
       if (d.swapToken0 && amount0 > 0 && token0 != d.loanToken) {

--- a/src/liquidator/V3Liquidator.sol
+++ b/src/liquidator/V3Liquidator.sol
@@ -401,6 +401,10 @@ contract V3Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessCont
       // leg is an ERC-20 sold via approve + call. Read it from the provider — never hardcode a chain.
       address wrappedNative = IV3Provider(d.v3Provider).WRAPPED_NATIVE();
 
+      // Snapshot before redeeming/swapping so profitability is judged on THIS liquidation's
+      // delta, not masked by loanToken balance already sitting idle from prior liquidations.
+      uint256 before = d.loanToken.balanceOf(address(this));
+
       // Redeem V3 shares → TOKEN0 + TOKEN1; the wrapped-native leg arrives as the native coin.
       (uint256 amount0, uint256 amount1) = IV3Provider(d.v3Provider).redeemShares(
         d.seized,
@@ -427,7 +431,8 @@ contract V3Liquidator is ReentrancyGuardUpgradeable, UUPSUpgradeable, AccessCont
         if (nativeBalance > 0) IWBNB(wrappedNative).deposit{ value: nativeBalance }();
       }
 
-      if (d.loanToken.balanceOf(address(this)) < repaidAssets) revert NoProfit();
+      uint256 out = d.loanToken.balanceOf(address(this)) - before;
+      if (out < repaidAssets) revert NoProfit();
     }
 
     // Approve Moolah to pull the repayment (always done, flash or pre-funded).

--- a/src/provider/interfaces/IV3DexAdapter.sol
+++ b/src/provider/interfaces/IV3DexAdapter.sol
@@ -152,6 +152,7 @@ interface IV3DexAdapter {
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
+    uint160 targetSqrtPriceX96,
     uint256 deadline,
     bytes calldata swapData
   ) external;

--- a/src/provider/interfaces/IV3DexAdapter.sol
+++ b/src/provider/interfaces/IV3DexAdapter.sol
@@ -135,6 +135,12 @@ interface IV3DexAdapter {
   /// @notice Set the per-swap rate-anchored loss cap (onlyRole MANAGER; ppm, 1e6 = 100%).
   function setMaxSwapLossBp(uint256 maxSwapLossBp) external;
 
+  /// @notice Max |pool spot − fair| price deviation (bps) tolerated when adding liquidity at pool spot.
+  function maxSpotDeviationBps() external view returns (uint256);
+
+  /// @notice Set the spot-vs-fair deviation gate (onlyRole MANAGER; bps of price, 0 disables).
+  function setMaxSpotDeviationBps(uint256 maxSpotDeviationBps) external;
+
   /// @notice Recenter the position to its range and convert inventory to the optimal ratio.
   ///         onlyProvider — the provider gates the caller with the BOT role.
   function rebalance(

--- a/src/provider/interfaces/IV3DexAdapter.sol
+++ b/src/provider/interfaces/IV3DexAdapter.sol
@@ -111,6 +111,11 @@ interface IV3DexAdapter {
   /// @notice Collect accrued fees and re-add them plus idle inventory as liquidity (compound).
   function collectAndCompound() external;
 
+  /// @notice Record tokens already transferred to the adapter as idle inventory, without minting into
+  ///         the pool. Used by the vault deposit path so new deposits enter as idle at the current fair
+  ///         composition (off-pool priced); a later spot-gated compound() deploys them.
+  function creditIdle(uint256 amount0, uint256 amount1) external;
+
   /* ─────────────────────── rebalance / rate config ────────────────── */
 
   /// @notice Exchange rate at the last successful center/init (rate-implied pairs; 0 for TWAP pairs).

--- a/src/provider/interfaces/IV3PoolMinimal.sol
+++ b/src/provider/interfaces/IV3PoolMinimal.sol
@@ -13,4 +13,20 @@ pragma solidity 0.8.34;
  */
 interface IV3PoolMinimal {
   function slot0() external view returns (uint160 sqrtPriceX96, int24 tick);
+
+  /// @notice Global fee growth per unit of liquidity, Q128.
+  function feeGrowthGlobal0X128() external view returns (uint256);
+
+  function feeGrowthGlobal1X128() external view returns (uint256);
+
+  /// @notice Tick state. Decodes only the first four fields (liquidityGross, liquidityNet,
+  ///         feeGrowthOutside0X128, feeGrowthOutside1X128) — the two fee-growth values are all the
+  ///         pending-fee simulation needs, and stopping the decode there keeps the read width-agnostic
+  ///         across V3 flavors (see the slot0 note above).
+  function ticks(
+    int24 tick
+  )
+    external
+    view
+    returns (uint128 liquidityGross, int128 liquidityNet, uint256 feeGrowthOutside0X128, uint256 feeGrowthOutside1X128);
 }

--- a/src/provider/interfaces/IV3Provider.sol
+++ b/src/provider/interfaces/IV3Provider.sol
@@ -26,14 +26,20 @@ interface IV3Provider is IProvider {
   /// @notice Total token0/token1 backing the vault at the current pool spot (display/bots).
   function getTotalAmounts() external view returns (uint256 total0, uint256 total1);
 
+  /// @notice Total token0/token1 backing the vault at the FAIR price (idle + fees included). This is the
+  ///         ratio a subsequent deposit binds to; size deposit legs in this ratio to minimise the refund.
+  function getFairComposition() external view returns (uint256 total0, uint256 total1);
+
   /// @notice Deposit token0/token1 into the V3 position and supply resulting shares as Moolah
-  ///         collateral on behalf of `onBehalf`.
+  ///         collateral on behalf of `onBehalf`. Reverts if the minted shares are below `minShares`
+  ///         (share-slippage floor; pass 0 to disable).
   function deposit(
     MarketParams calldata marketParams,
     uint256 amount0Desired,
     uint256 amount1Desired,
     uint256 amount0Min,
     uint256 amount1Min,
+    uint256 minShares,
     address onBehalf
   ) external payable returns (uint256 shares, uint256 amount0Used, uint256 amount1Used);
 

--- a/src/provider/libraries/SwapInventoryLib.sol
+++ b/src/provider/libraries/SwapInventoryLib.sol
@@ -83,10 +83,13 @@ library SwapInventoryLib {
 
     // Wrap any native this call delivered — a native-out venue's proceeds (instantWithdraw → BNB) or a
     // native-in venue's unspent refund — back into the wrapped-native ERC-20, so it is booked into the
-    // totals via the spent/received deltas and never stranded. Native can only belong to the
-    // wrapped-native leg; if neither leg is it, there is nowhere to book the native ⇒ revert.
-    if (address(this).balance > beforeNative) {
-      if (tokenIn != wrappedNative && tokenOut != wrappedNative) revert UnexpectedNative();
+    // totals via the spent/received deltas and never stranded. Only a wrapped-native leg can legitimately
+    // deliver native; wrap the delta ONLY when either leg is the wrapped-native token. If NEITHER leg is
+    // (an ERC-20↔ERC-20 swap on a future non-native pair), any native that appears is an unsolicited
+    // donation the venue forwarded (e.g. a router that sweeps its native balance; an attacker can seed it
+    // with 1 wei) — it is not part of this swap's accounting, so leave it untouched rather than reverting
+    // and bricking the rebalance.
+    if ((tokenIn == wrappedNative || tokenOut == wrappedNative) && address(this).balance > beforeNative) {
       IWBNB(wrappedNative).deposit{ value: address(this).balance - beforeNative }();
     }
 

--- a/src/provider/libraries/SwapInventoryLib.sol
+++ b/src/provider/libraries/SwapInventoryLib.sol
@@ -36,6 +36,7 @@ library SwapInventoryLib {
   error ExceedAmountIn();
   error InsufficientOutput();
   error UnexpectedNative();
+  error InsufficientInventory();
 
   /// @notice Execute one backend-built swap. `sellToken0` ⇒ sell token0 for token1, else token1 for
   ///         token0. `nativeIn` ⇒ the venue takes the native coin for the wrapped-native input leg
@@ -60,8 +61,11 @@ library SwapInventoryLib {
     address tokenOut = sellToken0 ? token1 : token0;
 
     uint256 avail = sellToken0 ? total0 : total1;
-    if (amountIn > avail) amountIn = avail; // never spend more than the position holds
-    if (amountIn == 0) return (total0, total1);
+    if (avail == 0) return (total0, total1); // nothing to sell
+
+    // Stale swapData (requested > held): fail fast. Capping would desync the venue allowance from
+    // swapData and could underflow the totals. Now amountIn <= avail, so the allowance matches the pull.
+    if (amountIn > avail) revert InsufficientInventory();
 
     uint256 beforeIn = IERC20(tokenIn).balanceOf(address(this));
     uint256 beforeOut = IERC20(tokenOut).balanceOf(address(this));

--- a/src/provider/v3/SlisBNBV3DexAdapter.sol
+++ b/src/provider/v3/SlisBNBV3DexAdapter.sol
@@ -58,18 +58,10 @@ contract SlisBNBV3DexAdapter is V3DexAdapter, ISlisBNBV3DexAdapter {
 
   /* ───────────────────────── hook overrides ───────────────────────── */
 
-  /// @dev slisBNB↔BNB rate from the StakeManager (1e18). 0 for any non-slisBNB/WBNB pair → base TWAP.
+  /// @dev slisBNB↔BNB rate from the StakeManager (1e18). The constructor pins TOKEN0 == slisBNB and
+  ///      TOKEN1 == WBNB, so the pair/order is fixed at deploy and the rate is always the direct
+  ///      slisBNB→BNB conversion (no runtime pair/order branch needed).
   function _lstNativeRate() internal view override returns (uint256) {
-    return _isSlisBnbWbnbPool() ? _poolPriceRate() : 0;
-  }
-
-  /* ─────────────────────────── internals ──────────────────────────── */
-
-  function _isSlisBnbWbnbPool() internal view returns (bool) {
-    return (TOKEN0 == SLISBNB && TOKEN1 == WBNB) || (TOKEN0 == WBNB && TOKEN1 == SLISBNB);
-  }
-
-  function _poolPriceRate() internal view returns (uint256) {
-    return TOKEN0 == SLISBNB ? STAKE_MANAGER.convertSnBnbToBnb(1e18) : STAKE_MANAGER.convertBnbToSnBnb(1e18);
+    return STAKE_MANAGER.convertSnBnbToBnb(1e18);
   }
 }

--- a/src/provider/v3/SlisBNBV3Provider.sol
+++ b/src/provider/v3/SlisBNBV3Provider.sol
@@ -86,6 +86,9 @@ contract SlisBNBV3Provider is V3Provider {
     uint256 price0 = IOracle(resilientOracle).peek(TOKEN0); // 8-decimal USD
     uint256 price1 = IOracle(resilientOracle).peek(TOKEN1); // 8-decimal USD
     uint256 bnbPrice = IOracle(resilientOracle).peek(BNB_ADDRESS); // 8-decimal USD
+    // Fail closed on a broken feed: a transiently-zero price would understate (possibly zero) the BNB
+    // value and make the slisBNBx minter burn the user's reward balance toward 0. Revert instead.
+    if (price0 == 0 || price1 == 0 || bnbPrice == 0) revert OracleZero();
 
     uint256 value0 = (user0 * price0 * 1e18) / (10 ** DECIMALS0);
     uint256 value1 = (user1 * price1 * 1e18) / (10 ** DECIMALS1);

--- a/src/provider/v3/SlisBNBV3Provider.sol
+++ b/src/provider/v3/SlisBNBV3Provider.sol
@@ -59,10 +59,11 @@ contract SlisBNBV3Provider is V3Provider {
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
+    uint160 targetSqrtPriceX96,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyRole(BOT) nonReentrant {
-    _guardedRebalance(minAmount0, minAmount1, minLiquidity, deadline, swapData);
+    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
   }
 
   /* ─────────────────── slisBNBx: sync / view ──────────────────────── */

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -161,6 +161,7 @@ abstract contract V3DexAdapter is
   error InsufficientBalance();
   error InsufficientAmount();
   error SpotDeviationTooHigh();
+  error ZeroAmount();
 
   /* ─────────────────────────── constructor ────────────────────────── */
 
@@ -327,6 +328,11 @@ abstract contract V3DexAdapter is
     // Overall-amount slippage floor: bounds the total actually delivered to the receiver, consistent
     // with what previewRemoveLiquidity reports, and covers the idle-only / dust-exit path too.
     if (amount0 < minAmount0 || amount1 < minAmount1) revert InsufficientAmount();
+
+    // Zero-output guard: a dust redeem where both the pro-rata liquidity and idle round to 0 would
+    // otherwise burn the caller's shares and deliver nothing when minAmount0/1 are 0 (the floor above
+    // is trivially satisfied by 0 >= 0). Revert so the share burn rolls back instead of being lost.
+    if (shares > 0 && amount0 == 0 && amount1 == 0) revert ZeroAmount();
 
     if (amount0 > 0) _sendToken(TOKEN0, amount0, payable(receiver));
     if (amount1 > 0) _sendToken(TOKEN1, amount1, payable(receiver));

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -160,6 +160,7 @@ abstract contract V3DexAdapter is
   error InvalidParam();
   error InsufficientBalance();
   error InsufficientAmount();
+  error SpotDeviationTooHigh();
 
   /* ─────────────────────────── constructor ────────────────────────── */
 
@@ -395,6 +396,7 @@ abstract contract V3DexAdapter is
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
+    uint160 targetSqrtPriceX96,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyProvider nonReentrant {
@@ -461,6 +463,16 @@ abstract contract V3DexAdapter is
     }
 
     if (uint256(mintedLiquidity) < minLiquidity) revert InsufficientLiquidityMinted();
+
+    // The minLiquidity floor alone can be satisfied by liquidity minted at a price manipulated around
+    // this call (then sandwiched on the back-swap). Bound the actual pool price after the swap+mint
+    // against the caller-supplied target: if the BOT's target != 0 (and the gate is enabled) the spot
+    // must be within maxSpotDeviationBps of it, so a price that was moved off the BOT's expectation
+    // reverts. target == 0 opts out (e.g. recenter with no price assertion).
+    if (targetSqrtPriceX96 != 0 && maxSpotDeviationBps != 0) {
+      if (!_priceWithinDeviation(spotSqrtPriceX96(), targetSqrtPriceX96, maxSpotDeviationBps))
+        revert SpotDeviationTooHigh();
+    }
 
     if (rateImplied) {
       uint256 oldCenterRate = lastCenterRate;
@@ -594,13 +606,17 @@ abstract contract V3DexAdapter is
   function _spotWithinFair() internal view returns (bool) {
     uint256 dev = maxSpotDeviationBps;
     if (dev == 0) return true;
-    uint256 fair = uint256(fairSqrtPriceX96());
-    uint256 spot = uint256(spotSqrtPriceX96());
-    uint256 priceFair = FullMath.mulDiv(fair, fair, 1 << 96);
-    uint256 priceSpot = FullMath.mulDiv(spot, spot, 1 << 96);
-    uint256 lo = FullMath.mulDiv(priceFair, BPS - dev, BPS);
-    uint256 hi = FullMath.mulDiv(priceFair, BPS + dev, BPS);
-    return priceSpot >= lo && priceSpot <= hi;
+    return _priceWithinDeviation(spotSqrtPriceX96(), fairSqrtPriceX96(), dev);
+  }
+
+  /// @dev True iff `aSqrt`'s price is within ±`dev` bps of `bSqrt`'s price (both sqrtPriceX96, Q96).
+  ///      Compared in price space (sqrt²) via overflow-safe mulDiv.
+  function _priceWithinDeviation(uint160 aSqrt, uint160 bSqrt, uint256 dev) internal pure returns (bool) {
+    uint256 priceA = FullMath.mulDiv(uint256(aSqrt), uint256(aSqrt), 1 << 96);
+    uint256 priceB = FullMath.mulDiv(uint256(bSqrt), uint256(bSqrt), 1 << 96);
+    uint256 lo = FullMath.mulDiv(priceB, BPS - dev, BPS);
+    uint256 hi = FullMath.mulDiv(priceB, BPS + dev, BPS);
+    return priceA >= lo && priceA <= hi;
   }
 
   /// @inheritdoc IV3DexAdapter

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -73,6 +73,8 @@ abstract contract V3DexAdapter is
   uint256 internal constant INITIAL_RANGE_BPS = 100;
   /// @dev Fallback half-range (ticks) around spot for non-rate (TWAP) pairs.
   int24 internal constant FALLBACK_HALF_RANGE_TICKS = 500;
+  /// @dev Fixed-point 2^128, the denominator of Uniswap V3 fee-growth (feeGrowthInside/Global) values.
+  uint256 internal constant Q128 = 1 << 128;
 
   /* ──────────────────────────── storage ───────────────────────────── */
 
@@ -465,9 +467,20 @@ abstract contract V3DexAdapter is
   function positionAmountsAt(uint160 sqrtPriceX96) public view returns (uint256 total0, uint256 total1) {
     if (tokenId == 0) return (idleToken0, idleToken1);
 
-    (, , , , , , , uint128 liquidity, , , uint128 tokensOwed0, uint128 tokensOwed1) = POSITION_MANAGER.positions(
-      tokenId
-    );
+    (
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      ,
+      uint128 liquidity,
+      uint256 feeGrowthInside0Last,
+      uint256 feeGrowthInside1Last,
+      uint128 tokensOwed0,
+      uint128 tokensOwed1
+    ) = POSITION_MANAGER.positions(tokenId);
 
     (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
       sqrtPriceX96,
@@ -476,8 +489,58 @@ abstract contract V3DexAdapter is
       liquidity
     );
 
-    total0 = amount0 + uint256(tokensOwed0) + idleToken0;
-    total1 = amount1 + uint256(tokensOwed1) + idleToken1;
+    // `tokensOwed{0,1}` only reflect fees checkpointed at the last NPM poke (mint/increase/decrease/
+    // collect). Fees earned in the pool since then are NOT in tokensOwed, so add the live pending amount
+    // (simulated from feeGrowthInside deltas) — otherwise every valuation built on this view (totalAssets,
+    // oracle peek, health checks, liquidations, slisBNBx) systematically under-values the collateral.
+    (uint256 pending0, uint256 pending1) = _pendingFees(liquidity, feeGrowthInside0Last, feeGrowthInside1Last);
+
+    total0 = amount0 + uint256(tokensOwed0) + pending0 + idleToken0;
+    total1 = amount1 + uint256(tokensOwed1) + pending1 + idleToken1;
+  }
+
+  /// @dev Uncollected fees earned since the position's last checkpoint, mirroring Uniswap V3's
+  ///      Tick.getFeeGrowthInside + Position.update. Uses the pool's CURRENT tick and cumulative fee
+  ///      growth (a pool fact, not spot-price-manipulable for value extraction), so it only ever
+  ///      corrects a stale under-count. All fee-growth arithmetic wraps by design (unchecked), exactly
+  ///      as the reference libraries compiled under Solidity <0.8.
+  function _pendingFees(
+    uint128 liquidity,
+    uint256 feeGrowthInside0Last,
+    uint256 feeGrowthInside1Last
+  ) internal view returns (uint256 pending0, uint256 pending1) {
+    if (liquidity == 0) return (0, 0);
+
+    (, int24 tickCurrent) = IV3PoolMinimal(POOL).slot0();
+    uint256 fgGlobal0 = IV3PoolMinimal(POOL).feeGrowthGlobal0X128();
+    uint256 fgGlobal1 = IV3PoolMinimal(POOL).feeGrowthGlobal1X128();
+    (, , uint256 lowerOutside0, uint256 lowerOutside1) = IV3PoolMinimal(POOL).ticks(tickLower);
+    (, , uint256 upperOutside0, uint256 upperOutside1) = IV3PoolMinimal(POOL).ticks(tickUpper);
+
+    unchecked {
+      uint256 below0;
+      uint256 below1;
+      uint256 above0;
+      uint256 above1;
+      if (tickCurrent >= tickLower) {
+        below0 = lowerOutside0;
+        below1 = lowerOutside1;
+      } else {
+        below0 = fgGlobal0 - lowerOutside0;
+        below1 = fgGlobal1 - lowerOutside1;
+      }
+      if (tickCurrent < tickUpper) {
+        above0 = upperOutside0;
+        above1 = upperOutside1;
+      } else {
+        above0 = fgGlobal0 - upperOutside0;
+        above1 = fgGlobal1 - upperOutside1;
+      }
+      uint256 inside0 = fgGlobal0 - below0 - above0;
+      uint256 inside1 = fgGlobal1 - below1 - above1;
+      pending0 = FullMath.mulDiv(inside0 - feeGrowthInside0Last, liquidity, Q128);
+      pending1 = FullMath.mulDiv(inside1 - feeGrowthInside1Last, liquidity, Q128);
+    }
   }
 
   /// @inheritdoc IV3DexAdapter

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -159,6 +159,7 @@ abstract contract V3DexAdapter is
   error SwapLossTooHigh();
   error InvalidParam();
   error InsufficientBalance();
+  error InsufficientAmount();
 
   /* ─────────────────────────── constructor ────────────────────────── */
 
@@ -299,7 +300,12 @@ abstract contract V3DexAdapter is
     uint128 liquidityToRemove = totalShares == 0 ? 0 : uint128((uint256(totalLiq) * shares) / totalShares);
 
     if (liquidityToRemove > 0) {
-      V3PositionLib.decreaseLiquidity(POSITION_MANAGER, tokenId, liquidityToRemove, minAmount0, minAmount1);
+      // Slippage is enforced on the OVERALL amount delivered (principal + fees + pro-rata idle) at the
+      // end of this function, NOT here on the burned principal alone. Callers size minAmount0/1 from
+      // previewRemoveLiquidity, which returns principal + pro-rata idle; a principal-only floor here
+      // would spuriously revert whenever idle is a meaningful share of the payout, and would not be
+      // enforced at all on an idle-only / dust (liquidityToRemove == 0) exit.
+      V3PositionLib.decreaseLiquidity(POSITION_MANAGER, tokenId, liquidityToRemove, 0, 0);
       (amount0, amount1) = V3PositionLib.collectAll(POSITION_MANAGER, tokenId);
     }
 
@@ -316,6 +322,10 @@ abstract contract V3DexAdapter is
         amount1 += idleOut1;
       }
     }
+
+    // Overall-amount slippage floor: bounds the total actually delivered to the receiver, consistent
+    // with what previewRemoveLiquidity reports, and covers the idle-only / dust-exit path too.
+    if (amount0 < minAmount0 || amount1 < minAmount1) revert InsufficientAmount();
 
     if (amount0 > 0) _sendToken(TOKEN0, amount0, payable(receiver));
     if (amount1 > 0) _sendToken(TOKEN1, amount1, payable(receiver));

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -412,6 +412,33 @@ abstract contract V3DexAdapter is
     int24 oldTickLower = tickLower;
     int24 oldTickUpper = tickUpper;
 
+    // Short-circuit a pure no-op recenter: the recomputed range matches the live one AND the caller
+    // asked us to enforce nothing (no swap-based inventory conversion, no target-price assertion, no
+    // slippage / min-liquidity floors). In that case a burn/mint would just re-create the identical
+    // position at the cost of gas and rounding dust. Compound accrued fees + idle into the existing
+    // position instead (itself spot-deviation guarded) and return. When any of those is supplied — a
+    // swap to run, a price/slippage/liquidity floor to honor, or a genuinely different range — we fall
+    // through to the full path so that work still happens and the guards are enforced.
+    if (
+      tokenId != 0 &&
+      newTickLower == oldTickLower &&
+      newTickUpper == oldTickUpper &&
+      swapData.length == 0 &&
+      targetSqrtPriceX96 == 0 &&
+      minAmount0 == 0 &&
+      minAmount1 == 0 &&
+      minLiquidity == 0
+    ) {
+      _collectAndCompound();
+      if (rateImplied) {
+        uint256 oldRate = lastCenterRate;
+        lastCenterRate = centerRate;
+        emit LastCenterRateUpdated(oldRate, centerRate);
+      }
+      emit Rebalanced(oldTickLower, oldTickUpper, newTickLower, newTickUpper, tokenId);
+      return;
+    }
+
     uint256 total0;
     uint256 total1;
     if (tokenId != 0) {
@@ -716,7 +743,9 @@ abstract contract V3DexAdapter is
     idleToken0 = toCompound0 - used0;
     idleToken1 = toCompound1 - used1;
 
-    emit Compounded(toCompound0, toCompound1, liquidityAdded);
+    // Emit the amounts actually consumed by increaseLiquidity, not the raw inputs — the leftover
+    // (toCompound - used) is held as idle, so the raw figures would overstate what was compounded.
+    emit Compounded(used0, used1, liquidityAdded);
   }
 
   function _getPositionLiquidity() internal view returns (uint128 liquidity) {
@@ -774,8 +803,16 @@ abstract contract V3DexAdapter is
       initialTickUpper = _ceilTick(currentTick + FALLBACK_HALF_RANGE_TICKS, tickSpacing);
     }
 
+    // _floorTick / _ceilTick can push an aligned tick just past the usable range (and TickMath /
+    // pool.mint would then revert). Clamp both bounds back into [MIN_TICK, MAX_TICK].
+    int24 minUsable = _ceilTick(TickMath.MIN_TICK, tickSpacing);
+    int24 maxUsable = _floorTick(TickMath.MAX_TICK, tickSpacing);
+    if (initialTickLower < minUsable) initialTickLower = minUsable;
+    if (initialTickUpper > maxUsable) initialTickUpper = maxUsable;
+
     if (initialTickLower >= initialTickUpper) {
-      initialTickUpper = initialTickLower + tickSpacing;
+      initialTickLower = maxUsable - tickSpacing;
+      initialTickUpper = maxUsable;
     }
   }
 

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -108,8 +108,16 @@ abstract contract V3DexAdapter is
   ///      this slippage on the converted leg. Default 50_000 = 5%.
   uint256 public maxSwapLossBp;
 
+  /// @dev Max allowed |pool spot − fair| price deviation (bps of price) for adding liquidity at the pool
+  ///      spot: the compound (permissionless) and the rebalance re-mint both call increaseLiquidity/mint
+  ///      with amountMin = 0 at the pool spot, so a flash-loan that skews spot could make the vault add
+  ///      liquidity at a manipulated price and get sandwiched on the attacker's back-swap. fairSqrtPriceX96
+  ///      is rate-anchored (flash-loan-immune for the LST pairs), so gating spot against it neutralises
+  ///      that vector. 0 disables the gate. Default INITIAL_RANGE_BPS (1%).
+  uint256 public maxSpotDeviationBps;
+
   /// @dev Reserved storage for future base variables (keep subclass storage stable on upgrade).
-  uint256[46] private __gap;
+  uint256[45] private __gap;
 
   /* ───────────────────────────── events ───────────────────────────── */
 
@@ -122,6 +130,8 @@ abstract contract V3DexAdapter is
   event Rebalanced(int24 oldTickLower, int24 oldTickUpper, int24 newTickLower, int24 newTickUpper, uint256 newTokenId);
   event SwapPairWhitelistSet(address indexed swapPair, bool status);
   event MaxSwapLossBpChanged(uint256 maxSwapLossBp);
+  event MaxSpotDeviationBpsChanged(uint256 maxSpotDeviationBps);
+  event CompoundSkippedSpotDeviated(uint160 spotSqrtPriceX96, uint160 fairSqrtPriceX96);
 
   /* ───────────────────────────── errors ───────────────────────────── */
 
@@ -205,6 +215,9 @@ abstract contract V3DexAdapter is
 
     maxSwapLossBp = 50_000; // 5% (ppm) — per-swap rate-anchored loss cap
     emit MaxSwapLossBpChanged(maxSwapLossBp);
+
+    maxSpotDeviationBps = INITIAL_RANGE_BPS; // 1% — spot-vs-fair gate for adding liquidity at pool spot
+    emit MaxSpotDeviationBpsChanged(maxSpotDeviationBps);
   }
 
   /// @notice Wire the vault that may drive this adapter. One-time, admin-only.
@@ -317,6 +330,14 @@ abstract contract V3DexAdapter is
     if (_centerRateThresholdBps > BPS) revert InvalidThreshold();
     centerRateThresholdBps = _centerRateThresholdBps;
     emit CenterRateThresholdChanged(_centerRateThresholdBps);
+  }
+
+  /// @notice Set the max |pool spot − fair| price deviation (bps) tolerated when adding liquidity at the
+  ///         pool spot (compound + rebalance re-mint). 0 disables the gate. onlyRole MANAGER.
+  function setMaxSpotDeviationBps(uint256 _maxSpotDeviationBps) external onlyRole(MANAGER) {
+    if (_maxSpotDeviationBps > BPS) revert InvalidThreshold();
+    maxSpotDeviationBps = _maxSpotDeviationBps;
+    emit MaxSpotDeviationBpsChanged(_maxSpotDeviationBps);
   }
 
   /// @notice Whitelist (or remove) a swap venue the rebalance inventory conversion may call. Backend-built
@@ -476,6 +497,22 @@ abstract contract V3DexAdapter is
     (sqrtPriceX96, ) = IV3PoolMinimal(POOL).slot0();
   }
 
+  /// @dev True when the pool spot price is within `maxSpotDeviationBps` (bps of price) of the fair price.
+  ///      Prices are compared in Q96 space (price = sqrtPriceX96^2 / 2^96) via FullMath, overflow-safe.
+  ///      `maxSpotDeviationBps == 0` disables the gate. `fair` is rate-anchored (flash-loan-immune for the
+  ///      LST pairs), so this refuses adding liquidity at a spot a flash-loan skewed away from fair.
+  function _spotWithinFair() internal view returns (bool) {
+    uint256 dev = maxSpotDeviationBps;
+    if (dev == 0) return true;
+    uint256 fair = uint256(fairSqrtPriceX96());
+    uint256 spot = uint256(spotSqrtPriceX96());
+    uint256 priceFair = FullMath.mulDiv(fair, fair, 1 << 96);
+    uint256 priceSpot = FullMath.mulDiv(spot, spot, 1 << 96);
+    uint256 lo = FullMath.mulDiv(priceFair, BPS - dev, BPS);
+    uint256 hi = FullMath.mulDiv(priceFair, BPS + dev, BPS);
+    return priceSpot >= lo && priceSpot <= hi;
+  }
+
   /// @inheritdoc IV3DexAdapter
   function previewAddLiquidity(
     uint256 amount0Desired,
@@ -526,6 +563,19 @@ abstract contract V3DexAdapter is
     uint256 toCompound0 = fees0 + idleToken0;
     uint256 toCompound1 = fees1 + idleToken1;
     if (toCompound0 == 0 && toCompound1 == 0) return;
+
+    // Never add liquidity at a manipulated pool spot. This compound runs (permissionlessly) as a
+    // side effect of deposit/withdraw/redeemShares with amountMin = 0, so a flash-loan that skews spot
+    // could make the vault add liquidity at a bad price and get sandwiched on the back-swap. fair is
+    // rate-anchored, so if spot deviates from it we SKIP the re-add (not revert — must not brick the
+    // user's hot-path op) and hold the collected fees as idle (valued at fair, unexposed) until a later
+    // compound when spot ~= fair.
+    if (!_spotWithinFair()) {
+      idleToken0 = toCompound0;
+      idleToken1 = toCompound1;
+      emit CompoundSkippedSpotDeviated(spotSqrtPriceX96(), fairSqrtPriceX96());
+      return;
+    }
 
     (uint128 liquidityAdded, uint256 used0, uint256 used1) = V3PositionLib.increaseLiquidity(
       POSITION_MANAGER,

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -676,15 +676,12 @@ abstract contract V3DexAdapter is
     uint256 totalShares
   ) external view returns (uint256 amount0, uint256 amount1) {
     if (totalShares == 0 || shares == 0) return (0, 0);
-    uint128 liquidityToRemove = uint128((uint256(_getPositionLiquidity()) * shares) / totalShares);
-    (amount0, amount1) = LiquidityAmounts.getAmountsForLiquidity(
-      spotSqrtPriceX96(),
-      TickMath.getSqrtRatioAtTick(tickLower),
-      TickMath.getSqrtRatioAtTick(tickUpper),
-      liquidityToRemove
-    );
-    amount0 += (idleToken0 * shares) / totalShares;
-    amount1 += (idleToken1 * shares) / totalShares;
+    // Pro-rata of the spot composition incl. pending fees + idle — matches removeLiquidity's actual
+    // (spot-priced) delivery, which the old formula understated by the uncollected fees. Spot (not fair)
+    // so the preview tracks the real burn; callers size minAmount from it.
+    (uint256 total0, uint256 total1) = positionAmountsAt(spotSqrtPriceX96());
+    amount0 = (total0 * shares) / totalShares;
+    amount1 = (total1 * shares) / totalShares;
   }
 
   /// @notice TWAP tick over TWAP_PERIOD seconds.

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -132,6 +132,8 @@ abstract contract V3DexAdapter is
   event MaxSwapLossBpChanged(uint256 maxSwapLossBp);
   event MaxSpotDeviationBpsChanged(uint256 maxSpotDeviationBps);
   event CompoundSkippedSpotDeviated(uint160 spotSqrtPriceX96, uint160 fairSqrtPriceX96);
+  event CompoundSkippedNoLiquidity(uint256 idleToken0, uint256 idleToken1);
+  event IdleCredited(uint256 amount0, uint256 amount1);
 
   /* ───────────────────────────── errors ───────────────────────────── */
 
@@ -154,6 +156,7 @@ abstract contract V3DexAdapter is
   error InvalidSwapPair();
   error SwapLossTooHigh();
   error InvalidParam();
+  error InsufficientBalance();
 
   /* ─────────────────────────── constructor ────────────────────────── */
 
@@ -321,6 +324,20 @@ abstract contract V3DexAdapter is
   /// @inheritdoc IV3DexAdapter
   function collectAndCompound() external onlyProvider nonReentrant {
     _collectAndCompound();
+  }
+
+  /// @inheritdoc IV3DexAdapter
+  function creditIdle(uint256 amount0, uint256 amount1) external onlyProvider nonReentrant {
+    // The provider transfers `amount0`/`amount1` here before calling; record them as idle inventory
+    // rather than minting into the pool. Deposits enter as idle at the current fair composition ratio
+    // (priced off-pool), then a later spot-gated compound() deploys them — this is what keeps share
+    // issuance free of the pool spot price. Assert the tokens really arrived so idle never exceeds the
+    // adapter's spendable balance (INV: idleTokenX <= balanceOf(this)).
+    if (amount0 > 0) idleToken0 += amount0;
+    if (amount1 > 0) idleToken1 += amount1;
+    if (idleToken0 > IERC20(TOKEN0).balanceOf(address(this))) revert InsufficientBalance();
+    if (idleToken1 > IERC20(TOKEN1).balanceOf(address(this))) revert InsufficientBalance();
+    emit IdleCredited(amount0, amount1);
   }
 
   /* ─────────────────────── manager / rebalance ────────────────────── */
@@ -574,6 +591,25 @@ abstract contract V3DexAdapter is
       idleToken0 = toCompound0;
       idleToken1 = toCompound1;
       emit CompoundSkippedSpotDeviated(spotSqrtPriceX96(), fairSqrtPriceX96());
+      return;
+    }
+
+    // One-sided inventory relative to the active range yields zero addable liquidity, which would
+    // revert inside pool.mint (require(amount > 0)). Hold everything as idle and skip this round
+    // instead of reverting, so deposit / withdraw / redeemShares (which reach here permissionlessly)
+    // are never bricked by a single-sided balance. The idle is deployed on a later compound once the
+    // opposite leg arrives or a rebalance recenters the range.
+    uint128 addable = LiquidityAmounts.getLiquidityForAmounts(
+      spotSqrtPriceX96(),
+      TickMath.getSqrtRatioAtTick(tickLower),
+      TickMath.getSqrtRatioAtTick(tickUpper),
+      toCompound0,
+      toCompound1
+    );
+    if (addable == 0) {
+      idleToken0 = toCompound0;
+      idleToken1 = toCompound1;
+      emit CompoundSkippedNoLiquidity(toCompound0, toCompound1);
       return;
     }
 

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -713,9 +713,14 @@ abstract contract V3DexAdapter is
     secondsAgos[0] = TWAP_PERIOD;
     secondsAgos[1] = 0;
     (int56[] memory tickCumulatives, ) = IListaV3Pool(POOL).observe(secondsAgos);
-    int56 delta = tickCumulatives[1] - tickCumulatives[0];
-    twapTick = int24(delta / int56(uint56(TWAP_PERIOD)));
-    if (delta < 0 && (delta % int56(uint56(TWAP_PERIOD)) != 0)) twapTick--;
+    // Match Uniswap's OracleLibrary.consult: the cumulative-tick subtraction is expected to wrap (the
+    // reference compiled under Solidity <0.8 with implicit wrap-around), so compute the TWAP tick in an
+    // unchecked block — otherwise a wrapped int56 delta would spuriously revert under 0.8 checked math.
+    unchecked {
+      int56 delta = tickCumulatives[1] - tickCumulatives[0];
+      twapTick = int24(delta / int56(uint56(TWAP_PERIOD)));
+      if (delta < 0 && (delta % int56(uint56(TWAP_PERIOD)) != 0)) twapTick--;
+    }
   }
 
   /// @dev Send `token` to `to`, unwrapping the wrapped-native token to native coin.

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -135,6 +135,10 @@ abstract contract V3Provider is
   error DailyLossExceeded();
   error OracleZero();
   error InvalidParam();
+  error InsufficientAmount();
+
+  /// @dev Fixed-point scale for the deposit composition-ratio math.
+  uint256 private constant WAD = 1e18;
 
   /* ─────────────────────────── constructor ────────────────────────── */
 
@@ -248,44 +252,74 @@ abstract contract V3Provider is
       IERC20(TOKEN1).safeTransferFrom(msg.sender, address(this), _amount1Desired);
     }
 
-    // Compound accrued fees first so existing holders capture them before new shares dilute.
+    // Compound accrued fees first so existing holders capture them before new shares dilute. This also
+    // folds all outstanding fees into the position / idle, so the composition snapshot below is complete.
     IV3DexAdapter(ADAPTER).collectAndCompound();
 
-    uint256 totalValueBefore;
     uint256 supplyBefore = totalSupply();
     uint160 fairSqrtPriceX96 = IV3DexAdapter(ADAPTER).fairSqrtPriceX96();
-    if (supplyBefore > 0) {
-      (uint256 total0Before, uint256 total1Before) = IV3DexAdapter(ADAPTER).positionAmountsAt(fairSqrtPriceX96);
-      totalValueBefore = _amountsValueUsd(total0Before, total1Before);
-      if (totalValueBefore == 0) revert ZeroShares();
-    }
 
-    // Forward the input to the adapter, which adds liquidity and refunds unused back to THIS vault.
-    // The refund is deliberately NOT sent to the depositor here: doing so (a native-BNB call) before
-    // shares are minted would expose a window where adapter NAV already includes the new liquidity
-    // but totalSupply() is still the old value, letting a malicious depositor reenter and read an
-    // inflated share price from the oracle (C-1). We forward the refund to the depositor only after
-    // _mint + supplyCollateral below, when NAV and totalSupply are consistent.
-    if (_amount0Desired > 0) IERC20(TOKEN0).safeTransfer(ADAPTER, _amount0Desired);
-    if (_amount1Desired > 0) IERC20(TOKEN1).safeTransfer(ADAPTER, _amount1Desired);
-
-    uint128 liquidityAdded;
-    (liquidityAdded, amount0Used, amount1Used) = IV3DexAdapter(ADAPTER).addLiquidity(
-      _amount0Desired,
-      _amount1Desired,
-      amount0Min,
-      amount1Min,
-      address(this)
-    );
-
-    (uint256 added0, uint256 added1) = IV3DexAdapter(ADAPTER).amountsForLiquidity(liquidityAdded, fairSqrtPriceX96);
-    uint256 addedValue = _amountsValueUsd(added0, added1);
     if (supplyBefore == 0) {
+      // First deposit: no existing composition to match and no holders to dilute. Mint the initial NFT
+      // position at spot and value it at fair via the oracle to set the opening share price. The
+      // spot-vs-fair over-crediting this path guards against needs pre-existing idle/holders, so it
+      // cannot occur on the first deposit; the first-depositor inflation surface is a separate concern.
+      //
+      // The addLiquidity refund is deliberately NOT sent to the depositor here (refundTo = this vault):
+      // a native-BNB refund before shares are minted would expose a window where adapter NAV already
+      // includes the new liquidity but totalSupply() is stale, letting a malicious depositor reenter and
+      // read an inflated share price (C-1). The vault refunds the depositor only after _mint below.
+      if (_amount0Desired > 0) IERC20(TOKEN0).safeTransfer(ADAPTER, _amount0Desired);
+      if (_amount1Desired > 0) IERC20(TOKEN1).safeTransfer(ADAPTER, _amount1Desired);
+      uint128 liquidityAdded;
+      (liquidityAdded, amount0Used, amount1Used) = IV3DexAdapter(ADAPTER).addLiquidity(
+        _amount0Desired,
+        _amount1Desired,
+        amount0Min,
+        amount1Min,
+        address(this)
+      );
+      (uint256 added0, uint256 added1) = IV3DexAdapter(ADAPTER).amountsForLiquidity(liquidityAdded, fairSqrtPriceX96);
       uint256 assetPrice = IOracle(resilientOracle).peek(asset()); // 8 decimals
-      if (assetPrice > 0) shares = (addedValue * (10 ** uint256(accountingAssetDecimals))) / assetPrice;
+      if (assetPrice > 0) {
+        shares = (_amountsValueUsd(added0, added1) * (10 ** uint256(accountingAssetDecimals))) / assetPrice;
+      }
     } else {
-      shares = (addedValue * supplyBefore) / totalValueBefore;
+      // Subsequent deposit: issue shares purely proportional to the existing position
+      // composition — never from a pool-spot mint re-valued at fair. Snapshot the composition at the
+      // fair price (positionAmountsAt already includes idle inventory + collected fees), bind the deposit
+      // to that ratio, and park the consumed tokens as IDLE rather than minting into the pool. The pool
+      // spot price never enters share issuance, so the mint-at-spot / value-at-fair gap that let a
+      // depositor be over-credited (with idle present) is eliminated. Value-conserving: the depositor
+      // adds exactly `frac` of each composition leg and receives `frac` of the supply.
+      (uint256 t0, uint256 t1) = IV3DexAdapter(ADAPTER).positionAmountsAt(fairSqrtPriceX96);
+      if (_amountsValueUsd(t0, t1) == 0) revert ZeroShares();
+
+      uint256 frac; // WAD-scaled fraction of the existing composition being added
+      if (t0 == 0) {
+        frac = (_amount1Desired * WAD) / t1;
+      } else if (t1 == 0) {
+        frac = (_amount0Desired * WAD) / t0;
+      } else {
+        uint256 f0 = (_amount0Desired * WAD) / t0;
+        uint256 f1 = (_amount1Desired * WAD) / t1;
+        frac = f0 < f1 ? f0 : f1;
+      }
+
+      amount0Used = (t0 * frac) / WAD;
+      amount1Used = (t1 * frac) / WAD;
+      // Repurposed slippage guard: amount0Min/amount1Min are now the minimum of each leg that must be
+      // consumed (the rest is refunded), protecting the depositor from an unexpected composition ratio.
+      if (amount0Used < amount0Min || amount1Used < amount1Min) revert InsufficientAmount();
+
+      shares = (supplyBefore * frac) / WAD;
+
+      // Park the consumed tokens into the adapter's idle inventory (deployed later by compound()).
+      if (amount0Used > 0) IERC20(TOKEN0).safeTransfer(ADAPTER, amount0Used);
+      if (amount1Used > 0) IERC20(TOKEN1).safeTransfer(ADAPTER, amount1Used);
+      IV3DexAdapter(ADAPTER).creditIdle(amount0Used, amount1Used);
     }
+
     if (shares == 0) revert ZeroShares();
 
     _mint(address(this), shares);
@@ -300,8 +334,22 @@ abstract contract V3Provider is
     // totalSupply are consistent, so the (native-BNB) refund callback cannot inflate the share price.
     uint256 refund0 = _amount0Desired - amount0Used;
     uint256 refund1 = _amount1Desired - amount1Used;
+    // The subsequent-deposit path leaves the WRAPPED_NATIVE leftover in the vault as WBNB, whereas the
+    // first-deposit path already received it as native from the adapter's addLiquidity refund. _refund
+    // sends the wrapped-native leg as native BNB, so normalize the subsequent case by unwrapping here.
+    if (supplyBefore > 0) {
+      if (TOKEN0 == WRAPPED_NATIVE && refund0 > 0) IWBNB(WRAPPED_NATIVE).withdraw(refund0);
+      if (TOKEN1 == WRAPPED_NATIVE && refund1 > 0) IWBNB(WRAPPED_NATIVE).withdraw(refund1);
+    }
     if (refund0 > 0) _refund(TOKEN0, refund0, msg.sender);
     if (refund1 > 0) _refund(TOKEN1, refund1, msg.sender);
+
+    // NOTE: the subsequent-deposit path deliberately does NOT deploy the freshly-parked
+    // idle into the pool here. Deposits enter as idle valued at the fair composition and are matched by
+    // proportionally-minted shares, so the deposit is exactly value-conserving and never touches the pool
+    // spot price. The idle is deployed later by the permissionless compound() (keeper cadence) or the
+    // next deposit/withdraw's collectAndCompound, always spot-gated. Deploying it inline here would mint
+    // at spot and realize a small IL shared by all holders — a (tiny) dilution triggered by a new deposit.
   }
 
   /// @inheritdoc IV3Provider
@@ -412,11 +460,31 @@ abstract contract V3Provider is
   }
 
   /// @notice Simulate a deposit at the current pool price (for tight amount0Min/amount1Min).
+  /// @notice Preview the token amounts a deposit would consume.
+  /// @dev For the first deposit (totalSupply == 0) this previews the pool mint (liquidity + amounts at
+  ///      spot). For subsequent deposits it previews the composition-ratio binding used by deposit():
+  ///      the amounts are `frac` of the current fair composition, where `frac = min(d0/T0, d1/T1)`, and
+  ///      `liquidity` is returned as 0 since the deposit is parked as idle rather than minted.
   function previewDepositAmounts(
     uint256 amount0Desired,
     uint256 amount1Desired
   ) external view returns (uint128 liquidity, uint256 amount0, uint256 amount1) {
-    return IV3DexAdapter(ADAPTER).previewAddLiquidity(amount0Desired, amount1Desired);
+    if (totalSupply() == 0) {
+      return IV3DexAdapter(ADAPTER).previewAddLiquidity(amount0Desired, amount1Desired);
+    }
+    (uint256 t0, uint256 t1) = IV3DexAdapter(ADAPTER).positionAmountsAt(IV3DexAdapter(ADAPTER).fairSqrtPriceX96());
+    uint256 frac;
+    if (t0 == 0) {
+      frac = t1 == 0 ? 0 : (amount1Desired * WAD) / t1;
+    } else if (t1 == 0) {
+      frac = (amount0Desired * WAD) / t0;
+    } else {
+      uint256 f0 = (amount0Desired * WAD) / t0;
+      uint256 f1 = (amount1Desired * WAD) / t1;
+      frac = f0 < f1 ? f0 : f1;
+    }
+    amount0 = (t0 * frac) / WAD;
+    amount1 = (t1 * frac) / WAD;
   }
 
   /// @notice IProvider hook — the "token" is this shares contract itself.
@@ -490,9 +558,12 @@ abstract contract V3Provider is
     }
   }
 
-  /// @dev Accept native BNB only from the adapter (WBNB refund unwrapped during deposit).
+  /// @dev Accept native BNB only from the adapter (its WBNB-unwrap refund) or from the wrapped-native
+  ///      token itself (when this vault unwraps a subsequent-deposit WBNB leftover before refunding it
+  ///      as native). No other sender may push native in; the vault's NAV is read from the adapter
+  ///      composition, not its native balance, so an accepted transfer cannot distort share pricing.
   receive() external payable {
-    if (msg.sender != ADAPTER) revert NotAdapter();
+    if (msg.sender != ADAPTER && msg.sender != WRAPPED_NATIVE) revert NotAdapter();
   }
 
   /// @notice Permissionlessly collect and compound accrued swap fees back into the position.

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -495,6 +495,16 @@ abstract contract V3Provider is
     if (msg.sender != ADAPTER) revert NotAdapter();
   }
 
+  /// @notice Permissionlessly collect and compound accrued swap fees back into the position.
+  /// @dev Lets keepers sweep fees on a regular cadence instead of only as a side effect of user actions,
+  ///      so fees never accumulate into a large amount that could be sandwiched, and so buy-and-hold
+  ///      vaults keep compounding. Safe to leave permissionless: the adapter's
+  ///      _collectAndCompound self-gates on the spot-vs-fair deviation and simply skips the re-add (holding
+  ///      fees as idle) when the pool spot is manipulated, so a caller cannot force a bad-price compound.
+  function compound() external nonReentrant {
+    IV3DexAdapter(ADAPTER).collectAndCompound();
+  }
+
   /* ─────────────────── rebalance loss guard (NAV + daily caps) ──────────────── */
 
   /// @notice Set the per-rebalance fair-NAV loss cap, in ppm (LOSS_DENOM = 1e6). onlyRole MANAGER.

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -223,6 +223,7 @@ abstract contract V3Provider is
     uint256 amount1Desired,
     uint256 amount0Min,
     uint256 amount1Min,
+    uint256 minShares,
     address onBehalf
   ) external payable nonReentrant returns (uint256 shares, uint256 amount0Used, uint256 amount1Used) {
     if (marketParams.collateralToken != address(this)) revert InvalidCollateralToken();
@@ -321,6 +322,11 @@ abstract contract V3Provider is
     }
 
     if (shares == 0) revert ZeroShares();
+    // Caller-specified share-slippage floor. Protects a depositor from receiving fewer shares than their
+    // contribution warrants — e.g. a first-depositor inflation attack (H02 / Issue_04) that inflates the
+    // position via a direct NPM.increaseLiquidity donation, or the fair composition shifting between the
+    // off-chain preview and execution (M01). Pass 0 to disable.
+    if (shares < minShares) revert InsufficientShares();
 
     _mint(address(this), shares);
     _approve(address(this), address(MOOLAH), shares);
@@ -454,6 +460,15 @@ abstract contract V3Provider is
     return IV3DexAdapter(ADAPTER).positionAmountsAt(IV3DexAdapter(ADAPTER).spotSqrtPriceX96());
   }
 
+  /// @inheritdoc IV3Provider
+  /// @dev The managed position's token composition valued at the FAIR (manipulation-resistant) price,
+  ///      inclusive of idle inventory and collected fees. This is the ratio a subsequent deposit binds
+  ///      to; front-ends should size the two deposit legs in this ratio to minimise the refund. Returns
+  ///      (0, 0) before the first deposit (no position yet) — use previewDepositAmounts for that case.
+  function getFairComposition() public view returns (uint256 total0, uint256 total1) {
+    return IV3DexAdapter(ADAPTER).positionAmountsAt(IV3DexAdapter(ADAPTER).fairSqrtPriceX96());
+  }
+
   /// @notice Simulate a redemption of `shares` at the current pool price (for tight minAmount0/1).
   function previewRedeemUnderlying(uint256 shares) external view returns (uint256 amount0, uint256 amount1) {
     return IV3DexAdapter(ADAPTER).previewRemoveLiquidity(shares, totalSupply());
@@ -485,6 +500,25 @@ abstract contract V3Provider is
     }
     amount0 = (t0 * frac) / WAD;
     amount1 = (t1 * frac) / WAD;
+  }
+
+  /// @notice Given a desired token0 amount, the token1 amount that pairs with it at the current fair
+  ///         composition ratio, so a subsequent deposit consumes both legs fully (minimal refund).
+  /// @dev    amount1 = amount0 * T1 / T0, where (T0, T1) = getFairComposition(). Reverts if the fair
+  ///         composition has no token0 leg (in that one-sided case deposit token1 only). For the first
+  ///         deposit (no position yet) use previewDepositAmounts, which previews the spot mint instead.
+  function previewDepositForToken0(uint256 amount0) external view returns (uint256 amount1) {
+    (uint256 t0, uint256 t1) = getFairComposition();
+    if (t0 == 0) revert ZeroAmounts();
+    amount1 = (amount0 * t1) / t0;
+  }
+
+  /// @notice Mirror of previewDepositForToken0: the token0 amount that pairs with a desired token1
+  ///         amount at the current fair composition ratio (amount0 = amount1 * T0 / T1).
+  function previewDepositForToken1(uint256 amount1) external view returns (uint256 amount0) {
+    (uint256 t0, uint256 t1) = getFairComposition();
+    if (t1 == 0) revert ZeroAmounts();
+    amount0 = (amount1 * t0) / t1;
   }
 
   /// @notice IProvider hook — the "token" is this shares contract itself.

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -210,6 +210,7 @@ abstract contract V3Provider is
     uint256 value
   ) public override(ERC20Upgradeable, IERC20) returns (bool) {
     if (msg.sender != address(MOOLAH)) revert OnlyMoolah();
+    _spendAllowance(from, msg.sender, value); // decrement the granted allowance like a standard ERC20 pull
     _transfer(from, to, value);
     return true;
   }
@@ -372,10 +373,12 @@ abstract contract V3Provider is
     if (receiver == address(0)) revert ZeroAddress();
     if (!_isSenderAuthorized(onBehalf)) revert Unauthorized();
 
+    // Compound accrued fees BEFORE Moolah's health check so the position is valued with fees folded in
+    // (not under-valued mid-withdrawal).
+    IV3DexAdapter(ADAPTER).collectAndCompound();
+
     MOOLAH.withdrawCollateral(marketParams, shares, onBehalf, address(this));
     _afterCollateralChange(marketParams.id(), onBehalf);
-
-    IV3DexAdapter(ADAPTER).collectAndCompound();
 
     // CEI: burn before the adapter removes liquidity and pushes underlying to `receiver`, so
     // totalSupply stays consistent with the reduced position during the (native-BNB) callback —
@@ -400,6 +403,9 @@ abstract contract V3Provider is
     if (receiver == address(0)) revert ZeroAddress();
     if (!_isSenderAuthorized(onBehalf)) revert Unauthorized();
 
+    // Compound accrued fees before Moolah's health check so it values the position with fees included.
+    IV3DexAdapter(ADAPTER).collectAndCompound();
+
     MOOLAH.withdrawCollateral(marketParams, shares, onBehalf, address(this));
     _afterCollateralChange(marketParams.id(), onBehalf);
 
@@ -413,6 +419,9 @@ abstract contract V3Provider is
     if (shares == 0) revert ZeroShares();
     if (onBehalf == address(0)) revert ZeroAddress();
     if (balanceOf(msg.sender) < shares) revert InsufficientShares();
+
+    // Compound accrued fees before supplying into Moolah so the position is valued with fees included.
+    IV3DexAdapter(ADAPTER).collectAndCompound();
 
     _transfer(msg.sender, address(this), shares);
     _approve(address(this), address(MOOLAH), shares);
@@ -549,6 +558,9 @@ abstract contract V3Provider is
   function _amountsValueUsd(uint256 amount0, uint256 amount1) internal view returns (uint256) {
     uint256 price0 = IOracle(resilientOracle).peek(TOKEN0); // 8 decimals
     uint256 price1 = IOracle(resilientOracle).peek(TOKEN1); // 8 decimals
+    // Fail closed: a broken feed on either leg (price 0) must revert, not silently value the position on
+    // one leg (which would under-price the collateral and enable unfair liquidation / over-borrow).
+    if (price0 == 0 || price1 == 0) revert OracleZero();
     return (amount0 * price0) / (10 ** DECIMALS0) + (amount1 * price1) / (10 ** DECIMALS1);
   }
 

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -638,13 +638,14 @@ abstract contract V3Provider is
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
+    uint160 targetSqrtPriceX96,
     uint256 deadline,
     bytes calldata swapData
   ) internal {
     uint256 navBefore = _positionValueUsd();
     if (totalSupply() != 0 && navBefore == 0) revert OracleZero();
 
-    IV3DexAdapter(ADAPTER).rebalance(minAmount0, minAmount1, minLiquidity, deadline, swapData);
+    IV3DexAdapter(ADAPTER).rebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
 
     uint256 navAfter = _positionValueUsd();
 

--- a/src/provider/v3/V3ProviderOracle.sol
+++ b/src/provider/v3/V3ProviderOracle.sol
@@ -137,15 +137,18 @@ contract V3ProviderOracle is UUPSUpgradeable, AccessControlEnumerableUpgradeable
     // Verified on-chain to the wei (e.g. peek(wstETH) == peek(WETH) × wstETH.stEthPerToken() / 1e18).
     uint256 price0 = IOracle(resilientOracle).peek(TOKEN0); // 8 decimals (rate-derived for the LST leg)
     uint256 price1 = IOracle(resilientOracle).peek(TOKEN1); // 8 decimals
-    if (price0 == 0 || price1 == 0) revert ZeroPrice(); // finding D
+    if (price0 == 0 || price1 == 0) revert ZeroPrice(); // broken feed: fail closed
 
     uint256 totalValue = (total0 * price0) / (10 ** DECIMALS0) + (total1 * price1) / (10 ** DECIMALS1);
-    if (totalValue == 0) revert ZeroPrice(); // finding D
 
     // 8-decimal USD price per ONE WHOLE share (10 ** SHARE_DECIMALS share-wei) — Moolah interprets peek()
     // using collateralToken.decimals() — minus the conservative haircut.
     uint256 raw = (totalValue * (10 ** SHARE_DECIMALS)) / supply;
-    return (raw * (BPS - haircutBps)) / BPS;
+    uint256 price = (raw * (BPS - haircutBps)) / BPS;
+    // Dust position rounds to 0: floor, don't revert (a reverting peek bricks liquidation). Avoid 0 —
+    // Moolah's liquidation math degenerates at price 0.
+    if (price == 0) price = 1;
+    return price;
   }
 
   /// @inheritdoc IOracle

--- a/src/provider/v3/V3ProviderOracle.sol
+++ b/src/provider/v3/V3ProviderOracle.sol
@@ -105,6 +105,7 @@ contract V3ProviderOracle is UUPSUpgradeable, AccessControlEnumerableUpgradeable
 
     resilientOracle = _resilientOracle;
     haircutBps = _haircutBps;
+    emit HaircutChanged(_haircutBps);
   }
 
   /* ─────────────────────── IOracle implementation ─────────────────── */
@@ -166,6 +167,7 @@ contract V3ProviderOracle is UUPSUpgradeable, AccessControlEnumerableUpgradeable
   /// @inheritdoc IV3ProviderOracle
   function setHaircutBps(uint256 _haircutBps) external onlyRole(MANAGER) {
     if (_haircutBps > MAX_HAIRCUT_BPS) revert InvalidHaircut();
+    if (_haircutBps == haircutBps) return; // no-op: skip the redundant write + misleading event
     haircutBps = _haircutBps;
     emit HaircutChanged(_haircutBps);
   }

--- a/src/provider/v3/WbETHV3Provider.sol
+++ b/src/provider/v3/WbETHV3Provider.sol
@@ -35,9 +35,10 @@ contract WbETHV3Provider is V3Provider {
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
+    uint160 targetSqrtPriceX96,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyRole(BOT) nonReentrant {
-    _guardedRebalance(minAmount0, minAmount1, minLiquidity, deadline, swapData);
+    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
   }
 }

--- a/src/provider/v3/WstETHV3Provider.sol
+++ b/src/provider/v3/WstETHV3Provider.sol
@@ -34,9 +34,10 @@ contract WstETHV3Provider is V3Provider {
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
+    uint160 targetSqrtPriceX96,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyRole(BOT) nonReentrant {
-    _guardedRebalance(minAmount0, minAmount1, minLiquidity, deadline, swapData);
+    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
   }
 }

--- a/test/liquidator/V3Liquidator.t.sol
+++ b/test/liquidator/V3Liquidator.t.sol
@@ -230,6 +230,19 @@ contract V3LiquidatorTest is Test {
     );
   }
 
+  /// @dev Mock collateral oracle to `bps`/10000 of its real price — unhealthy (borrowed at 60% LTV vs a
+  ///      70% LLTV survives only down to ~86% of original price) but, unlike `_makeUnhealthy` (price=0),
+  ///      leaves `seizedAssetsQuoted` (and thus `repaidAssets`) genuinely positive so tests can exercise
+  ///      the NoProfit profitability check on a real repayment amount instead of a trivial ~0 one.
+  function _makeUnhealthyPartial(uint256 bps) internal {
+    uint256 originalPrice = providerOracle.peek(address(provider));
+    vm.mockCall(
+      address(providerOracle),
+      abi.encodeWithSelector(IOracle.peek.selector, address(provider)),
+      abi.encode((originalPrice * bps) / 10_000)
+    );
+  }
+
   /* ─────────────────── whitelist management ───────────────────────── */
 
   function test_setTokenWhitelist_togglesAndReverts() public {
@@ -438,6 +451,57 @@ contract V3LiquidatorTest is Test {
     assertEq(_collateral(user), 0, "borrower collateral seized");
     // Excess lisUSD (borrowed*2 - repaidAssets ≈ borrowed) remains in liquidator.
     assertGt(IERC20(LISUSD).balanceOf(address(liquidator)), 0, "excess lisUSD in liquidator");
+  }
+
+  /// @dev Regression: a stale absolute-balance check (`balanceOf(this) < repaidAssets`) lets an
+  ///      unprofitable flash liquidation settle against loanToken the liquidator already holds from
+  ///      unrelated prior activity, silently draining those reserves. Uses `_makeUnhealthyPartial` (not
+  ///      `_makeUnhealthy`'s price=0) so `repaidAssets` is a real, positive number — with price=0,
+  ///      `seizedAssetsQuoted` and hence `repaidAssets` round to ~0 and the check is trivially satisfied
+  ///      regardless of the fix, masking the bug. Pre-fund the liquidator with a reserve cushion large
+  ///      enough to cover repayment on its own, then run a flash liquidation whose swaps yield zero
+  ///      lisUSD. The fix (before/after delta check) must revert NoProfit regardless of the pre-existing
+  ///      balance, because THIS liquidation's redeem+swap produced no proceeds.
+  function test_flashLiquidate_revertsIfSwapUnprofitable_evenWithPreFundedReserves() public {
+    (uint256 shares, , ) = _deposit(user, 10 ether, 10 ether);
+    uint256 borrowed = _borrowAgainstCollateral(user);
+    _makeUnhealthyPartial(5_000); // 50% of real price — unhealthy (60% LTV vs 70% LLTV), repaidAssets > 0
+
+    // Reserve cushion from unrelated prior activity — comfortably covers repaidAssets by itself.
+    deal(LISUSD, address(liquidator), borrowed * 10);
+
+    // Both legs swap for zero lisUSD out — this liquidation's redeem+swap is a total loss.
+    bytes memory swap0Data = abi.encodeWithSelector(
+      mockSwap.swap.selector,
+      SLISBNB, // tokenIn
+      LISUSD, // tokenOut
+      uint256(0), // amountIn
+      uint256(0) // amountOutMin — zero proceeds from this leg
+    );
+    bytes memory swap1Data = abi.encodeWithSelector(
+      mockSwap.swap.selector,
+      BNB_ADDRESS, // tokenIn (native BNB path)
+      LISUSD,
+      uint256(0), // amountIn
+      uint256(0) // amountOutMin — zero proceeds from this leg
+    );
+
+    V3Liquidator.FlashLiquidateParams memory params = V3Liquidator.FlashLiquidateParams({
+      v3Provider: address(provider),
+      minToken0Amt: 0,
+      minToken1Amt: 0,
+      redeemShares: true,
+      token0Pair: address(mockSwap),
+      token0Spender: address(0),
+      token1Pair: address(mockSwap),
+      token1Spender: address(0),
+      swapToken0Data: swap0Data,
+      swapToken1Data: swap1Data
+    });
+
+    vm.prank(bot);
+    vm.expectRevert(V3Liquidator.NoProfit.selector);
+    liquidator.flashLiquidate(Id.unwrap(marketId), user, shares, params);
   }
 
   function test_flashLiquidate_revertsIfMarketNotWhitelisted() public {

--- a/test/liquidator/V3Liquidator.t.sol
+++ b/test/liquidator/V3Liquidator.t.sol
@@ -201,6 +201,7 @@ contract V3LiquidatorTest is Test {
       amount1,
       (exp0 * 999) / 1000,
       (exp1 * 999) / 1000,
+      0,
       _user
     );
     vm.stopPrank();

--- a/test/liquidator/V3Liquidator.t.sol
+++ b/test/liquidator/V3Liquidator.t.sol
@@ -454,6 +454,57 @@ contract V3LiquidatorTest is Test {
     assertGt(IERC20(LISUSD).balanceOf(address(liquidator)), 0, "excess lisUSD in liquidator");
   }
 
+  /// @dev The V3Liquidation event must report the amounts actually redeemed in the callback, not the
+  ///      hardcoded 0 / 0 it previously logged. Both legs (SLISBNB, WBNB→native) are non-zero here.
+  function test_flashLiquidate_eventReportsRedeemedAmounts() public {
+    (uint256 shares, , ) = _deposit(user, 10 ether, 10 ether);
+    uint256 borrowed = _borrowAgainstCollateral(user);
+    _makeUnhealthy();
+
+    bytes memory swap0Data = abi.encodeWithSelector(mockSwap.swap.selector, SLISBNB, LISUSD, uint256(0), borrowed * 2);
+    bytes memory swap1Data = abi.encodeWithSelector(
+      mockSwap.swap.selector,
+      BNB_ADDRESS,
+      LISUSD,
+      uint256(0),
+      uint256(0)
+    );
+
+    V3Liquidator.FlashLiquidateParams memory params = V3Liquidator.FlashLiquidateParams({
+      v3Provider: address(provider),
+      minToken0Amt: 0,
+      minToken1Amt: 0,
+      redeemShares: true,
+      token0Pair: address(mockSwap),
+      token0Spender: address(0),
+      token1Pair: address(mockSwap),
+      token1Spender: address(0),
+      swapToken0Data: swap0Data,
+      swapToken1Data: swap1Data
+    });
+
+    vm.recordLogs();
+    vm.prank(bot);
+    liquidator.flashLiquidate(Id.unwrap(marketId), user, shares, params);
+
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+    bool found;
+    for (uint256 i = 0; i < logs.length; i++) {
+      if (logs[i].topics[0] == V3Liquidator.V3Liquidation.selector) {
+        (uint256 seized, uint256 repaid, uint256 amount0, uint256 amount1) = abi.decode(
+          logs[i].data,
+          (uint256, uint256, uint256, uint256)
+        );
+        seized;
+        repaid;
+        assertGt(amount0, 0, "event reports redeemed token0");
+        assertGt(amount1, 0, "event reports redeemed token1");
+        found = true;
+      }
+    }
+    assertTrue(found, "V3Liquidation event emitted");
+  }
+
   /// @dev Regression: a stale absolute-balance check (`balanceOf(this) < repaidAssets`) lets an
   ///      unprofitable flash liquidation settle against loanToken the liquidator already holds from
   ///      unrelated prior activity, silently draining those reserves. Uses `_makeUnhealthyPartial` (not

--- a/test/liquidator/V3LiquidatorEth.t.sol
+++ b/test/liquidator/V3LiquidatorEth.t.sol
@@ -194,7 +194,7 @@ contract V3LiquidatorEthTest is Test {
     vm.startPrank(user);
     IERC20(WSTETH).approve(address(provider), amtWst);
     IERC20(WETH).approve(address(provider), amtWeth);
-    (shares, , ) = provider.deposit(mp, amtWst, amtWeth, (e0 * 99) / 100, (e1 * 99) / 100, user);
+    (shares, , ) = provider.deposit(mp, amtWst, amtWeth, (e0 * 99) / 100, (e1 * 99) / 100, 0, user);
     vm.stopPrank();
   }
 

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -1506,6 +1506,37 @@ contract SlisBNBV3ProviderTest is Test {
     provider.redeemShares(shares, min0, exp1 * 2, user2);
   }
 
+  /// @dev Counter-test: the removeLiquidity slippage floor must apply to the OVERALL amount delivered
+  ///      (principal + fees + pro-rata idle), matching what previewRedeemUnderlying reports — not to the
+  ///      burned principal alone. Previously a withdraw/redeem whose minAmount was sized from the preview
+  ///      reverted (decreaseLiquidity's principal-only check) once idle was a meaningful share of the
+  ///      payout. One-sided idle keeps the pre-removeLiquidity compound a no-op, so the idle survives to
+  ///      be paid out — the exact condition that tripped the old floor.
+  function test_redeemShares_minAmountFloor_coversIdlePayout() public {
+    (uint256 shares, , ) = _deposit(user, 10 ether, 10 ether);
+    vm.prank(MOOLAH_PROXY);
+    provider.transfer(user2, shares);
+
+    // Force a one-sided idle state (token0 only) so collectAndCompound no-ops and the idle is not
+    // deployed before removeLiquidity pays it out pro-rata.
+    uint256 idle0 = 5 ether;
+    deal(SLISBNB, address(adapter), IERC20(SLISBNB).balanceOf(address(adapter)) + idle0);
+    stdstore.target(address(adapter)).sig("idleToken0()").checked_write(adapter.idleToken0() + idle0);
+    stdstore.target(address(adapter)).sig("idleToken1()").checked_write(uint256(0));
+
+    // Preview reports principal + pro-rata idle; a tight (preview-sized) floor must now pass.
+    (uint256 exp0, uint256 exp1) = provider.previewRedeemUnderlying(shares);
+    uint256 min0 = (exp0 * 999) / 1000;
+    uint256 min1 = (exp1 * 999) / 1000;
+    assertGt(exp0, 0, "preview includes idle payout");
+
+    vm.prank(user2);
+    (uint256 out0, uint256 out1) = provider.redeemShares(shares, min0, min1, user2);
+
+    assertGe(out0, min0, "delivered token0 >= preview-derived floor (incl. idle)");
+    assertGe(out1, min1, "delivered token1 >= floor");
+  }
+
   /* ──────────── withdraw token composition by price position ─────── */
 
   function test_withdraw_belowRange_returnsToken0Only() public {

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -2552,4 +2552,20 @@ contract SlisBNBV3ProviderTest is Test {
     vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
     provider.rebalance(0, 0, 0, fairTarget, block.timestamp, "");
   }
+
+  /// @dev setHaircutBps is a no-op when the value is unchanged (no redundant write / misleading event).
+  function test_setHaircutBps_noOpWhenUnchanged() public {
+    uint256 h0 = providerOracle.haircutBps();
+
+    vm.recordLogs();
+    vm.prank(manager);
+    providerOracle.setHaircutBps(h0); // unchanged → no-op
+    assertEq(vm.getRecordedLogs().length, 0, "no event emitted when haircut is unchanged");
+    assertEq(providerOracle.haircutBps(), h0, "haircut unchanged");
+
+    uint256 h1 = h0 == 0 ? 50 : 0;
+    vm.prank(manager);
+    providerOracle.setHaircutBps(h1); // real change → applies
+    assertEq(providerOracle.haircutBps(), h1, "haircut updated on a real change");
+  }
 }

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -2233,4 +2233,63 @@ contract SlisBNBV3ProviderTest is Test {
     vm.expectRevert(V3DexAdapter.SwapLossTooHigh.selector);
     provider.rebalance(0, 0, 0, block.timestamp, data);
   }
+
+  /* ───────────── Spot-vs-fair gate when adding liquidity at pool spot ───────────── */
+
+  function test_spotDeviationGate_defaults() public view {
+    assertEq(adapter.maxSpotDeviationBps(), 100, "default spot-deviation gate = 1%");
+  }
+
+  function test_setMaxSpotDeviationBps_accessAndCaps() public {
+    vm.prank(manager);
+    adapter.setMaxSpotDeviationBps(250);
+    assertEq(adapter.maxSpotDeviationBps(), 250);
+
+    vm.prank(manager);
+    vm.expectRevert(V3DexAdapter.InvalidThreshold.selector);
+    adapter.setMaxSpotDeviationBps(10_001); // > BPS
+
+    vm.expectRevert(); // non-manager
+    adapter.setMaxSpotDeviationBps(50);
+  }
+
+  /// @dev Give the adapter idle inventory to compound (mirrors test_deposit_afterIdle…).
+  function _injectIdle(uint256 idle0, uint256 idle1) internal {
+    deal(SLISBNB, address(adapter), IERC20(SLISBNB).balanceOf(address(adapter)) + idle0);
+    deal(WBNB, address(adapter), IERC20(WBNB).balanceOf(address(adapter)) + idle1);
+    stdstore.target(address(adapter)).sig("idleToken0()").checked_write(adapter.idleToken0() + idle0);
+    stdstore.target(address(adapter)).sig("idleToken1()").checked_write(adapter.idleToken1() + idle1);
+  }
+
+  /// @dev Push the pool spot far above the rate-anchored fair price (sell WBNB/token1 → slisBNB/token0).
+  function _skewSpotUp() internal {
+    PoolSwapper swapper = new PoolSwapper();
+    deal(WBNB, address(swapper), 120_000 ether);
+    swapper.swapExactIn(POOL, false, 100_000 ether);
+  }
+
+  function test_compoundSkipsWhenSpotManipulated() public {
+    _deposit(user, 10 ether, 10 ether);
+    _injectIdle(1 ether, 50 ether);
+
+    uint128 liqBefore = adapter.totalLiquidity();
+    _skewSpotUp();
+
+    // Permissionless compound must SKIP the re-add at the manipulated spot (no new liquidity minted).
+    provider.compound();
+
+    assertEq(adapter.totalLiquidity(), liqBefore, "compound must not add liquidity at a manipulated spot");
+    assertGe(adapter.idleToken1(), 50 ether, "collected fees + old idle held as idle, never minted");
+  }
+
+  function test_compoundProceedsWhenSpotNearFair() public {
+    _deposit(user, 10 ether, 10 ether);
+    _injectIdle(1 ether, 50 ether);
+
+    uint128 liqBefore = adapter.totalLiquidity();
+    // No skew: the live pool spot ~ rate (fair) at the fork block, so the gate lets the compound through.
+    provider.compound();
+
+    assertGt(adapter.totalLiquidity(), liqBefore, "compound should add liquidity when spot ~ fair");
+  }
 }

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -302,7 +302,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(_user);
     IERC20(SLISBNB).approve(address(provider), amount0);
     IERC20(WBNB).approve(address(provider), amount1);
-    (shares, used0, used1) = provider.deposit(marketParams, amount0, amount1, min0, min1, _user);
+    (shares, used0, used1) = provider.deposit(marketParams, amount0, amount1, min0, min1, 0, _user);
     vm.stopPrank();
   }
 
@@ -391,6 +391,38 @@ contract SlisBNBV3ProviderTest is Test {
 
     assertGe(priceAfter, priceBefore, "second deposit must not dilute existing share price");
     assertGt(shares2, shares1, "larger-value deposit yields more shares");
+  }
+
+  /// @dev H02 / Issue_04 (+ M01) counter-test. The minShares floor makes a deposit revert instead of
+  ///      silently under-crediting the depositor when it would receive fewer shares than demanded — the
+  ///      protection against a first-depositor inflation attack (a direct NPM.increaseLiquidity donation
+  ///      inflates the composition so a normal deposit rounds down) and against the fair composition
+  ///      drifting between the off-chain preview and execution. A minShares at fair passes; a higher one
+  ///      reverts.
+  function test_deposit_minShares_guardsShareSlippage() public {
+    _deposit(user, 10 ether, 10 ether);
+
+    // Preview the shares a balanced 10/10 deposit would mint at the current fair composition.
+    (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(10 ether, 10 ether);
+    uint256 supplyBefore = provider.totalSupply();
+    (uint256 t0, uint256 t1) = provider.getFairComposition();
+    uint256 fracExp = (exp0 * 1e18) / t0 < (exp1 * 1e18) / t1 ? (exp0 * 1e18) / t0 : (exp1 * 1e18) / t1;
+    uint256 expectedShares = (supplyBefore * fracExp) / 1e18;
+
+    deal(SLISBNB, user2, 10 ether);
+    deal(WBNB, user2, 10 ether);
+    vm.startPrank(user2);
+    IERC20(SLISBNB).approve(address(provider), 10 ether);
+    IERC20(WBNB).approve(address(provider), 10 ether);
+
+    // Demanding more than the deposit can mint reverts (does not silently under-credit).
+    vm.expectRevert(V3Provider.InsufficientShares.selector);
+    provider.deposit(marketParams, 10 ether, 10 ether, 0, 0, expectedShares * 2, user2);
+
+    // A floor at/just below the achievable amount passes.
+    (uint256 shares, , ) = provider.deposit(marketParams, 10 ether, 10 ether, 0, 0, (expectedShares * 99) / 100, user2);
+    vm.stopPrank();
+    assertGe(shares, (expectedShares * 99) / 100, "mint met the minShares floor");
   }
 
   function test_withdraw_fullWithdrawal() public {
@@ -681,7 +713,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(_user);
     IERC20(SLISBNB).approve(address(provider), amount0);
     IERC20(WBNB).approve(address(provider), amount1);
-    (shares, used0, used1) = provider.deposit(marketParams, amount0, amount1, min0, min1, _user);
+    (shares, used0, used1) = provider.deposit(marketParams, amount0, amount1, min0, min1, 0, _user);
     vm.stopPrank();
   }
 
@@ -744,6 +776,35 @@ contract SlisBNBV3ProviderTest is Test {
     (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(10 ether, 10 ether);
     assertGt(exp0, 0, "fair composition consumes token0 regardless of spot");
     assertGt(exp1, 0, "fair composition consumes token1 regardless of spot");
+  }
+
+  function test_previewDepositForToken_pairsLegsAtFairComposition() public {
+    _deposit(user, 10 ether, 10 ether);
+
+    (uint256 t0, uint256 t1) = provider.getFairComposition();
+    assertGt(t0, 0, "fair composition token0 > 0");
+    assertGt(t1, 0, "fair composition token1 > 0");
+
+    // token0 -> matching token1 at the fair ratio.
+    uint256 a0 = 5 ether;
+    uint256 a1 = provider.previewDepositForToken0(a0);
+    assertEq(a1, (a0 * t1) / t0, "previewDepositForToken0 = a0 * T1 / T0");
+
+    // Reverse direction round-trips within rounding.
+    assertApproxEqRel(provider.previewDepositForToken1(a1), a0, 0.0001e18, "reverse pairing round-trips");
+
+    // Depositing the paired amounts consumes both legs ~fully (minimal refund).
+    deal(SLISBNB, user2, a0);
+    deal(WBNB, user2, a1);
+    vm.startPrank(user2);
+    IERC20(SLISBNB).approve(address(provider), a0);
+    IERC20(WBNB).approve(address(provider), a1);
+    (uint256 shares, uint256 used0, uint256 used1) = provider.deposit(marketParams, a0, a1, 0, 0, 0, user2);
+    vm.stopPrank();
+
+    assertGt(shares, 0, "shares minted");
+    assertApproxEqRel(used0, a0, 0.001e18, "token0 consumed ~fully");
+    assertApproxEqRel(used1, a1, 0.001e18, "token1 consumed ~fully");
   }
 
   function test_previewDeposit_secondDeposit_matchesActual() public {
@@ -869,7 +930,7 @@ contract SlisBNBV3ProviderTest is Test {
     IERC20(SLISBNB).approve(address(provider), amount0);
     IERC20(WBNB).approve(address(provider), amount1);
     vm.expectRevert();
-    provider.deposit(marketParams, amount0, amount1, amount0 * 2, 0, user);
+    provider.deposit(marketParams, amount0, amount1, amount0 * 2, 0, 0, user);
     vm.stopPrank();
   }
 
@@ -883,7 +944,7 @@ contract SlisBNBV3ProviderTest is Test {
     IERC20(SLISBNB).approve(address(provider), amount0);
     IERC20(WBNB).approve(address(provider), amount1);
     vm.expectRevert();
-    provider.deposit(marketParams, amount0, amount1, 0, amount1 * 2, user);
+    provider.deposit(marketParams, amount0, amount1, 0, amount1 * 2, 0, user);
     vm.stopPrank();
   }
 
@@ -899,7 +960,7 @@ contract SlisBNBV3ProviderTest is Test {
     IERC20(SLISBNB).approve(address(provider), amount0);
     IERC20(WBNB).approve(address(provider), amount1);
     vm.expectRevert();
-    provider.deposit(marketParams, amount0, amount1, amount0 * 2, 0, user2);
+    provider.deposit(marketParams, amount0, amount1, amount0 * 2, 0, 0, user2);
     vm.stopPrank();
   }
 
@@ -915,7 +976,7 @@ contract SlisBNBV3ProviderTest is Test {
     IERC20(SLISBNB).approve(address(provider), amount0);
     IERC20(WBNB).approve(address(provider), amount1);
     vm.expectRevert();
-    provider.deposit(marketParams, amount0, amount1, 0, amount1 * 2, user2);
+    provider.deposit(marketParams, amount0, amount1, 0, amount1 * 2, 0, user2);
     vm.stopPrank();
   }
 
@@ -937,7 +998,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(user);
     IERC20(SLISBNB).approve(address(provider), 10 ether);
     vm.expectRevert();
-    provider.deposit(marketParams, 10 ether, 0, 0, 0, user);
+    provider.deposit(marketParams, 10 ether, 0, 0, 0, 0, user);
     vm.stopPrank();
   }
 
@@ -947,7 +1008,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(user);
     IERC20(WBNB).approve(address(provider), 10 ether);
     vm.expectRevert();
-    provider.deposit(marketParams, 0, 10 ether, 0, 0, user);
+    provider.deposit(marketParams, 0, 10 ether, 0, 0, 0, user);
     vm.stopPrank();
   }
 
@@ -967,7 +1028,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(user2);
     IERC20(SLISBNB).approve(address(provider), amount0);
     vm.expectRevert(); // ZeroShares
-    provider.deposit(marketParams, amount0, 0, 0, 0, user2);
+    provider.deposit(marketParams, amount0, 0, 0, 0, 0, user2);
     vm.stopPrank();
   }
 
@@ -981,7 +1042,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(user2);
     IERC20(WBNB).approve(address(provider), 10 ether);
     vm.expectRevert();
-    provider.deposit(marketParams, 0, 10 ether, 0, 0, user2);
+    provider.deposit(marketParams, 0, 10 ether, 0, 0, 0, user2);
     vm.stopPrank();
   }
 
@@ -995,7 +1056,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(user2);
     IERC20(WBNB).approve(address(provider), amount1);
     vm.expectRevert(); // ZeroShares
-    provider.deposit(marketParams, 0, amount1, 0, 0, user2);
+    provider.deposit(marketParams, 0, amount1, 0, 0, 0, user2);
     vm.stopPrank();
   }
 
@@ -1009,7 +1070,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.startPrank(user2);
     IERC20(SLISBNB).approve(address(provider), 10 ether);
     vm.expectRevert();
-    provider.deposit(marketParams, 10 ether, 0, 0, 0, user2);
+    provider.deposit(marketParams, 10 ether, 0, 0, 0, 0, user2);
     vm.stopPrank();
   }
 
@@ -1024,7 +1085,7 @@ contract SlisBNBV3ProviderTest is Test {
     IERC20(WBNB).approve(address(provider), 10 ether);
     vm.expectRevert(V3Provider.InvalidCollateralToken.selector);
     // The revert fires before min amounts are evaluated; use 1,1 for consistency.
-    provider.deposit(badParams, 10 ether, 10 ether, 1, 1, user);
+    provider.deposit(badParams, 10 ether, 10 ether, 1, 1, 0, user);
     vm.stopPrank();
   }
 

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -2496,6 +2496,35 @@ contract SlisBNBV3ProviderTest is Test {
     assertApproxEqAbs(pend1, col1 - owed1, 2, "simulated pending1 == actual collectable minus checkpointed");
   }
 
+  /// @dev previewRemoveLiquidity pro-rates the fee-inclusive fair composition, so it no longer
+  ///      under-reports by pending fees (was: spot principal + idle only).
+  function test_previewRemoveLiquidity_includesPendingFees() public {
+    (uint256 shares, , ) = _deposit(user, 100 ether, 100 ether);
+    uint256 supply = provider.totalSupply();
+
+    // Accrue real swap fees across the range.
+    PoolSwapper swapper = new PoolSwapper();
+    deal(WBNB, address(swapper), 5_000 ether);
+    deal(SLISBNB, address(swapper), 5_000 ether);
+    swapper.swapExactIn(POOL, false, 2_000 ether);
+    swapper.swapExactIn(POOL, true, 2_000 ether);
+
+    uint160 spot = adapter.spotSqrtPriceX96();
+
+    // New preview == pro-rata of the fee-inclusive spot composition (matches actual delivery).
+    (uint256 p0, uint256 p1) = adapter.previewRemoveLiquidity(shares, supply);
+    (uint256 t0, uint256 t1) = adapter.positionAmountsAt(spot);
+    assertEq(p0, (t0 * shares) / supply, "preview0 == pro-rata spot composition (incl. fees)");
+    assertEq(p1, (t1 * shares) / supply, "preview1 == pro-rata spot composition (incl. fees)");
+
+    // Old formula (spot principal + idle, no pending fees) under-reports on at least one leg.
+    uint128 liqRemove = uint128((uint256(adapter.totalLiquidity()) * shares) / supply);
+    (uint256 o0, uint256 o1) = adapter.amountsForLiquidity(liqRemove, spot);
+    o0 += (adapter.idleToken0() * shares) / supply;
+    o1 += (adapter.idleToken1() * shares) / supply;
+    assertTrue(p0 > o0 || p1 > o1, "preview now exceeds the fee-omitting spot formula");
+  }
+
   /// @dev Counter-test: rebalance now takes a target pool price and reverts if the actual pool price
   ///      after the swap+mint deviates from it beyond maxSpotDeviationBps. This is what stops a price
   ///      manipulated around the rebalance (making the minLiquidity floor pass on off-market liquidity,

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -17,6 +17,7 @@ import { V3DexAdapter } from "../../src/provider/v3/V3DexAdapter.sol";
 import { SwapInventoryLib } from "../../src/provider/libraries/SwapInventoryLib.sol";
 import { IListaV3Pool } from "lista-v3/core/interfaces/IListaV3Pool.sol";
 import { IV3PoolMinimal } from "../../src/provider/interfaces/IV3PoolMinimal.sol";
+import { INonfungiblePositionManager } from "../../src/provider/interfaces/INonfungiblePositionManager.sol";
 import { Moolah } from "../../src/moolah/Moolah.sol";
 import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
 import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
@@ -1410,16 +1411,19 @@ contract SlisBNBV3ProviderTest is Test {
     _deposit(user, 10 ether, 10 ether);
     _pushPriceBelowRange();
 
-    (uint256 total0, ) = provider.getTotalAmounts();
-    assertGt(total0, 0, "should hold slisBNB before rebalance");
+    // rebalance's minAmount0 bounds the PRINCIPAL burned by decreaseLiquidity (fees are collected
+    // separately), so size it from the liquidity principal at spot — not getTotalAmounts(), which now
+    // also includes the pending fees the price-push swap accrued and would over-shoot the floor.
+    (uint256 principal0, ) = adapter.amountsForLiquidity(adapter.totalLiquidity(), adapter.spotSqrtPriceX96());
+    assertGt(principal0, 0, "should hold slisBNB principal before rebalance");
 
     // The rate-derived recenter target is unaffected by a pool swap, so disable the rate-drift guard.
     vm.prank(manager);
     adapter.setCenterRateThresholdBps(0);
 
-    // minAmount0 = total0 (exact), minAmount1 = 0 (position has no WBNB).
+    // minAmount0 = principal0 (exact), minAmount1 = 0 (position has no WBNB).
     vm.prank(bot);
-    provider.rebalance(total0, 0, 0, block.timestamp, "");
+    provider.rebalance(principal0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -1446,16 +1450,18 @@ contract SlisBNBV3ProviderTest is Test {
     _deposit(user, 10 ether, 10 ether);
     _pushPriceAboveRange();
 
-    (, uint256 total1) = provider.getTotalAmounts();
-    assertGt(total1, 0, "should hold WBNB before rebalance");
+    // minAmount1 bounds the principal burned by decreaseLiquidity (see the below-range test); size it
+    // from the liquidity principal at spot, not fee-inclusive getTotalAmounts().
+    (, uint256 principal1) = adapter.amountsForLiquidity(adapter.totalLiquidity(), adapter.spotSqrtPriceX96());
+    assertGt(principal1, 0, "should hold WBNB principal before rebalance");
 
     // The rate-derived recenter target is unaffected by a pool swap, so disable the rate-drift guard.
     vm.prank(manager);
     adapter.setCenterRateThresholdBps(0);
 
-    // minAmount0 = 0 (no slisBNB), minAmount1 = total1 (exact).
+    // minAmount0 = 0 (no slisBNB), minAmount1 = principal1 (exact).
     vm.prank(bot);
-    provider.rebalance(0, total1, 0, block.timestamp, "");
+    provider.rebalance(0, principal1, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -2355,5 +2361,54 @@ contract SlisBNBV3ProviderTest is Test {
 
     assertEq(adapter.totalLiquidity(), liqBefore, "one-sided idle must not mint liquidity");
     assertGe(adapter.idleToken0(), idle0, "one-sided idle is held, not lost");
+  }
+
+  /// @dev Counter-test: positionAmountsAt used to add only the
+  ///      checkpointed tokensOwed, ignoring fees accrued in the pool since the last poke — understating
+  ///      every valuation built on it. The fix simulates the live feeGrowthInside delta. This fork test
+  ///      cross-checks that simulated pending against the pool's ground truth: NPM.collect (which pokes
+  ///      the pool) returns checkpointed owed + freshly-earned, so collected - owed must equal our
+  ///      simulated pending to the wei.
+  function test_positionAmountsAt_pendingFees_crossCheckedAgainstCollect() public {
+    _deposit(user, 100 ether, 100 ether);
+
+    // Accrue real swap fees to the position by trading both directions across its range.
+    PoolSwapper swapper = new PoolSwapper();
+    deal(WBNB, address(swapper), 5_000 ether);
+    deal(SLISBNB, address(swapper), 5_000 ether);
+    swapper.swapExactIn(POOL, false, 2_000 ether); // token1 -> token0 (price up)
+    swapper.swapExactIn(POOL, true, 2_000 ether); // token0 -> token1 (price back down)
+
+    uint160 fair = adapter.fairSqrtPriceX96();
+    uint256 tid = adapter.tokenId();
+
+    // Stale total = the OLD formula: principal at fair + checkpointed tokensOwed + idle (no pending).
+    (, , , , , , , uint128 liq, , , uint128 owed0, uint128 owed1) = INonfungiblePositionManager(NPM).positions(tid);
+    (uint256 principal0, uint256 principal1) = adapter.amountsForLiquidity(liq, fair);
+    uint256 stale0 = principal0 + owed0 + adapter.idleToken0();
+    uint256 stale1 = principal1 + owed1 + adapter.idleToken1();
+
+    // With the fix, positionAmountsAt adds the simulated pending fees on top of the stale total.
+    (uint256 sim0, uint256 sim1) = adapter.positionAmountsAt(fair);
+    uint256 pend0 = sim0 - stale0;
+    uint256 pend1 = sim1 - stale1;
+    assertTrue(pend0 > 0 || pend1 > 0, "swaps must have accrued measurable pending fees");
+
+    // Ground truth: NPM.collect pokes the pool and returns owed + freshly-earned. Snapshot so the
+    // collect does not mutate the position under test.
+    uint256 snap = vm.snapshotState();
+    vm.prank(address(adapter));
+    (uint256 col0, uint256 col1) = INonfungiblePositionManager(NPM).collect(
+      INonfungiblePositionManager.CollectParams({
+        tokenId: tid,
+        recipient: address(adapter),
+        amount0Max: type(uint128).max,
+        amount1Max: type(uint128).max
+      })
+    );
+    assertTrue(vm.revertToState(snap), "snapshot revert failed");
+
+    assertApproxEqAbs(pend0, col0 - owed0, 2, "simulated pending0 == actual collectable minus checkpointed");
+    assertApproxEqAbs(pend1, col1 - owed1, 2, "simulated pending1 == actual collectable minus checkpointed");
   }
 }

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -589,7 +589,7 @@ contract SlisBNBV3ProviderTest is Test {
     // manager cannot rebalance — revert fires on role check before amounts matter.
     vm.prank(manager);
     vm.expectRevert();
-    provider.rebalance(1, 1, 1, block.timestamp, "");
+    provider.rebalance(1, 1, 1, 0, block.timestamp, "");
 
     // Disable the rate-drift guard — a pool swap does NOT move the StakeManager rate, so the
     // default 1% center-rate threshold would block this rebalance with RateDeviationBelowThreshold.
@@ -602,7 +602,7 @@ contract SlisBNBV3ProviderTest is Test {
     uint256 min1 = (total1 * 999) / 1000;
     uint256 oldTokenId = adapter.tokenId();
     vm.prank(bot);
-    provider.rebalance(min0, min1, 0, block.timestamp, "");
+    provider.rebalance(min0, min1, 0, 0, block.timestamp, "");
 
     assertGt(adapter.tokenId(), oldTokenId, "position NFT should be re-minted");
     assertLt(adapter.tickLower(), adapter.tickUpper());
@@ -621,7 +621,7 @@ contract SlisBNBV3ProviderTest is Test {
     uint256 min0 = (total0 * 999) / 1000;
     uint256 min1 = (total1 * 999) / 1000;
     vm.prank(bot);
-    provider.rebalance(min0, min1, 0, block.timestamp, "");
+    provider.rebalance(min0, min1, 0, 0, block.timestamp, "");
 
     // Share count is unchanged after rebalance.
     assertEq(_collateral(user), shares, "shares should be unchanged after rebalance");
@@ -1148,7 +1148,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // Rebalance uses an internally derived range; caller only supplies execution guards.
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
 
@@ -1184,7 +1184,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(address(mockSwap), true, amountIn, (fairOut * 99) / 100, false, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after swap");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "fair swap ~value-neutral");
@@ -1202,7 +1202,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.NotWhitelistedPair.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice Defense-in-depth: a swap venue may never be the position's own tokens / pool / NPM.
@@ -1243,7 +1243,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(STAKE_MANAGER, true, amountIn, (fairOut * 99) / 100, false, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after instantWithdraw conversion");
     assertApproxEqRel(
@@ -1273,7 +1273,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(SwapInventoryLib.InsufficientOutput.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice The other swap direction (sellToken0 = false): sell WBNB → slisBNB, value-neutral.
@@ -1292,7 +1292,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(address(mockSwap), false, amountIn, (fairOut * 99) / 100, false, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "WBNB->slisBNB swap ~value-neutral");
   }
 
@@ -1319,7 +1319,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(STAKE_MANAGER, false, amountIn, (fairOut * 99) / 100, true, inner); // nativeIn=true
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after deposit conversion");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "deposit conversion ~value-neutral");
@@ -1346,7 +1346,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(SwapInventoryLib.InsufficientOutput.selector); // slisBNB received = 0 < amountOutMin
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /* ─────────── rebalance after price leaves range (fully WBNB) ──────── */
@@ -1391,7 +1391,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // Rebalance uses an internally derived range; caller only supplies execution guards.
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
 
@@ -1423,7 +1423,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // minAmount0 = principal0 (exact), minAmount1 = 0 (position has no WBNB).
     vm.prank(bot);
-    provider.rebalance(principal0, 0, 0, block.timestamp, "");
+    provider.rebalance(principal0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -1441,7 +1441,7 @@ contract SlisBNBV3ProviderTest is Test {
     // minAmount0 one unit above actual → should revert with NPM slippage check.
     vm.prank(bot);
     vm.expectRevert();
-    provider.rebalance(total0 + 1, 0, 0, block.timestamp, "");
+    provider.rebalance(total0 + 1, 0, 0, 0, block.timestamp, "");
   }
 
   /// @dev When price is above range the position is 100% WBNB (token1).
@@ -1461,7 +1461,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // minAmount0 = 0 (no slisBNB), minAmount1 = principal1 (exact).
     vm.prank(bot);
-    provider.rebalance(0, principal1, 0, block.timestamp, "");
+    provider.rebalance(0, principal1, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -1479,7 +1479,7 @@ contract SlisBNBV3ProviderTest is Test {
     // minAmount1 one unit above actual → should revert with NPM slippage check.
     vm.prank(bot);
     vm.expectRevert();
-    provider.rebalance(0, total1 + 1, 0, block.timestamp, "");
+    provider.rebalance(0, total1 + 1, 0, 0, block.timestamp, "");
   }
 
   function test_withdraw_minAmount_tooHigh_reverts() public {
@@ -2060,7 +2060,7 @@ contract SlisBNBV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -2075,7 +2075,7 @@ contract SlisBNBV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -2120,7 +2120,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SwapLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   function test_lossGuard_perSwapCap_passesWithinCap() public {
@@ -2134,7 +2134,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = _sellToken0Data(amountIn, (fairOut * 97) / 100, 0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted (3% swap loss within 5% per-swap cap)");
   }
 
@@ -2158,7 +2158,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.RebalanceLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   // ── per-UTC-day cumulative loss cap ──
@@ -2181,7 +2181,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.DailyLossExceeded.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   function test_lossGuard_dailyCap_dailyAccumulatorResetsNextDay() public {
@@ -2199,7 +2199,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     bytes memory data1 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data1);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data1);
     uint256 accumDay1 = provider.dailyLossAccum();
     uint256 day1 = provider.dailyLossDay();
     assertGt(accumDay1, 0, "loss accrued on day 1");
@@ -2208,7 +2208,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.warp(block.timestamp + 1 days);
     bytes memory data2 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data2);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data2);
 
     assertGt(provider.dailyLossDay(), day1, "UTC day advanced");
     assertLt(provider.dailyLossAccum(), (accumDay1 * 3) / 2, "accumulator reset for the new day (not doubled)");
@@ -2265,7 +2265,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     bytes memory d1 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, d1);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, d1);
     uint256 loss1 = provider.dailyLossAccum();
     assertGt(loss1, 0, "rebalance 1 accrued loss");
 
@@ -2275,14 +2275,14 @@ contract SlisBNBV3ProviderTest is Test {
 
     bytes memory d2 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, d2);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, d2);
     // Proves cumulative `+=` (a `= loss` overwrite would leave accum ≈ loss1, failing this).
     assertGt(provider.dailyLossAccum(), (loss1 * 3) / 2, "same-day loss accumulates across rebalances");
 
     bytes memory d3 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
     vm.expectRevert(V3Provider.DailyLossExceeded.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, d3);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, d3);
   }
 
   /// @notice Fail-closed: if the feed returns 0 for a non-empty vault, rebalance must revert (not run
@@ -2294,7 +2294,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.OracleZero.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
   }
 
   /// @notice The per-swap cap also covers the sell-token1 direction (WBNB→slisBNB), exercising `_fairAmount0ForAmount1`.
@@ -2311,7 +2311,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SwapLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /* ───────────── Spot-vs-fair gate when adding liquidity at pool spot ───────────── */
@@ -2441,5 +2441,115 @@ contract SlisBNBV3ProviderTest is Test {
 
     assertApproxEqAbs(pend0, col0 - owed0, 2, "simulated pending0 == actual collectable minus checkpointed");
     assertApproxEqAbs(pend1, col1 - owed1, 2, "simulated pending1 == actual collectable minus checkpointed");
+  }
+
+  /// @dev Counter-test: rebalance now takes a target pool price and reverts if the actual pool price
+  ///      after the swap+mint deviates from it beyond maxSpotDeviationBps. This is what stops a price
+  ///      manipulated around the rebalance (making the minLiquidity floor pass on off-market liquidity,
+  ///      then sandwiched) — the minLiquidity floor alone did not.
+  function test_rebalance_revertsWhenPoolPriceDeviatesFromTarget() public {
+    _deposit(user, 10 ether, 10 ether);
+    // Get past the rate-drift guard so execution reaches the post-mint target-deviation check.
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+
+    // BOT's target is far from the actual pool price (a stand-in for the pool being moved away from the
+    // price the BOT built the rebalance against) -> must revert.
+    uint160 badTarget = uint160(uint256(adapter.spotSqrtPriceX96()) * 2); // ~4x price, well beyond ±1%
+    vm.prank(bot);
+    vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
+    provider.rebalance(0, 0, 0, badTarget, block.timestamp, "");
+  }
+
+  function test_rebalance_passesWhenPoolPriceMatchesTarget() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+
+    // Target == the actual pool price ⇒ within the band ⇒ the deviation check passes.
+    uint160 target = adapter.spotSqrtPriceX96();
+    vm.prank(bot);
+    provider.rebalance(0, 0, 0, target, block.timestamp, "");
+    assertLt(adapter.tickLower(), adapter.tickUpper(), "recentered with a matching target");
+  }
+
+  /// @dev target == 0 opts out of the price check: the same call that reverts with a bad target
+  ///      succeeds when target is 0 (parity with minAmount/minLiquidity being caller-supplied guards).
+  function test_rebalance_target_zeroOptsOut() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+
+    uint160 bad = uint160(uint256(adapter.spotSqrtPriceX96()) * 2);
+    vm.prank(bot);
+    vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
+    provider.rebalance(0, 0, 0, bad, block.timestamp, "");
+
+    // Same state, target 0 → no price check → succeeds.
+    vm.prank(bot);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    assertLt(adapter.tickLower(), adapter.tickUpper(), "recentered with target 0");
+  }
+
+  /// @dev maxSpotDeviationBps == 0 disables the gate entirely, even for a non-zero (bad) target.
+  function test_rebalance_target_disabledWhenDeviationZero() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.startPrank(manager);
+    adapter.setCenterRateThresholdBps(0);
+    adapter.setMaxSpotDeviationBps(0); // disable the gate
+    vm.stopPrank();
+
+    uint160 bad = uint160(uint256(adapter.spotSqrtPriceX96()) * 2);
+    vm.prank(bot);
+    provider.rebalance(0, 0, 0, bad, block.timestamp, ""); // gate off → no revert
+    assertLt(adapter.tickLower(), adapter.tickUpper(), "gate disabled: bad target ignored");
+  }
+
+  /// @dev The band is two-sided: a target far ABOVE the pool price (pool price below target) reverts too.
+  function test_rebalance_target_lowSideReverts() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+
+    uint160 bad = uint160(uint256(adapter.spotSqrtPriceX96()) / 2); // target ~1/4 price of actual → outside band
+    vm.prank(bot);
+    vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
+    provider.rebalance(0, 0, 0, bad, block.timestamp, "");
+  }
+
+  /// @dev A target just inside the ±band passes; the same call just outside it reverts.
+  function test_rebalance_target_bandBoundary() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+    uint256 spot = uint256(adapter.spotSqrtPriceX96());
+
+    // maxSpotDeviationBps defaults to 100 (1% on price). sqrt·(1+0.2%) ⇒ price·~0.4% (inside);
+    // sqrt·(1+0.8%) ⇒ price·~1.6% (outside).
+    uint160 inside = uint160((spot * 10020) / 10000);
+    uint160 outside = uint160((spot * 10080) / 10000);
+
+    vm.prank(bot);
+    vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
+    provider.rebalance(0, 0, 0, outside, block.timestamp, "");
+
+    vm.prank(bot);
+    provider.rebalance(0, 0, 0, inside, block.timestamp, "");
+    assertLt(adapter.tickLower(), adapter.tickUpper(), "inside-band target passes");
+  }
+
+  /// @dev Realistic sandwich shape: the pool spot is pushed far from fair, the BOT passes target = fair
+  ///      (the price it built the rebalance against), and the manipulated spot fails the check.
+  function test_rebalance_target_sandwichRevertsWithFairTarget() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+
+    uint160 fairTarget = adapter.fairSqrtPriceX96(); // BOT's expected (rate-implied) price
+    _skewSpotUp(); // attacker moves pool spot far above fair around the rebalance
+
+    vm.prank(bot);
+    vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
+    provider.rebalance(0, 0, 0, fairTarget, block.timestamp, "");
   }
 }

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -567,6 +567,21 @@ contract SlisBNBV3ProviderTest is Test {
     assertEq(liquidator.balance, bnbBefore + out1); // WBNB unwrapped to BNB
   }
 
+  /// @dev A dust redeem whose pro-rata liquidity AND idle both round to 0 delivers (0,0). With
+  ///      minAmounts of 0 the overall-amount floor (0 >= 0) is trivially satisfied, so without the
+  ///      zero-output guard the shares would be burned for nothing. The guard must revert instead.
+  ///      Driven at the adapter to force the rounding deterministically (share fraction ≈ 0), which the
+  ///      provider path can't guarantee on a fork where position liquidity exceeds total shares.
+  function test_removeLiquidity_dustRoundsToZero_reverts() public {
+    _deposit(user, 10 ether, 10 ether); // establish a live position (+possible idle)
+
+    // A single wei against a colossal totalShares makes totalLiq*shares/totalShares and the pro-rata
+    // idle both floor to 0 → amount0 == amount1 == 0. removeLiquidity is onlyProvider.
+    vm.prank(address(provider));
+    vm.expectRevert(V3DexAdapter.ZeroAmount.selector);
+    adapter.removeLiquidity(1, type(uint256).max, 0, 0, user);
+  }
+
   function test_transferRestriction_directTransferReverts() public {
     _deposit(user, 10 ether, 10 ether);
 
@@ -665,6 +680,21 @@ contract SlisBNBV3ProviderTest is Test {
 
     uint256 price = providerOracle.peek(address(provider));
     assertGt(price, 0, "share price should be non-zero after deposit");
+  }
+
+  /// @dev Dust (zero-value) composition, valid feeds ⇒ peek floors to 1, not revert (else liquidation bricks).
+  function test_peek_dustPositionFloorsInsteadOfReverting() public {
+    _deposit(user, 10 ether, 10 ether); // totalSupply > 0 so peek runs the full valuation
+
+    // Force the adapter to report a zero-value composition at the fair price (dust position).
+    vm.mockCall(
+      address(adapter),
+      abi.encodeWithSelector(bytes4(keccak256("positionAmountsAt(uint160)"))),
+      abi.encode(uint256(0), uint256(0))
+    );
+
+    uint256 price = providerOracle.peek(address(provider));
+    assertEq(price, 1, "dust position floors to 1 (peek does not revert)");
   }
 
   function test_getTotalAmounts_nonZeroAfterDeposit() public {

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -378,14 +378,19 @@ contract SlisBNBV3ProviderTest is Test {
     assertEq(user.balance, amount1 - used1);
   }
 
-  function test_deposit_secondDeposit_sharesProportional() public {
-    _deposit(user, 10 ether, 10 ether);
-    uint256 sharesAfterFirst = _collateral(user);
+  function test_deposit_secondDeposit_doesNotDilute() public {
+    // Shares are issued proportional to the fair composition (value-conserving), not to raw
+    // token inputs — the first deposit refunds part of its WBNB at the spot mint ratio, so equal token
+    // amounts are not equal value. The invariant that matters is that the mint never lowers the existing
+    // per-share price, and a larger-value deposit yields more shares.
+    (uint256 shares1, , ) = _deposit(user, 10 ether, 10 ether);
+    uint256 priceBefore = providerOracle.peek(address(provider));
 
     (uint256 shares2, , ) = _deposit(user2, 20 ether, 20 ether);
+    uint256 priceAfter = providerOracle.peek(address(provider));
 
-    // Second depositor contributes roughly twice as much — shares should be ~2x.
-    assertApproxEqRel(shares2, sharesAfterFirst * 2, 0.01e18, "second deposit shares should be ~2x");
+    assertGe(priceAfter, priceBefore, "second deposit must not dilute existing share price");
+    assertGt(shares2, shares1, "larger-value deposit yields more shares");
   }
 
   function test_withdraw_fullWithdrawal() public {
@@ -635,40 +640,32 @@ contract SlisBNBV3ProviderTest is Test {
     assertEq(_collateral(user), shares);
   }
 
-  function test_deposit_afterIdle_mintsByNav_doesNotDiluteExistingShares() public {
+  /// @dev Counter-test (deposit cannot be gamed via spot vs idle). With tracked idle inventory present AND the pool spot pushed far from
+  ///      the fair (rate) price, the OLD deposit path minted liquidity at spot but valued it at fair,
+  ///      over-crediting the new depositor and dropping existing holders' share price (dilution/theft).
+  ///      The deposit is proportional to the fair composition and parks to idle — the pool spot
+  ///      never enters share issuance — so a deposit under these exact conditions cannot dilute.
+  function test_deposit_withIdleAndSkewedSpot_doesNotDilute() public {
     _deposit(user, 10 ether, 10 ether);
 
+    // Heavy one-sided idle skews the composition (the ingredient the old bug needed)...
     uint256 idle0 = 1 ether;
     uint256 idle1 = 50 ether;
     deal(SLISBNB, address(adapter), IERC20(SLISBNB).balanceOf(address(adapter)) + idle0);
     deal(WBNB, address(adapter), IERC20(WBNB).balanceOf(address(adapter)) + idle1);
     stdstore.target(address(adapter)).sig("idleToken0()").checked_write(adapter.idleToken0() + idle0);
     stdstore.target(address(adapter)).sig("idleToken1()").checked_write(adapter.idleToken1() + idle1);
+    assertGt(_valueUSD(adapter.idleToken0(), adapter.idleToken1()), 0, "test setup should include idle");
 
-    uint256 idleValue = _valueUSD(adapter.idleToken0(), adapter.idleToken1());
-    assertGt(idleValue, 0, "test setup should include tracked idle value");
-
-    uint256 snapshot = vm.snapshotState();
-    vm.prank(address(provider));
-    adapter.collectAndCompound();
+    // ...and the pool spot is pushed far above fair (the other ingredient).
+    _skewSpotUp();
 
     uint256 priceBefore = providerOracle.peek(address(provider));
-    uint256 supplyBefore = provider.totalSupply();
-    uint160 fairSqrtPriceX96 = adapter.fairSqrtPriceX96();
-    (uint256 total0Before, uint256 total1Before) = adapter.positionAmountsAt(fairSqrtPriceX96);
-    uint256 totalValueBefore = _valueUSD(total0Before, total1Before);
-    (uint128 liquidityPreview, , ) = adapter.previewAddLiquidity(10 ether, 10 ether);
-    (uint256 added0, uint256 added1) = adapter.amountsForLiquidity(liquidityPreview, fairSqrtPriceX96);
-    uint256 expectedNavShares = (_valueUSD(added0, added1) * supplyBefore) / totalValueBefore;
-    uint256 liquidityOnlyShares = (uint256(liquidityPreview) * supplyBefore) / uint256(adapter.totalLiquidity());
-    assertLt(expectedNavShares, liquidityOnlyShares, "tracked idle should reduce new depositor shares");
-    assertTrue(vm.revertToState(snapshot), "snapshot revert failed");
-
     (uint256 shares2, , ) = _deposit(user2, 10 ether, 10 ether);
-    assertApproxEqAbs(shares2, expectedNavShares, 1, "second depositor should receive NAV-priced shares");
-
     uint256 priceAfter = providerOracle.peek(address(provider));
-    assertGe(priceAfter, priceBefore, "NAV-based mint must not dilute existing share value");
+
+    assertGt(shares2, 0, "deposit should still mint shares");
+    assertGe(priceAfter, priceBefore, "deposit with idle + skewed spot must not dilute existing holders");
   }
 
   /// @dev Helper: deposit with explicit min amounts (bypasses _deposit which passes zeros).
@@ -729,32 +726,24 @@ contract SlisBNBV3ProviderTest is Test {
     assertGe(used1, min1, "used1 >= min1");
   }
 
-  function test_previewDeposit_priceBelowRange_onlyToken0() public {
+  function test_previewDeposit_belowRangeSpot_usesFairCompositionBothLegs() public {
     _deposit(user, 10 ether, 10 ether);
-    _pushPriceBelowRange();
+    _pushPriceBelowRange(); // manipulate SPOT below range
 
-    uint256 amount0 = 10 ether;
-    uint256 amount1 = 10 ether;
-
-    (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(amount0, amount1);
-
-    // Position is fully slisBNB — only token0 consumed, token1 = 0.
-    assertGt(exp0, 0, "expected token0 consumed when price below range");
-    assertEq(exp1, 0, "expected no token1 consumed when price below range");
+    // preview (and deposit) bind to the FAIR composition — rate-implied for slisBNB, which stays
+    // ~in-range — so both legs are consumed regardless of where the manipulable pool spot sits.
+    (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(10 ether, 10 ether);
+    assertGt(exp0, 0, "fair composition consumes token0 regardless of spot");
+    assertGt(exp1, 0, "fair composition consumes token1 regardless of spot");
   }
 
-  function test_previewDeposit_priceAboveRange_onlyToken1() public {
+  function test_previewDeposit_aboveRangeSpot_usesFairCompositionBothLegs() public {
     _deposit(user, 10 ether, 10 ether);
-    _pushPriceAboveRange();
+    _pushPriceAboveRange(); // manipulate SPOT above range
 
-    uint256 amount0 = 10 ether;
-    uint256 amount1 = 10 ether;
-
-    (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(amount0, amount1);
-
-    // Position is fully WBNB — only token1 consumed, token0 = 0.
-    assertEq(exp0, 0, "expected no token0 consumed when price above range");
-    assertGt(exp1, 0, "expected token1 consumed when price above range");
+    (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(10 ether, 10 ether);
+    assertGt(exp0, 0, "fair composition consumes token0 regardless of spot");
+    assertGt(exp1, 0, "fair composition consumes token1 regardless of spot");
   }
 
   function test_previewDeposit_secondDeposit_matchesActual() public {
@@ -965,24 +954,21 @@ contract SlisBNBV3ProviderTest is Test {
   // When the price is outside the range only one token is valid.
   // Supplying the correct token succeeds; supplying the wrong token reverts.
 
-  function test_deposit_oneSided_token0Only_belowRange_succeeds() public {
-    // Seed a position first so rebalance can move ticks.
+  function test_deposit_oneSided_token0Only_revertsUnderProportional() public {
+    // Deposits must match the FAIR composition (rate-implied for slisBNB, always ~in-range and
+    // therefore two-sided). A one-sided token0-only deposit binds the composition fraction to the empty
+    // token1 leg -> frac 0 -> 0 shares -> revert. (Manipulating spot out of range does not change this,
+    // because the composition is measured at fair, not spot.)
     _deposit(user, 10 ether, 10 ether);
     _pushPriceBelowRange();
 
-    // Price below tickLower: only token0 (slisBNB) is accepted.
     uint256 amount0 = 10 ether;
     deal(SLISBNB, user2, amount0);
     vm.startPrank(user2);
     IERC20(SLISBNB).approve(address(provider), amount0);
-    (, uint256 exp0, ) = provider.previewDepositAmounts(amount0, 0);
-    uint256 min0 = (exp0 * 999) / 1000;
-    (uint256 shares, uint256 used0, uint256 used1) = provider.deposit(marketParams, amount0, 0, min0, 0, user2);
+    vm.expectRevert(); // ZeroShares
+    provider.deposit(marketParams, amount0, 0, 0, 0, user2);
     vm.stopPrank();
-
-    assertGt(shares, 0, "should mint shares with token0 only below range");
-    assertGt(used0, 0, "should consume token0");
-    assertEq(used1, 0, "should not consume token1");
   }
 
   function test_deposit_oneSided_token1Only_belowRange_reverts() public {
@@ -999,23 +985,18 @@ contract SlisBNBV3ProviderTest is Test {
     vm.stopPrank();
   }
 
-  function test_deposit_oneSided_token1Only_aboveRange_succeeds() public {
+  function test_deposit_oneSided_token1Only_revertsUnderProportional() public {
+    // Symmetric to the token0-only case: a token1-only deposit binds frac to the empty token0 leg -> 0.
     _deposit(user, 10 ether, 10 ether);
     _pushPriceAboveRange();
 
-    // Price above tickUpper: only token1 (WBNB) is accepted.
     uint256 amount1 = 10 ether;
     deal(WBNB, user2, amount1);
     vm.startPrank(user2);
     IERC20(WBNB).approve(address(provider), amount1);
-    (, , uint256 exp1) = provider.previewDepositAmounts(0, amount1);
-    uint256 min1 = (exp1 * 999) / 1000;
-    (uint256 shares, uint256 used0, uint256 used1) = provider.deposit(marketParams, 0, amount1, 0, min1, user2);
+    vm.expectRevert(); // ZeroShares
+    provider.deposit(marketParams, 0, amount1, 0, 0, user2);
     vm.stopPrank();
-
-    assertGt(shares, 0, "should mint shares with token1 only above range");
-    assertEq(used0, 0, "should not consume token0");
-    assertGt(used1, 0, "should consume token1");
   }
 
   function test_deposit_oneSided_token0Only_aboveRange_reverts() public {
@@ -1653,14 +1634,15 @@ contract SlisBNBV3ProviderTest is Test {
   }
 
   function test_getUserBalanceInBnb_proportionalToShares() public {
-    _deposit(user, 10 ether, 10 ether);
-    _deposit(user2, 20 ether, 20 ether);
+    (uint256 shares1, , ) = _deposit(user, 10 ether, 10 ether);
+    (uint256 shares2, , ) = _deposit(user2, 20 ether, 20 ether);
 
     uint256 value1 = provider.getUserBalanceInBnb(user);
     uint256 value2 = provider.getUserBalanceInBnb(user2);
 
-    // user2 deposited ~2x; allow 2% tolerance for compounding and rounding.
-    assertApproxEqRel(value2, value1 * 2, 0.02e18, "user2 BNB value should be ~2x user");
+    // Each share is an equal pro-rata claim, so BNB value tracks the share count — not the raw deposit
+    // amounts (equal token inputs are not equal value). Assert value2/value1 == shares2/shares1.
+    assertApproxEqRel(value2 * shares1, value1 * shares2, 0.01e18, "BNB value should be proportional to shares");
   }
 
   function test_getUserBalanceInBnb_matchesShareValueInBnb() public {
@@ -2291,5 +2273,26 @@ contract SlisBNBV3ProviderTest is Test {
     provider.compound();
 
     assertGt(adapter.totalLiquidity(), liqBefore, "compound should add liquidity when spot ~ fair");
+  }
+
+  /// @dev Counter-test (one-sided idle must not brick compounding): with spot ~ fair (gate passes) but strictly one-sided idle inventory,
+  ///      the computed addable liquidity is zero, which would revert inside pool.mint. _collectAndCompound
+  ///      must instead hold the idle and return, so the permissionless compound() (and the deposit /
+  ///      withdraw / redeemShares that reach it) is never bricked by a single-sided balance.
+  function test_compound_oneSidedIdle_noOpsInsteadOfReverting() public {
+    _deposit(user, 10 ether, 10 ether);
+    uint128 liqBefore = adapter.totalLiquidity();
+
+    // Force a clean one-sided idle state: token0 only, token1 exactly zero. Spot ~ fair (fork default),
+    // so the spot-deviation gate passes and execution reaches the zero-liquidity no-op guard.
+    uint256 idle0 = 5 ether;
+    deal(SLISBNB, address(adapter), IERC20(SLISBNB).balanceOf(address(adapter)) + idle0);
+    stdstore.target(address(adapter)).sig("idleToken0()").checked_write(adapter.idleToken0() + idle0);
+    stdstore.target(address(adapter)).sig("idleToken1()").checked_write(uint256(0));
+
+    provider.compound(); // must NOT revert
+
+    assertEq(adapter.totalLiquidity(), liqBefore, "one-sided idle must not mint liquidity");
+    assertGe(adapter.idleToken0(), idle0, "one-sided idle is held, not lost");
   }
 }

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -583,6 +583,29 @@ contract SlisBNBV3ProviderTest is Test {
     provider.transferFrom(MOOLAH_PROXY, user2, 1);
   }
 
+  /// @dev Even Moolah's own transferFrom must debit the allowance the owner granted it, rather than
+  ///      moving shares with an unbounded allowance. No allowance ⇒ revert; a set allowance is spent.
+  function test_transferRestriction_moolahTransferFromSpendsAllowance() public {
+    (uint256 shares, , ) = _deposit(user, 10 ether, 10 ether);
+    // The deposit path parked the shares in Moolah as collateral; move them back to `user` to hold.
+    vm.prank(user);
+    provider.withdrawShares(marketParams, shares, user, user);
+
+    // Moolah with no allowance from `user` cannot pull shares.
+    vm.prank(MOOLAH_PROXY);
+    vm.expectRevert();
+    provider.transferFrom(user, user2, shares);
+
+    // With an allowance set, Moolah's transferFrom succeeds and the allowance is debited.
+    vm.prank(user);
+    provider.approve(MOOLAH_PROXY, shares);
+    vm.prank(MOOLAH_PROXY);
+    provider.transferFrom(user, user2, shares);
+
+    assertEq(provider.balanceOf(user2), shares, "shares moved to user2");
+    assertEq(provider.allowance(user, MOOLAH_PROXY), 0, "allowance fully spent");
+  }
+
   function test_rebalance_onlyBot() public {
     _deposit(user, 10 ether, 10 ether);
 

--- a/test/provider/SlisBNBV3ProviderRate.t.sol
+++ b/test/provider/SlisBNBV3ProviderRate.t.sol
@@ -328,7 +328,7 @@ contract SlisBNBV3ProviderRateTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
     assertGt(adapter.tokenId(), oldTokenId, "position should be re-minted");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "rate-derived range should be valid");
@@ -341,7 +341,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.RateDeviationBelowThreshold.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
   }
 
   function test_rebalance_revertsAfterDeadline() public {
@@ -349,7 +349,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.DeadlineExpired.selector);
-    provider.rebalance(0, 0, 0, block.timestamp - 1, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp - 1, "");
   }
 
   function test_rebalance_revertsWhenMinLiquidityTooHigh() public {
@@ -360,7 +360,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.InsufficientLiquidityMinted.selector);
-    provider.rebalance(0, 0, type(uint256).max, block.timestamp, "");
+    provider.rebalance(0, 0, type(uint256).max, 0, block.timestamp, "");
   }
 
   function _tick() internal view returns (int24 tick) {

--- a/test/provider/SlisBNBV3ProviderRate.t.sol
+++ b/test/provider/SlisBNBV3ProviderRate.t.sol
@@ -330,10 +330,28 @@ contract SlisBNBV3ProviderRateTest is Test {
     vm.prank(bot);
     provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
-    assertGt(adapter.tokenId(), oldTokenId, "position should be re-minted");
+    // A no-op recenter — recomputed range equals the live one and the caller supplied no swap, target,
+    // or min floors — short-circuits to an in-place compound instead of burning and re-minting the
+    // identical position. Same tokenId (no churn), value preserved, center rate still refreshed.
+    assertEq(adapter.tokenId(), oldTokenId, "no-op recenter keeps the same position (no burn/mint)");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "rate-derived range should be valid");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "rebalance is ~value-neutral");
     assertEq(adapter.lastCenterRate(), IStakeManager(STAKE_MANAGER).convertSnBnbToBnb(1e18), "center rate updated");
+  }
+
+  /// @dev The no-op short-circuit is narrow: supplying any guard (here a min-liquidity floor) takes the
+  ///      full burn/mint recenter path even when the recomputed range is unchanged.
+  function test_rebalance_guardedRecenterTakesFullPath() public {
+    _deposit(10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+
+    uint256 oldTokenId = adapter.tokenId();
+    vm.prank(bot);
+    provider.rebalance(0, 0, 1, 0, block.timestamp, ""); // minLiquidity = 1 ⇒ not a no-op
+
+    assertGt(adapter.tokenId(), oldTokenId, "guarded recenter re-mints");
+    assertLt(adapter.tickLower(), adapter.tickUpper(), "range valid");
   }
 
   function test_rebalance_revertsWhenCenterRateDeviationBelowThreshold() public {

--- a/test/provider/SlisBNBV3ProviderRate.t.sol
+++ b/test/provider/SlisBNBV3ProviderRate.t.sol
@@ -251,7 +251,7 @@ contract SlisBNBV3ProviderRateTest is Test {
     vm.startPrank(user);
     IERC20(SLISBNB).approve(address(provider), amtSlis);
     IERC20(WBNB).approve(address(provider), amtWbnb);
-    (shares, , ) = provider.deposit(marketParams, amtSlis, amtWbnb, (e0 * 99) / 100, (e1 * 99) / 100, user);
+    (shares, , ) = provider.deposit(marketParams, amtSlis, amtWbnb, (e0 * 99) / 100, (e1 * 99) / 100, 0, user);
     vm.stopPrank();
   }
 

--- a/test/provider/SwapInventoryLibNative.t.sol
+++ b/test/provider/SwapInventoryLibNative.t.sol
@@ -134,4 +134,32 @@ contract SwapInventoryLibNativeTest is Test {
     assertEq(t1, amountOut, "token1 total increased by received");
     assertEq(address(harness).balance, 1, "stray native left untouched (not wrapped, not reverted)");
   }
+
+  /// @notice requested amountIn > held ⇒ fail fast (was: silent cap + opaque allowance revert).
+  function test_swap_revertsWhenAmountInExceedsAvail() public {
+    uint256 avail = 5 ether; // the position (total0) holds only 5
+    uint256 amountIn = 10 ether; // stale swapData requests 10 (> avail)
+    bytes memory swapData = abi.encodeWithSelector(
+      NativeDonatingVenue.swap.selector,
+      address(tokenIn),
+      address(tokenOut),
+      amountIn,
+      uint256(9 ether)
+    );
+
+    vm.expectRevert(SwapInventoryLib.InsufficientInventory.selector);
+    harness.doSwap(
+      address(venue),
+      address(tokenIn), // token0
+      address(tokenOut), // token1
+      true, // sellToken0
+      amountIn,
+      9 ether, // amountOutMin
+      swapData,
+      avail, // total0 (available) < amountIn
+      0, // total1
+      WRAPPED_NATIVE,
+      false // nativeIn
+    );
+  }
 }

--- a/test/provider/SwapInventoryLibNative.t.sol
+++ b/test/provider/SwapInventoryLibNative.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SwapInventoryLib } from "../../src/provider/libraries/SwapInventoryLib.sol";
+
+/// @dev Minimal ERC-20 sufficient for SafeERC20.forceApprove + transfer/transferFrom.
+contract MiniERC20 {
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  function mint(address to, uint256 a) external {
+    balanceOf[to] += a;
+  }
+
+  function approve(address s, uint256 a) external returns (bool) {
+    allowance[msg.sender][s] = a;
+    return true;
+  }
+
+  function transfer(address to, uint256 a) external returns (bool) {
+    balanceOf[msg.sender] -= a;
+    balanceOf[to] += a;
+    return true;
+  }
+
+  function transferFrom(address f, address to, uint256 a) external returns (bool) {
+    allowance[f][msg.sender] -= a;
+    balanceOf[f] -= a;
+    balanceOf[to] += a;
+    return true;
+  }
+}
+
+/// @dev A venue that pulls tokenIn, pays tokenOut, AND forwards 1 wei of native to the caller — the
+///      Velodrome-style "sweeps its native balance" behaviour an attacker can seed with a dust donation.
+contract NativeDonatingVenue {
+  function swap(address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut) external {
+    IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
+    MiniERC20(tokenOut).transfer(msg.sender, amountOut);
+    (bool ok, ) = msg.sender.call{ value: 1 }("");
+    require(ok, "native fwd failed");
+  }
+
+  receive() external payable {}
+}
+
+/// @dev Harness: an external library call compiles to DELEGATECALL, so inside SwapInventoryLib.swap
+///      `address(this)` is this harness (holds tokens, grants allowances, receives native).
+contract SwapLibHarness {
+  function doSwap(
+    address swapPair,
+    address token0,
+    address token1,
+    bool sellToken0,
+    uint256 amountIn,
+    uint256 amountOutMin,
+    bytes memory swapData,
+    uint256 total0,
+    uint256 total1,
+    address wrappedNative,
+    bool nativeIn
+  ) external returns (uint256, uint256) {
+    return
+      SwapInventoryLib.swap(
+        swapPair,
+        token0,
+        token1,
+        sellToken0,
+        amountIn,
+        amountOutMin,
+        swapData,
+        total0,
+        total1,
+        wrappedNative,
+        nativeIn
+      );
+  }
+
+  receive() external payable {}
+}
+
+/// @notice Counter-test for the SwapInventoryLib native-handling fix: when NEITHER swap leg is the
+///         wrapped-native token, a venue that forwards stray native must NOT brick the conversion. The
+///         live LST pairs always include the wrapped-native leg, so this path is only reachable for a
+///         future non-native pair — exercised here against the library directly.
+contract SwapInventoryLibNativeTest is Test {
+  SwapLibHarness harness;
+  NativeDonatingVenue venue;
+  MiniERC20 tokenIn;
+  MiniERC20 tokenOut;
+  address constant WRAPPED_NATIVE = address(0xdEaD); // dummy: NOT either token
+
+  function setUp() public {
+    harness = new SwapLibHarness();
+    venue = new NativeDonatingVenue();
+    tokenIn = new MiniERC20();
+    tokenOut = new MiniERC20();
+
+    tokenIn.mint(address(harness), 100 ether); // the position's token0 inventory
+    tokenOut.mint(address(venue), 100 ether); // venue pays out token1
+    vm.deal(address(venue), 1); // venue has 1 wei native to forward
+  }
+
+  function test_swap_ignoresStrayNativeWhenNeitherLegIsWrappedNative() public {
+    uint256 amountIn = 10 ether;
+    uint256 amountOut = 9 ether;
+    bytes memory swapData = abi.encodeWithSelector(
+      NativeDonatingVenue.swap.selector,
+      address(tokenIn),
+      address(tokenOut),
+      amountIn,
+      amountOut
+    );
+
+    // Neither token0 nor token1 is WRAPPED_NATIVE. Pre-fix this reverted UnexpectedNative on the 1-wei
+    // donation; post-fix the stray native is ignored and the ERC-20↔ERC-20 swap settles normally.
+    (uint256 t0, uint256 t1) = harness.doSwap(
+      address(venue),
+      address(tokenIn), // token0
+      address(tokenOut), // token1
+      true, // sellToken0
+      amountIn,
+      amountOut, // amountOutMin
+      swapData,
+      100 ether, // total0
+      0, // total1
+      WRAPPED_NATIVE,
+      false // nativeIn
+    );
+
+    assertEq(t0, 100 ether - amountIn, "token0 total reduced by spent");
+    assertEq(t1, amountOut, "token1 total increased by received");
+    assertEq(address(harness).balance, 1, "stray native left untouched (not wrapped, not reverted)");
+  }
+}

--- a/test/provider/V3ProviderReentrancyPoC.t.sol
+++ b/test/provider/V3ProviderReentrancyPoC.t.sol
@@ -117,13 +117,13 @@ contract Attacker {
   function predeposit(uint256 a0, uint256 a1) external {
     IERC20(slis).approve(address(provider), type(uint256).max);
     IERC20(wbnb).approve(address(provider), type(uint256).max);
-    provider.deposit(mp, a0, a1, 0, 0, address(this));
+    provider.deposit(mp, a0, a1, 0, 0, 0, address(this));
   }
 
   /// @dev The malicious deposit. onBehalf = a separate (recoverable) account.
   function attack(uint256 a0, uint256 a1, address onBehalf) external {
     armed = true;
-    provider.deposit(mp, a0, a1, 0, 0, onBehalf);
+    provider.deposit(mp, a0, a1, 0, 0, 0, onBehalf);
     armed = false;
   }
 

--- a/test/provider/WstETHV3Provider.t.sol
+++ b/test/provider/WstETHV3Provider.t.sol
@@ -373,7 +373,7 @@ contract WstETHV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "valid range");
@@ -401,7 +401,7 @@ contract WstETHV3ProviderTest is Test {
     bytes memory data = _swapData(address(mockSwap), true, amountIn, (fairOut * 99) / 100, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after swap");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "fair swap ~value-neutral");
@@ -433,7 +433,7 @@ contract WstETHV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.RebalanceLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice Linchpin: the backend-supplied `amountOutMin` is enforced on the measured output. A venue
@@ -455,7 +455,7 @@ contract WstETHV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(SwapInventoryLib.InsufficientOutput.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice The adapter only allows whitelisted swap venues; a non-whitelisted target reverts before
@@ -472,7 +472,7 @@ contract WstETHV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.NotWhitelistedPair.selector);
-    provider.rebalance(0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
   }
 
   /* ─────────────────────── access control / config ─────────────────────── */
@@ -480,7 +480,7 @@ contract WstETHV3ProviderTest is Test {
   function test_rebalance_onlyBot() public {
     _deposit(10 ether, 10 ether);
     vm.expectRevert();
-    provider.rebalance(0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
   }
 
   function test_rebalance_revertsAfterDeadline() public {
@@ -489,7 +489,7 @@ contract WstETHV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.DeadlineExpired.selector);
-    provider.rebalance(0, 0, 0, block.timestamp - 1, "");
+    provider.rebalance(0, 0, 0, 0, block.timestamp - 1, "");
   }
 
   function test_setSwapPairWhitelist_onlyManager() public {

--- a/test/provider/WstETHV3Provider.t.sol
+++ b/test/provider/WstETHV3Provider.t.sol
@@ -375,7 +375,9 @@ contract WstETHV3ProviderTest is Test {
     vm.prank(bot);
     provider.rebalance(0, 0, 0, 0, block.timestamp, "");
 
-    assertGt(adapter.tokenId(), oldTokenId, "position re-minted");
+    // No-op recenter (unchanged range, no swap / target / floors) short-circuits to an in-place compound
+    // rather than burning and re-minting the identical position: same tokenId, value preserved.
+    assertEq(adapter.tokenId(), oldTokenId, "no-op recenter keeps the same position (no burn/mint)");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "valid range");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "rebalance ~value-neutral");
     assertEq(adapter.lastCenterRate(), IWstETH(WSTETH).stEthPerToken(), "center rate updated");

--- a/test/provider/WstETHV3Provider.t.sol
+++ b/test/provider/WstETHV3Provider.t.sol
@@ -196,7 +196,7 @@ contract WstETHV3ProviderTest is Test {
     vm.startPrank(user);
     IERC20(WSTETH).approve(address(provider), amtWst);
     IERC20(WETH).approve(address(provider), amtWeth);
-    (shares, , ) = provider.deposit(marketParams, amtWst, amtWeth, (e0 * 99) / 100, (e1 * 99) / 100, user);
+    (shares, , ) = provider.deposit(marketParams, amtWst, amtWeth, (e0 * 99) / 100, (e1 * 99) / 100, 0, user);
     vm.stopPrank();
   }
 


### PR DESCRIPTION
# Remediate V3 LP-collateral audits

## Summary

Remediates the findings from the two V3 LP-collateral audits — across the `V3Provider` collateral stack: the ERC-4626 share provider, the DEX adapter (NFT custody + pool/NPM writes), the share-pricing oracle, the inventory-conversion swap library, and the V3 liquidator.

No storage-layout-breaking changes — all UUPS proxies remain upgrade-safe (new vars append / consume `__gap`).

**Scope:** `src/provider/v3/*`, `src/provider/libraries/SwapInventoryLib.sol`, `src/provider/interfaces/*`, `src/liquidator/V3Liquidator.sol` — 12 shipped files (+496/−83), with counter-tests across 7 test files (+847/−129).

## Fixes

### High

- **Deposit share issuance (Bailsec 04, 05 / HashDit H02, M01)** — reworked subsequent deposits to mint strictly proportional to the position's *fair* composition (`frac = min(dᵢ·WAD/Tᵢ)`, excess parked as idle) instead of a spot-mint re-valued at fair; added a caller-supplied `minShares` slippage floor. Closes the inflation / mint-at-spot-value-at-fair surface. First-depositor inflation is additionally covered by a dead-share seed (launch SOP).
- **`positionAmountsAt` ignored accrued fees (Bailsec 19)** — now simulates live uncollected fees from `feeGrowthInside` deltas; fork-cross-checked against `NPM.collect` to the wei. All downstream valuations (health check, share price, rewards) now include pending fees.
- **Rebalance mint at a manipulated price (Bailsec 20, 21 / HashDit)** — `rebalance` now takes a `targetSqrtPriceX96` and reverts `SpotDeviationTooHigh` if the post-swap+mint pool spot deviates from it beyond `maxSpotDeviationBps`.
- **Permissionless compounding at manipulated spot (Bailsec 23 / HashDit H01)** — compounding is gated on a bounded spot-vs-fair deviation; on a deviated spot the adapter holds fees as idle instead of minting liquidity at a bad ratio.
- **One-sided idle DoS (Bailsec 46)** — a zero-computed-liquidity compound is now a no-op (holds as idle) instead of reverting inside `pool.mint`, so deposit/withdraw/redeem can't be bricked by a single-sided balance.

### Medium

- **Preview-vs-actual slippage mismatch (Bailsec 27)** — `removeLiquidity` enforces `minAmount` against the total delivered (principal + fees + idle), not the burned principal alone; the floor runs unconditionally (covers idle-only / dust exits).
- **Swap reverts on native refund (Bailsec 43)** — `SwapInventoryLib` only re-wraps native when a leg is the wrapped-native token; stray native on a non-native pair is left untouched instead of reverting.

### Low / Informational

- **Compound before the health check (Bailsec 09, 10)** — `withdraw` / `withdrawShares` / `supplyShares` compound accrued fees before Moolah's health-check valuation.
- **Fail closed on a zero oracle leg (Bailsec 11, 18)** — `V3Provider._amountsValueUsd` and `SlisBNBV3Provider.getUserBalanceInBnb` revert `OracleZero` when a leg price is 0, instead of computing a one-legged / zero valuation.
- **`transferFrom` allowance (Bailsec 12)** — the override now `_spendAllowance`s before transferring.
- **Fail-fast swap inventory (Bailsec 44)** — `SwapInventoryLib.swap` reverts `InsufficientInventory` when the requested `amountIn` exceeds the position balance, instead of silently capping (which desynced the venue allowance from `swapData` and could underflow the totals).
- **Oracle dust floor (Bailsec 50)** — `V3ProviderOracle.peek` floors a dust position's post-haircut price to a non-zero unit instead of reverting, so a tiny position stays liquidatable; a zero *leg price* still fails closed.
- **Dust redeem guard (Bailsec 32 / HashDit L07)** — `removeLiquidity` reverts `ZeroAmount` when a share-burning redeem would deliver `(0,0)`, rather than silently burning shares.
- **Preview omits pending fees (Bailsec 38 / HashDit L08)** — `previewRemoveLiquidity` pro-rates `positionAmountsAt(spot)` (principal + pending fees + idle), matching actual delivery.
- **Compounded event / event hygiene (Bailsec 31, 52, 53)** — `Compounded` emits the amounts actually consumed; `setHaircutBps` skips the write/emit on an unchanged value; `initialize` emits `HaircutChanged`.
- **Tick-range clamping (Bailsec 34)** — the initial tick range is clamped to the usable `[MIN_TICK, MAX_TICK]` band after alignment.
- **No-op recenter short-circuit (Bailsec 35)** — a pure no-op recenter (unchanged range, no swap/target/floors) compounds in place instead of a burn/mint cycle.
- **TWAP parity (Bailsec 29)** — `_twapTick` computes the cumulative-tick delta under `unchecked`, matching Uniswap `OracleLibrary`.
- **Permissionless `compound()` (Bailsec 30)** — added a spot-deviation-guarded `compound()` entrypoint so yield realization is decoupled from user activity.
- **Adapter rate simplification (Bailsec 40)** — removed dead pool-ordering branches; `_lstNativeRate` returns the StakeManager rate directly (constructor pins token ordering).
- **Liquidation profitability (Bailsec 56)** — `onMoolahLiquidate` judges profitability on a before/after `loanToken` delta, so idle reserves can't mask an unprofitable flash liquidation.
- **V3Liquidation event (HashDit)** — `flashLiquidate` reports the actual redeemed `amount0/amount1` (were hardcoded `0`).

## Testing

- Each fix ships with at least one counter-test proving the vulnerability and the fix.
- Full V3 suite green: **331 tests, 0 failed** (`SlisBNBV3Provider`, `SlisBNBV3ProviderRate`, `WstETHV3Provider`, `WbETHV3Provider`, `V3Liquidator`, `V3LiquidatorEth`, `SwapInventoryLibNative`).
- Fork tests run against BSC (`BSC_RPC`) and Ethereum (`ETH_RPC`).
- Post-fix stack smoke-tested end-to-end on BSC testnet (deposit → borrow → repay → withdraw → redeem → rebalance).

## Acknowledged / operational (no code change)

- **Flash-loan on provider-share collateral (Bailsec 03)** — the share token is added to Moolah's flashLoan blacklist at launch.
- **Unregistered provider markets (Bailsec 14)** — every V3 market registers its provider (`Moolah.setProvider`) at launch.
- **BOT control during rebalance (Bailsec 22)** — bounded by the three-tier loss caps + the target-price guard; residual accepted under the trusted-BOT model.
- **TWAP-observe DoS on low-cardinality pools (Bailsec 26, 42)** — observation-cardinality sizing + monitoring at deploy (wstETH/wbETH only; slisBNB is pure rate-implied). `maxTwapDeviationBps = 0` fully disables the TWAP read.
- **LST depeg (Bailsec 48, 49, 51)** — carried by LLTV + a conservatively-set haircut; only robust LSTs onboarded with depeg alerting.
- **Rate-consistent leg pricing (Bailsec 15, 28)** — the resilient oracle is configured so the LST leg price is the on-chain exchangeRate-derived price, so composition and valuation are rate-consistent by configuration.
