### PR TITLE
feat(revenue): add batchAccrueVaultFees to RevenueCollector

### DIFF
--- a/script/revenue/deploy_RevenueCollector_impl.sol
+++ b/script/revenue/deploy_RevenueCollector_impl.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { RevenueCollector } from "revenue/RevenueCollector.sol";
+
+/// @notice BSC mainnet: Deploy a new RevenueCollector implementation only.
+///         The proxy upgrade to this impl is performed separately (via the
+///         Timelock / Safe that holds DEFAULT_ADMIN_ROLE on the proxy).
+///
+///   Usage:
+///     source .env && forge script script/revenue/deploy_RevenueCollector_impl.sol \
+///       --rpc-url $BSC_RPC --broadcast --verify --via-ir -vvv
+contract RevenueCollectorImplDeploy is DeployBase {
+  function run() public {
+    require(block.chainid == 56, "not BSC mainnet");
+
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+    console.log("Chain ID: ", block.chainid);
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy RevenueCollector implementation
+    RevenueCollector impl = new RevenueCollector();
+    console.log("RevenueCollector implementation: ", address(impl));
+
+    vm.stopBroadcast();
+  }
+}

--- a/src/revenue/RevenueCollector.sol
+++ b/src/revenue/RevenueCollector.sol
@@ -8,6 +8,7 @@ import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/Saf
 
 import { IStableSwap } from "../dex/interfaces/IStableSwap.sol";
 import { ILiquidator } from "../liquidator/ILiquidator.sol";
+import { IMoolahVault } from "../moolah-vault/interfaces/IMoolahVault.sol";
 
 /**
  * @title RevenueCollector
@@ -38,6 +39,7 @@ contract RevenueCollector is UUPSUpgradeable, AccessControlEnumerableUpgradeable
   event StableSwapFeeCollected(address indexed pool);
   event LiquidationFeeCollected(address indexed liquidator, address indexed asset, uint256 amount);
   event EmergencyWithdraw(address indexed asset, uint256 amount, address indexed to);
+  event VaultFeeAccrued(address indexed vault);
 
   constructor() {
     _disableInitializers();
@@ -106,6 +108,34 @@ contract RevenueCollector is UUPSUpgradeable, AccessControlEnumerableUpgradeable
     IStableSwap(pool).withdraw_admin_fees();
 
     emit StableSwapFeeCollected(pool);
+  }
+
+  /**
+   * @dev Triggers fee accrual on Moolah vaults by depositing 0 assets.
+   * A zero-asset deposit mints no shares but runs the vault's `_accrueFee` logic,
+   * realizing accrued fees to the vault's fee recipient.
+   * @param vaults The list of Moolah vaults to accrue fees on
+   */
+  function batchAccrueVaultFees(address[] calldata vaults) external onlyRole(BOT) {
+    require(vaults.length > 0 && vaults.length <= MAX_LENGTH, "invalid length");
+
+    for (uint256 i = 0; i < vaults.length; i++) {
+      _accrueVaultFee(vaults[i]);
+    }
+  }
+
+  /**
+   * @dev Triggers fee accrual on a single Moolah vault by depositing 0 assets.
+   * @param vault The address of the Moolah vault
+   */
+  function accrueVaultFee(address vault) external onlyRole(BOT) {
+    _accrueVaultFee(vault);
+  }
+
+  function _accrueVaultFee(address vault) internal {
+    IMoolahVault(vault).deposit(0, address(this));
+
+    emit VaultFeeAccrued(vault);
   }
 
   /**

--- a/test/revenue/RevenueCollector.t.sol
+++ b/test/revenue/RevenueCollector.t.sol
@@ -169,6 +169,59 @@ contract RevenueCollectorTest is Test {
     assertEq(token4.balanceOf(address(revenueCollector)), 20 ether);
   }
 
+  function test_batchAccrueVaultFees() public {
+    MockMoolahVault vault1 = new MockMoolahVault();
+    MockMoolahVault vault2 = new MockMoolahVault();
+
+    address[] memory vaults = new address[](2);
+    vaults[0] = address(vault1);
+    vaults[1] = address(vault2);
+
+    // only BOT can call
+    vm.expectRevert(); // AccessControlUnauthorizedAccount
+    revenueCollector.batchAccrueVaultFees(vaults);
+
+    vm.prank(bot);
+    revenueCollector.batchAccrueVaultFees(vaults);
+
+    // each vault received a deposit(0, revenueCollector) call
+    assertEq(vault1.depositCalls(), 1);
+    assertEq(vault1.lastAssets(), 0);
+    assertEq(vault1.lastReceiver(), address(revenueCollector));
+    assertEq(vault2.depositCalls(), 1);
+    assertEq(vault2.lastAssets(), 0);
+    assertEq(vault2.lastReceiver(), address(revenueCollector));
+  }
+
+  function test_accrueVaultFee() public {
+    MockMoolahVault vault = new MockMoolahVault();
+
+    vm.expectRevert(); // AccessControlUnauthorizedAccount
+    revenueCollector.accrueVaultFee(address(vault));
+
+    vm.prank(bot);
+    revenueCollector.accrueVaultFee(address(vault));
+
+    assertEq(vault.depositCalls(), 1);
+    assertEq(vault.lastAssets(), 0);
+    assertEq(vault.lastReceiver(), address(revenueCollector));
+  }
+
+  function test_batchAccrueVaultFees_invalidLength() public {
+    address[] memory empty = new address[](0);
+    vm.prank(bot);
+    vm.expectRevert("invalid length");
+    revenueCollector.batchAccrueVaultFees(empty);
+
+    address[] memory tooMany = new address[](31);
+    for (uint256 i = 0; i < 31; i++) {
+      tooMany[i] = address(new MockMoolahVault());
+    }
+    vm.prank(bot);
+    vm.expectRevert("invalid length");
+    revenueCollector.batchAccrueVaultFees(tooMany);
+  }
+
   function test_emergencyWithdraw() public {
     // fund revenue collector
     token0.setBalance(address(revenueCollector), 50 ether);
@@ -223,4 +276,17 @@ contract MockStableSwap {
   }
 
   receive() external payable {}
+}
+
+contract MockMoolahVault {
+  uint256 public depositCalls;
+  uint256 public lastAssets;
+  address public lastReceiver;
+
+  function deposit(uint256 assets, address receiver) external returns (uint256) {
+    depositCalls += 1;
+    lastAssets = assets;
+    lastReceiver = receiver;
+    return 0;
+  }
 }


### PR DESCRIPTION
## Summary

Adds a BOT-gated way for the `RevenueCollector` to trigger fee accrual on Moolah vaults via a zero-asset `deposit(0, address(this))` call. A zero-asset deposit mints no shares but runs the vault's `_accrueFee()` logic, realizing accrued fees to the vault's fee recipient.

## Changes

- `batchAccrueVaultFees(address[] calldata vaults)` — validates `0 < length <= MAX_LENGTH` (30) and accrues each vault.
- `accrueVaultFee(address vault)` — single-vault variant.
- `_accrueVaultFee` internal helper + `VaultFeeAccrued(address indexed vault)` event.
- Both external methods are `onlyRole(BOT)`, consistent with the existing DEX/liquidation fee methods.

## Notes

- `deposit(0, ...)` in `MoolahVault` gates the **receiver** on the vault whitelist (when non-empty). Since the receiver is `address(this)`, the RevenueCollector address must be whitelisted on any vault that enforces a whitelist. Shareholding is irrelevant.
- Zero-amount paths are safe: `_supplyMoolah(0)` is a no-op and `_mint(receiver, 0)` does not revert.

## Testing

- `forge test --mc RevenueCollectorTest` — 8 passed (3 new: `test_batchAccrueVaultFees`, `test_accrueVaultFee`, `test_batchAccrueVaultFees_invalidLength`).
- `forge build` clean; prettier passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)