### PR TITLE
fix(provider): credit min(fair,spot) shares on deposit to close the deposit-withdraw cycle

### DIFF
--- a/src/provider/interfaces/IV3Provider.sol
+++ b/src/provider/interfaces/IV3Provider.sol
@@ -11,8 +11,10 @@ import { IProvider } from "./IProvider.sol";
  *         (IV3ProviderOracle). The vault is no longer an IOracle.
  */
 interface IV3Provider is IProvider {
+  /// @notice token0 of the underlying V3 pool (token0 < token1 by address).
   function TOKEN0() external view returns (address);
 
+  /// @notice token1 of the underlying V3 pool.
   function TOKEN1() external view returns (address);
 
   /// @notice Wrapped-native token of the pool's chain (WBNB on BSC, WETH on Ethereum). On exit the
@@ -31,8 +33,17 @@ interface IV3Provider is IProvider {
   function getFairComposition() external view returns (uint256 total0, uint256 total1);
 
   /// @notice Deposit token0/token1 into the V3 position and supply resulting shares as Moolah
-  ///         collateral on behalf of `onBehalf`. Reverts if the minted shares are below `minShares`
-  ///         (share-slippage floor; pass 0 to disable).
+  ///         collateral on behalf of `onBehalf`.
+  /// @param marketParams   target Moolah market (collateral token must be this vault).
+  /// @param amount0Desired token0 offered (unused excess is refunded).
+  /// @param amount1Desired token1 offered (unused excess is refunded).
+  /// @param amount0Min     min token0 that must be consumed, else revert.
+  /// @param amount1Min     min token1 that must be consumed, else revert.
+  /// @param minShares      share-slippage floor: revert if minted shares < this (0 disables).
+  /// @param onBehalf       Moolah collateral owner credited with the shares.
+  /// @return shares        shares minted and supplied.
+  /// @return amount0Used   token0 actually consumed.
+  /// @return amount1Used   token1 actually consumed.
   function deposit(
     MarketParams calldata marketParams,
     uint256 amount0Desired,
@@ -44,6 +55,14 @@ interface IV3Provider is IProvider {
   ) external payable returns (uint256 shares, uint256 amount0Used, uint256 amount1Used);
 
   /// @notice Withdraw shares from Moolah, remove liquidity, and return token0/token1 to `receiver`.
+  /// @param marketParams market to pull the collateral from.
+  /// @param shares       shares to burn.
+  /// @param minAmount0   min token0 delivered, else revert.
+  /// @param minAmount1   min token1 delivered, else revert.
+  /// @param onBehalf     collateral owner whose shares are withdrawn.
+  /// @param receiver     recipient of the underlying (wrapped-native leg paid as native coin).
+  /// @return amount0     token0 delivered.
+  /// @return amount1     token1 delivered.
   function withdraw(
     MarketParams calldata marketParams,
     uint256 shares,
@@ -54,6 +73,10 @@ interface IV3Provider is IProvider {
   ) external returns (uint256 amount0, uint256 amount1);
 
   /// @notice Withdraw provider shares from Moolah collateral without redeeming the underlying position.
+  /// @param marketParams market to pull the collateral from.
+  /// @param shares       shares to withdraw.
+  /// @param onBehalf     collateral owner whose shares are withdrawn.
+  /// @param receiver     recipient of the share tokens.
   function withdrawShares(
     MarketParams calldata marketParams,
     uint256 shares,
@@ -62,9 +85,18 @@ interface IV3Provider is IProvider {
   ) external;
 
   /// @notice Supply wallet-held provider shares as Moolah collateral.
+  /// @param marketParams market to supply into.
+  /// @param shares       shares to supply.
+  /// @param onBehalf     collateral owner credited with the shares.
   function supplyShares(MarketParams calldata marketParams, uint256 shares, address onBehalf) external;
 
   /// @notice Redeem shares already held by the caller (e.g. a liquidator) for the underlying token0/token1.
+  /// @param shares     shares to redeem.
+  /// @param minAmount0 min token0 delivered, else revert.
+  /// @param minAmount1 min token1 delivered, else revert.
+  /// @param receiver   recipient of the underlying (wrapped-native leg paid as native coin).
+  /// @return amount0   token0 delivered.
+  /// @return amount1   token1 delivered.
   function redeemShares(
     uint256 shares,
     uint256 minAmount0,

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -294,30 +294,11 @@ abstract contract V3Provider is
       // spot price never enters share issuance, so the mint-at-spot / value-at-fair gap that let a
       // depositor be over-credited (with idle present) is eliminated. Value-conserving: the depositor
       // adds exactly `frac` of each composition leg and receives `frac` of the supply.
-      (uint256 t0, uint256 t1) = IV3DexAdapter(ADAPTER).positionAmountsAt(fairSqrtPriceX96);
-      if (_amountsValueUsd(t0, t1) == 0) revert ZeroShares();
-
-      uint256 frac; // WAD-scaled fraction of the existing composition being added
-      if (t0 == 0) {
-        frac = (_amount1Desired * WAD) / t1;
-      } else if (t1 == 0) {
-        frac = (_amount0Desired * WAD) / t0;
-      } else {
-        uint256 f0 = (_amount0Desired * WAD) / t0;
-        uint256 f1 = (_amount1Desired * WAD) / t1;
-        frac = f0 < f1 ? f0 : f1;
-      }
-
-      // Round the consumed amounts UP so the depositor pays >= their pro-rata share (shares below round
-      // down) — any sub-wei rounding favors existing holders, never the depositor. Both stay <= the
-      // desired input since frac <= dᵢ·WAD/tᵢ, so no over-consumption.
-      amount0Used = (t0 * frac + WAD - 1) / WAD;
-      amount1Used = (t1 * frac + WAD - 1) / WAD;
+      // min(fair, spot) share credit + fair-pinned consumed amounts (see _quoteDeposit).
+      (shares, amount0Used, amount1Used) = _quoteDeposit(supplyBefore, _amount0Desired, _amount1Desired);
       // Repurposed slippage guard: amount0Min/amount1Min are now the minimum of each leg that must be
       // consumed (the rest is refunded), protecting the depositor from an unexpected composition ratio.
       if (amount0Used < amount0Min || amount1Used < amount1Min) revert InsufficientAmount();
-
-      shares = (supplyBefore * frac) / WAD;
 
       // Park the consumed tokens into the adapter's idle inventory (deployed later by compound()).
       if (amount0Used > 0) IERC20(TOKEN0).safeTransfer(ADAPTER, amount0Used);
@@ -511,6 +492,28 @@ abstract contract V3Provider is
     amount1 = (t1 * frac) / WAD;
   }
 
+  /// @notice Preview the shares a deposit would mint — the exact min(fair, spot) credit deposit() uses.
+  ///         Frontends size `minShares` off this (× a slippage tolerance). First deposit (supply == 0)
+  ///         previews the oracle-valued opening mint.
+  /// @param amount0Desired token0 offered by the depositor.
+  /// @param amount1Desired token1 offered by the depositor.
+  /// @return shares shares deposit() would mint for these amounts.
+  function previewDepositShares(uint256 amount0Desired, uint256 amount1Desired) external view returns (uint256 shares) {
+    uint256 supplyBefore = totalSupply();
+    if (supplyBefore > 0) {
+      (shares, , ) = _quoteDeposit(supplyBefore, amount0Desired, amount1Desired);
+      return shares;
+    }
+    (uint128 liquidity, , ) = IV3DexAdapter(ADAPTER).previewAddLiquidity(amount0Desired, amount1Desired);
+    (uint256 added0, uint256 added1) = IV3DexAdapter(ADAPTER).amountsForLiquidity(
+      liquidity,
+      IV3DexAdapter(ADAPTER).fairSqrtPriceX96()
+    );
+    uint256 assetPrice = IOracle(resilientOracle).peek(asset());
+    if (assetPrice > 0)
+      shares = (_amountsValueUsd(added0, added1) * (10 ** uint256(accountingAssetDecimals))) / assetPrice;
+  }
+
   /// @notice Given a desired token0 amount, the token1 amount that pairs with it at the current fair
   ///         composition ratio, so a subsequent deposit consumes both legs fully (minimal refund).
   /// @dev    amount1 = amount0 * T1 / T0, where (T0, T1) = getFairComposition(). Reverts if the fair
@@ -562,6 +565,57 @@ abstract contract V3Provider is
     // one leg (which would under-price the collateral and enable unfair liquidation / over-borrow).
     if (price0 == 0 || price1 == 0) revert OracleZero();
     return (amount0 * price0) / (10 ** DECIMALS0) + (amount1 * price1) / (10 ** DECIMALS1);
+  }
+
+  /// @dev WAD-fraction of a composition covered by given amounts, on the binding (smaller) leg:
+  ///      min(amount0/comp0, amount1/comp1) × WAD. Single-sided composition binds on the present leg;
+  ///      all-zero composition reverts (div-by-zero) — callers guard it.
+  /// @param amount0 token0 amount being priced.
+  /// @param amount1 token1 amount being priced.
+  /// @param comp0   token0 of the composition priced against.
+  /// @param comp1   token1 of the composition priced against.
+  /// @return WAD-scaled fraction (1e18 == the full composition).
+  function _compositionFractionWad(
+    uint256 amount0,
+    uint256 amount1,
+    uint256 comp0,
+    uint256 comp1
+  ) internal pure returns (uint256) {
+    if (comp0 == 0) return (amount1 * WAD) / comp1;
+    if (comp1 == 0) return (amount0 * WAD) / comp0;
+    uint256 frac0 = (amount0 * WAD) / comp0;
+    uint256 frac1 = (amount1 * WAD) / comp1;
+    return frac0 < frac1 ? frac0 : frac1;
+  }
+
+  /// @dev Quote a subsequent deposit (supplyBefore > 0): consumed amounts pinned to the FAIR composition
+  ///      (rounded up); shares = min(sharesFair, sharesSpot), the spot quote re-pricing the SAME consumed
+  ///      amounts. Withdraw settles at spot, so the min caps the credit at what a spot exit can back
+  ///      (closes the deposit-withdraw cycle). Shared with previewDepositShares — preview can't drift.
+  /// @param supplyBefore   share supply before this deposit.
+  /// @param amount0Desired token0 offered by the depositor.
+  /// @param amount1Desired token1 offered by the depositor.
+  /// @return shares      shares to mint = min(fair, spot).
+  /// @return amount0Used token0 consumed and parked to idle (rest refunded).
+  /// @return amount1Used token1 consumed and parked to idle (rest refunded).
+  function _quoteDeposit(
+    uint256 supplyBefore,
+    uint256 amount0Desired,
+    uint256 amount1Desired
+  ) internal view returns (uint256 shares, uint256 amount0Used, uint256 amount1Used) {
+    (uint256 t0, uint256 t1) = IV3DexAdapter(ADAPTER).positionAmountsAt(IV3DexAdapter(ADAPTER).fairSqrtPriceX96());
+    if (_amountsValueUsd(t0, t1) == 0) revert ZeroShares();
+
+    uint256 frac = _compositionFractionWad(amount0Desired, amount1Desired, t0, t1);
+    amount0Used = (t0 * frac + WAD - 1) / WAD;
+    amount1Used = (t1 * frac + WAD - 1) / WAD;
+
+    uint256 sharesFair = (supplyBefore * frac) / WAD;
+    (uint256 s0, uint256 s1) = IV3DexAdapter(ADAPTER).positionAmountsAt(IV3DexAdapter(ADAPTER).spotSqrtPriceX96());
+    uint256 sharesSpot = (s0 == 0 && s1 == 0)
+      ? type(uint256).max // degenerate spot composition: do not let it lower the credit
+      : (supplyBefore * _compositionFractionWad(amount0Used, amount1Used, s0, s1)) / WAD;
+    shares = sharesFair < sharesSpot ? sharesFair : sharesSpot;
   }
 
   /// @dev Single-asset ERC-4626 entry is disabled — this is a two-token LP vault. Use the two-token

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -403,12 +403,9 @@ contract SlisBNBV3ProviderTest is Test {
   function test_deposit_minShares_guardsShareSlippage() public {
     _deposit(user, 10 ether, 10 ether);
 
-    // Preview the shares a balanced 10/10 deposit would mint at the current fair composition.
-    (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(10 ether, 10 ether);
-    uint256 supplyBefore = provider.totalSupply();
-    (uint256 t0, uint256 t1) = provider.getFairComposition();
-    uint256 fracExp = (exp0 * 1e18) / t0 < (exp1 * 1e18) / t1 ? (exp0 * 1e18) / t0 : (exp1 * 1e18) / t1;
-    uint256 expectedShares = (supplyBefore * fracExp) / 1e18;
+    // previewDepositShares returns the exact min(fair, spot) credit deposit() will mint, so the floor
+    // below is measured against the real amount (not a fair-only estimate that a spot move could fail).
+    uint256 expectedShares = provider.previewDepositShares(10 ether, 10 ether);
 
     deal(SLISBNB, user2, 10 ether);
     deal(WBNB, user2, 10 ether);
@@ -830,6 +827,94 @@ contract SlisBNBV3ProviderTest is Test {
     (, uint256 exp0, uint256 exp1) = provider.previewDepositAmounts(10 ether, 10 ether);
     assertGt(exp0, 0, "fair composition consumes token0 regardless of spot");
     assertGt(exp1, 0, "fair composition consumes token1 regardless of spot");
+  }
+
+  /* ───────────── deposit crediting: min(fair, spot) shares ───────────── */
+
+  /// @dev Push the pool spot off the rate-anchored fair by selling WBNB (token1) into the pool.
+  function _skewSpotUp(uint256 wbnbIn) internal {
+    PoolSwapper sw = new PoolSwapper();
+    deal(WBNB, address(sw), wbnbIn);
+    sw.swapExactIn(POOL, false, wbnbIn);
+  }
+
+  /// @dev At a skewed spot the SAME deposit is credited fewer shares than at fair — the spot quote (same
+  ///      consumed amounts) wins the min, capping the credit at what a spot exit can back. Pre-fix
+  ///      (fair-only issuance) the skew would not change the credited shares, so this fails pre-fix.
+  function test_deposit_skewedSpotCreditsFewerShares() public {
+    _deposit(user, 100 ether, 100 ether); // seed
+
+    uint256 snap = vm.snapshotState();
+    (uint256 sharesFair, , ) = _deposit(user2, 100 ether, 100 ether); // no skew → fair basis
+    vm.revertToState(snap);
+
+    _skewSpotUp(300 ether);
+    (uint256 sharesSkew, , ) = _deposit(user2, 100 ether, 100 ether);
+
+    assertLt(sharesSkew, sharesFair, "skewed spot must credit fewer shares (min fair/spot)");
+    assertGt(sharesSkew, 0, "still mints > 0");
+  }
+
+  /// @dev previewDepositShares returns exactly what deposit() mints — unskewed AND at a skewed spot — so
+  ///      frontends can size minShares off it without the mint drifting below their floor.
+  function test_previewDepositShares_matchesActualMint() public {
+    _deposit(user, 100 ether, 100 ether); // seed
+
+    uint256 snap = vm.snapshotState();
+    uint256 preview1 = provider.previewDepositShares(100 ether, 100 ether);
+    (uint256 actual1, , ) = _deposit(user2, 100 ether, 100 ether);
+    vm.revertToState(snap);
+    assertEq(preview1, actual1, "preview matches mint (unskewed)");
+
+    _skewSpotUp(300 ether);
+    uint256 preview2 = provider.previewDepositShares(100 ether, 100 ether);
+    (uint256 actual2, , ) = _deposit(user2, 100 ether, 100 ether);
+    assertEq(preview2, actual2, "preview matches mint (skewed spot)");
+    assertLt(preview2, preview1, "skew lowers the previewed shares (min = spot quote)");
+  }
+
+  /// @dev The deposit->withdraw cycle at a skewed spot is no longer profitable: the exiter cannot walk
+  ///      out with more fair value than it put in (the core deposit-withdraw leak, closed).
+  function test_depositWithdraw_cycleNotProfitableAtSkewedSpot() public {
+    _deposit(user, 100 ether, 100 ether); // seed
+    _skewSpotUp(300 ether);
+
+    (uint256 shares, uint256 in0, uint256 in1) = _deposit(user2, 100 ether, 100 ether);
+    (uint256 e0, uint256 e1) = provider.previewRedeemUnderlying(shares);
+    vm.prank(user2);
+    (uint256 out0, uint256 out1) = provider.withdraw(
+      marketParams,
+      shares,
+      (e0 * 90) / 100,
+      (e1 * 90) / 100,
+      user2,
+      user2
+    );
+
+    assertLe(_valueUSD(out0, out1), _valueUSD(in0, in1), "cycle must not extract fair value after the fix");
+  }
+
+  /// @dev MEV backstop: an attacker front-running a spot skew squeezes the credited shares; the
+  ///      depositor's minShares (set to its fair-basis expectation) reverts rather than settle low.
+  function test_deposit_minSharesBackstopsSpotSqueeze() public {
+    _deposit(user, 100 ether, 100 ether); // seed
+
+    uint256 snap = vm.snapshotState();
+    (uint256 fairShares, , ) = _deposit(user2, 100 ether, 100 ether); // fair-basis expectation
+    vm.revertToState(snap);
+
+    _skewSpotUp(300 ether); // attacker front-run
+
+    deal(SLISBNB, user2, 100 ether);
+    deal(WBNB, user2, 100 ether);
+    (, uint256 e0, uint256 e1) = provider.previewDepositAmounts(100 ether, 100 ether);
+    vm.startPrank(user2);
+    IERC20(SLISBNB).approve(address(provider), 100 ether);
+    IERC20(WBNB).approve(address(provider), 100 ether);
+    // minShares = fair expectation → after the squeeze the credit is lower → revert.
+    vm.expectRevert(V3Provider.InsufficientShares.selector);
+    provider.deposit(marketParams, 100 ether, 100 ether, (e0 * 99) / 100, (e1 * 99) / 100, fairShares, user2);
+    vm.stopPrank();
   }
 
   function test_previewDepositForToken_pairsLegsAtFairComposition() public {

--- a/test/provider/V3ProviderReentrancyPoC.t.sol
+++ b/test/provider/V3ProviderReentrancyPoC.t.sol
@@ -25,9 +25,9 @@ import { SlisBNBV3ProviderTest } from "./SlisBNBV3Provider.t.sol";
  *         totalSupply are inconsistent, so the oracle can never be transiently inflated.
  *
  *         This test still drives the full attack (deposit -> refund reentry -> borrow), but now asserts
- *         the attack is NEUTRALIZED: the price read during the refund callback equals the normal price,
- *         and the attacker's position stays healthy (no bad debt). It FAILS against the pre-fix code
- *         (26x inflation, insolvent attacker) and PASSES against the fixed code.
+ *         the attack is NEUTRALIZED: the price read during the refund callback equals the SETTLED price
+ *         (no transient inflation), and the attacker's position stays healthy (no bad debt). It FAILS
+ *         against the pre-fix code (26x inflation, insolvent attacker) and PASSES against the fixed code.
  */
 contract V3ProviderReentrancyPoC is SlisBNBV3ProviderTest {
   Attacker attacker;
@@ -68,10 +68,14 @@ contract V3ProviderReentrancyPoC is SlisBNBV3ProviderTest {
     emit log_named_uint("peek after deposit settles", peekAfter);
 
     // ── Proofs the attack is neutralized ────────────────────────────────────
-    // (a) The refund callback fires AFTER mint+supply, so NAV and totalSupply are consistent: the
-    //     price observed mid-deposit must match the settled/normal price (no transient inflation).
-    assertApproxEqRel(peekDuring, peekNormal, 1e16, "peek during refund must equal normal price (<=1%)");
+    // (a) The refund callback fires AFTER mint+supply, so NAV and totalSupply are consistent: the price
+    //     observed mid-deposit equals the SETTLED price — no transient inflation. This is the core
+    //     regression guard: pre-fix the refund preceded mint, so peekDuring spiked ~26x vs peekAfter.
     assertApproxEqRel(peekDuring, peekAfter, 1e16, "peek during refund must equal settled price (<=1%)");
+    //     The settled price sits at/above the pre-deposit price: min(fair,spot) crediting caps a large
+    //     imbalanced deposit at its spot-exit value, so the surplus accrues to holders — a legitimate,
+    //     persistent rise, never a transient inflation to over-borrow against.
+    assertGe(peekDuring, peekNormal, "deposit may only raise peek (surplus to holders), never lower it");
 
     // (b) Because the price was never inflated, any reentrant borrow was fairly priced: the attacker's
     //     position is solvent — no bad debt is left to the protocol.

--- a/test/provider/WbETHV3Provider.t.sol
+++ b/test/provider/WbETHV3Provider.t.sol
@@ -3,6 +3,9 @@ pragma solidity 0.8.34;
 
 import "forge-std/Test.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { FullMath } from "lista-dao-contracts/oracle/libraries/FullMath.sol";
 
 import { WbETHV3Provider } from "../../src/provider/v3/WbETHV3Provider.sol";
@@ -10,7 +13,11 @@ import { WbETHV3DexAdapter } from "../../src/provider/v3/WbETHV3DexAdapter.sol";
 import { V3DexAdapter } from "../../src/provider/v3/V3DexAdapter.sol";
 import { V3ProviderOracle } from "../../src/provider/v3/V3ProviderOracle.sol";
 import { IWbETH } from "../../src/provider/interfaces/IWbETH.sol";
+import { Moolah } from "../../src/moolah/Moolah.sol";
+import { IMoolah, MarketParams, Id } from "moolah/interfaces/IMoolah.sol";
+import { MarketParamsLib } from "moolah/libraries/MarketParamsLib.sol";
 import { IOracle, TokenConfig } from "moolah/interfaces/IOracle.sol";
+import { IListaV3Pool } from "lista-v3/core/interfaces/IListaV3Pool.sol";
 
 /// @dev Minimal resilient-oracle mock: 8-decimal USD prices, settable per token.
 contract MockOracle is IOracle {
@@ -29,6 +36,23 @@ contract MockOracle is IOracle {
   }
 }
 
+/// @dev Executes a direct Uniswap V3 pool swap (to skew the pool spot) and pays the callback.
+contract PoolSwapper {
+  uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+  uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+  function swapExactIn(address pool, bool zeroForOne, uint256 amountIn) external {
+    uint160 limit = zeroForOne ? MIN_SQRT_RATIO + 1 : MAX_SQRT_RATIO - 1;
+    IListaV3Pool(pool).swap(address(this), zeroForOne, int256(amountIn), limit, abi.encode(pool));
+  }
+
+  function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
+    address pool = abi.decode(data, (address));
+    if (amount0Delta > 0) IERC20(IListaV3Pool(pool).token0()).transfer(msg.sender, uint256(amount0Delta));
+    if (amount1Delta > 0) IERC20(IListaV3Pool(pool).token1()).transfer(msg.sender, uint256(amount1Delta));
+  }
+}
+
 /// @notice Ethereum fork tests for the wbETH/WETH V3 LP topology (WbETHV3DexAdapter + WbETHV3Provider
 ///         + generic V3ProviderOracle). The mechanism is identical to wstETH/WETH (shared base +
 ///         SwapInventoryLib), so the deposit / withdraw / redeem / swap-rebalance PATH is validated by
@@ -39,7 +63,9 @@ contract MockOracle is IOracle {
 ///      functional deposit/rebalance fork tests await a seeded Lista pool; the rebalance swap venue is
 ///      backend-built calldata against a whitelisted pair, validated end-to-end by WstETHV3Provider.t.sol.
 contract WbETHV3ProviderTest is Test {
-  /* the (empty) Uniswap V3 wbETH/WETH 0.3% pool — used only to satisfy the adapter's pool wiring */
+  using MarketParamsLib for MarketParams;
+
+  /* the (empty) Uniswap V3 wbETH/WETH 0.3% pool — a first deposit seeds it with our own liquidity */
   address constant POOL = 0xFEBf58c2E1bBaBE298A9E5EC099385a4B641AE18;
   address constant NPM = 0xC36442b4a4522E871399CD717aBDD847Ab11FE88;
   uint24 constant FEE = 3000;
@@ -47,30 +73,49 @@ contract WbETHV3ProviderTest is Test {
   address constant WBETH = 0xa2E3356610840701BDf5611a53974510Ae27E2e1; // token0
   address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2; // token1
   address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
 
   address constant MOOLAH_PROXY = 0xf820fB4680712CD7263a0D3D024D5b5aEA82Fd70;
+  address constant MOOLAH_ADMIN = 0xa18ae79AEDA3e711E0CD64cfe1Cd06402d400D61; // admin timelock (DEFAULT_ADMIN)
+  address constant IRM = 0x8b7d334d243b74D63C4b963893267A0F5240F990;
+
+  bytes32 constant OPERATOR = keccak256("OPERATOR");
+  bytes32 constant MOOLAH_MANAGER = keccak256("MANAGER");
 
   uint32 constant TWAP_PERIOD = 1800;
+  uint256 constant LLTV = 86 * 1e16;
   uint256 constant ETH_USD = 3000e8; // mock ETH price, 8 decimals
 
+  Moolah moolah;
   WbETHV3DexAdapter adapter;
   WbETHV3Provider provider;
   V3ProviderOracle providerOracle;
   MockOracle oracle;
+  PoolSwapper swapper;
+  MarketParams marketParams;
+  Id marketId;
 
   address admin = makeAddr("admin");
   address manager = makeAddr("manager");
   address bot = makeAddr("bot");
+  address user = makeAddr("user");
 
   function setUp() public {
     vm.createSelectFork(vm.envString("ETH_RPC"), 23566432);
 
-    // Mock resilient oracle: WETH = ETH price; wbETH = ETH price × exchangeRate (rate-derived). USDC = $1.
+    // Upgrade Moolah to the local implementation (keeps the split-topology wiring consistent with source).
+    address newMoolahImpl = address(new Moolah());
+    vm.prank(MOOLAH_ADMIN);
+    UUPSUpgradeable(MOOLAH_PROXY).upgradeToAndCall(newMoolahImpl, bytes(""));
+    moolah = Moolah(MOOLAH_PROXY);
+
+    // Mock resilient oracle: WETH = ETH price; wbETH = ETH price × exchangeRate (rate-derived). USDT = $1.
     oracle = new MockOracle();
     uint256 rate = IWbETH(WBETH).exchangeRate();
     oracle.setPrice(WETH, ETH_USD);
     oracle.setPrice(WBETH, (ETH_USD * rate) / 1e18);
     oracle.setPrice(USDC, 1e8);
+    oracle.setPrice(USDT, 1e8);
 
     WbETHV3DexAdapter adapterImpl = new WbETHV3DexAdapter(NPM, WBETH, WETH, FEE, TWAP_PERIOD);
     adapter = WbETHV3DexAdapter(
@@ -102,6 +147,26 @@ contract WbETHV3ProviderTest is Test {
         )
       )
     );
+
+    swapper = new PoolSwapper();
+
+    // Grant ourselves OPERATOR (createMarket) + MANAGER (setProvider) on the forked Moolah.
+    vm.startPrank(MOOLAH_ADMIN);
+    IAccessControl(MOOLAH_PROXY).grantRole(OPERATOR, address(this));
+    IAccessControl(MOOLAH_PROXY).grantRole(MOOLAH_MANAGER, address(this));
+    vm.stopPrank();
+
+    marketParams = MarketParams({
+      loanToken: USDT,
+      collateralToken: address(provider),
+      oracle: address(providerOracle),
+      irm: IRM,
+      lltv: LLTV
+    });
+    marketId = marketParams.id();
+
+    moolah.createMarket(marketParams);
+    moolah.setProvider(marketId, address(provider), true);
   }
 
   /* ───────────────────────────── tests ────────────────────────────── */
@@ -179,5 +244,94 @@ contract WbETHV3ProviderTest is Test {
     vm.prank(manager);
     adapter.setMaxTwapDeviationBps(0);
     assertEq(adapter.maxTwapDeviationBps(), 0, "clamp band settable to 0 (pure rate)");
+  }
+
+  /* ─────────── deposit crediting: min(fair, spot) shares (deposit-withdraw cycle) ───────────
+
+     WbETHV3Provider does not override V3Provider.deposit, so these exercise the SAME min(fair,spot)
+     credit path proven for slisBNB/wstETH — here against the wbETH topology (exchangeRate-anchored fair).
+     The only wbETH/WETH pool is empty, so the first deposit bootstraps it with our own liquidity; pure-rate
+     mode + a wide center band let that seed land despite the pool's un-arbitraged slot0. */
+
+  /// @dev Relax the guards the empty/un-arbitraged pool would otherwise trip, then seed the position with
+  ///      our own liquidity. Fair stays exchangeRate-anchored; spot = the (manipulable) slot0.
+  function _bootstrap() internal {
+    vm.startPrank(manager);
+    adapter.setMaxTwapDeviationBps(0); // pure-rate fair: no pool TWAP/observe dependency
+    adapter.setCenterRateThresholdBps(5000); // wide band so the seed mint isn't rejected on deviation
+    vm.stopPrank();
+    _depositRet(50 ether, 50 ether);
+  }
+
+  /// @dev Deposit as `user`, returning the consumed amounts. Per-leg floors 0 so a skewed spot cannot
+  ///      trip the slippage floor — we are measuring the share credit here.
+  function _depositRet(uint256 amtWb, uint256 amtWeth) internal returns (uint256 shares, uint256 used0, uint256 used1) {
+    deal(WBETH, user, amtWb);
+    deal(WETH, user, amtWeth);
+    vm.startPrank(user);
+    IERC20(WBETH).approve(address(provider), amtWb);
+    IERC20(WETH).approve(address(provider), amtWeth);
+    (shares, used0, used1) = provider.deposit(marketParams, amtWb, amtWeth, 0, 0, 0, user);
+    vm.stopPrank();
+  }
+
+  /// @dev 8-dec USD value of a (wbETH, WETH) amount pair through the mock resilient oracle.
+  function _valueUSD(uint256 amtWb, uint256 amtWeth) internal view returns (uint256) {
+    return (amtWb * oracle.peek(WBETH)) / 1e18 + (amtWeth * oracle.peek(WETH)) / 1e18;
+  }
+
+  /// @dev WETH->wbETH swap to push the pool spot up (instant; exchangeRate-anchored fair unmoved).
+  function _swapPoolUp(uint256 amountIn) internal {
+    deal(WETH, address(swapper), amountIn);
+    swapper.swapExactIn(POOL, false, amountIn); // token1 (WETH) in → price up
+  }
+
+  /// @dev A spot pushed further from the rate-anchored fair credits fewer shares for the same deposit —
+  ///      the spot quote wins the min, capping the credit at what a spot exit can back.
+  function test_deposit_skewedSpotCreditsFewerShares() public {
+    _bootstrap();
+    _swapPoolUp(20 ether); // push spot clearly above fair
+
+    uint256 snap = vm.snapshotState();
+    (uint256 sharesNear, , ) = _depositRet(10 ether, 10 ether);
+    vm.revertToState(snap);
+
+    _swapPoolUp(20 ether); // push further from fair
+    (uint256 sharesFar, , ) = _depositRet(10 ether, 10 ether);
+
+    assertLt(sharesFar, sharesNear, "further skew, fewer shares");
+    assertGt(sharesFar, 0, "mints > 0");
+  }
+
+  /// @dev previewDepositShares returns exactly what deposit() mints at a skewed spot.
+  function test_previewDepositShares_matchesActualMint() public {
+    _bootstrap();
+    _swapPoolUp(20 ether);
+
+    uint256 preview = provider.previewDepositShares(10 ether, 10 ether);
+    (uint256 actual, , ) = _depositRet(10 ether, 10 ether);
+    assertEq(preview, actual, "preview == mint (skewed)");
+    assertGt(actual, 0, "mints > 0");
+  }
+
+  /// @dev The deposit->withdraw cycle at a skewed spot is not profitable on wbETH either: the exiter
+  ///      cannot walk out with more fair (USD) value than it put in.
+  function test_depositWithdraw_cycleNotProfitableAtSkewedSpot() public {
+    _bootstrap();
+    _swapPoolUp(20 ether); // skew slot0 before the cycle
+
+    (uint256 shares, uint256 in0, uint256 in1) = _depositRet(10 ether, 10 ether);
+    (uint256 e0, uint256 e1) = provider.previewRedeemUnderlying(shares);
+    vm.prank(user);
+    (uint256 out0, uint256 out1) = provider.withdraw(
+      marketParams,
+      shares,
+      (e0 * 90) / 100,
+      (e1 * 90) / 100,
+      user,
+      user
+    );
+
+    assertLe(_valueUSD(out0, out1), _valueUSD(in0, in1), "cycle extracts no value");
   }
 }

--- a/test/provider/WstETHV3Provider.t.sol
+++ b/test/provider/WstETHV3Provider.t.sol
@@ -572,4 +572,83 @@ contract WstETHV3ProviderTest is Test {
     vm.expectRevert(V3ProviderOracle.ShareAdapterMismatch.selector);
     new V3ProviderOracle(address(adapter2), address(provider), WSTETH, WETH);
   }
+
+  /* ─────────── deposit crediting: min(fair, spot) shares (deposit-withdraw cycle) ─────────── */
+
+  /// @dev Deposit as `user`, returning the consumed amounts (unlike `_deposit`). Per-leg floors set to 0
+  ///      so a skewed spot cannot trip the slippage floor — we are measuring the share credit here.
+  function _depositRet(
+    uint256 amtWst,
+    uint256 amtWeth
+  ) internal returns (uint256 shares, uint256 used0, uint256 used1) {
+    deal(WSTETH, user, amtWst);
+    deal(WETH, user, amtWeth);
+    vm.startPrank(user);
+    IERC20(WSTETH).approve(address(provider), amtWst);
+    IERC20(WETH).approve(address(provider), amtWeth);
+    (shares, used0, used1) = provider.deposit(marketParams, amtWst, amtWeth, 0, 0, 0, user);
+    vm.stopPrank();
+  }
+
+  /// @dev 8-dec USD value of a (wstETH, WETH) amount pair through the mock resilient oracle.
+  function _valueUSD(uint256 amtWst, uint256 amtWeth) internal view returns (uint256) {
+    return (amtWst * oracle.peek(WSTETH)) / 1e18 + (amtWeth * oracle.peek(WETH)) / 1e18;
+  }
+
+  /// @dev At a spot skewed off the rate-anchored fair the SAME deposit is credited fewer shares: the spot
+  ///      quote (same consumed amounts re-priced at the manipulated slot0 composition) wins the min,
+  ///      capping the credit at what a spot exit can back. Pre-fix (fair-only issuance) the skew would
+  ///      not change the credited shares, so this fails pre-fix.
+  function test_deposit_skewedSpotCreditsFewerShares() public {
+    _deposit(50 ether, 50 ether); // seed
+
+    uint256 snap = vm.snapshotState();
+    (uint256 sharesFair, , ) = _depositRet(10 ether, 10 ether); // no skew → fair basis
+    vm.revertToState(snap);
+
+    _swapPoolUp(5000 ether); // instant slot0 skew; TWAP-clamped fair unmoved
+    (uint256 sharesSkew, , ) = _depositRet(10 ether, 10 ether);
+
+    assertLt(sharesSkew, sharesFair, "fewer shares at skewed spot");
+    assertGt(sharesSkew, 0, "mints > 0");
+  }
+
+  /// @dev previewDepositShares returns exactly what deposit() mints — unskewed AND at a skewed spot — so
+  ///      a frontend can size minShares off it without the mint drifting below its floor.
+  function test_previewDepositShares_matchesActualMint() public {
+    _deposit(50 ether, 50 ether); // seed
+
+    uint256 snap = vm.snapshotState();
+    uint256 preview1 = provider.previewDepositShares(10 ether, 10 ether);
+    (uint256 actual1, , ) = _depositRet(10 ether, 10 ether);
+    vm.revertToState(snap);
+    assertEq(preview1, actual1, "preview == mint (unskewed)");
+
+    _swapPoolUp(5000 ether);
+    uint256 preview2 = provider.previewDepositShares(10 ether, 10 ether);
+    (uint256 actual2, , ) = _depositRet(10 ether, 10 ether);
+    assertEq(preview2, actual2, "preview == mint (skewed)");
+    assertLt(preview2, preview1, "skew lowers preview");
+  }
+
+  /// @dev The deposit->withdraw cycle at a skewed spot is not profitable: the exiter cannot walk out with
+  ///      more fair (USD) value than it put in — the core deposit-withdraw leak, closed on this pair too.
+  function test_depositWithdraw_cycleNotProfitableAtSkewedSpot() public {
+    _deposit(50 ether, 50 ether); // seed
+    _swapPoolUp(5000 ether); // skew slot0 before the cycle
+
+    (uint256 shares, uint256 in0, uint256 in1) = _depositRet(10 ether, 10 ether);
+    (uint256 e0, uint256 e1) = provider.previewRedeemUnderlying(shares);
+    vm.prank(user);
+    (uint256 out0, uint256 out1) = provider.withdraw(
+      marketParams,
+      shares,
+      (e0 * 90) / 100,
+      (e1 * 90) / 100,
+      user,
+      user
+    );
+
+    assertLe(_valueUSD(out0, out1), _valueUSD(in0, in1), "cycle extracts no value");
+  }
 }


### PR DESCRIPTION
## What

Closes the residual **deposit → withdraw cycle** leak in the V3 LP vault (HashDit M01 / Bailsec Issue_05): a subsequent deposit is credited on the manipulation-resistant **fair** composition, but `withdraw` settles on the pool **spot** decomposition. When `spot ≠ fair`, fair-valued shares could be redeemed against a richer spot composition, extracting value from remaining holders.

## Fix

Subsequent-deposit share crediting is now `min(sharesFair, sharesSpot)`:

- **Consumed amounts stay pinned to the fair composition** (2a design unchanged — the pool spot never sets what the depositor pays).
- **`sharesSpot`** re-prices the *same* consumed amounts against the pool-spot composition; the credit is the smaller of the two. Since `spot ≠ fair` always makes the spot quote the lower one, this caps the credit at what a spot exit can back → the cycle nets ≤ 0.
- **Manipulation-resistant**: pushing spot can only *lower* the credit (never above `sharesFair`); a depositor's `minShares` is the MEV floor.
- Shared `_quoteDeposit` helper so `deposit()` and the new `previewDepositShares` can't drift.

## Added

- **`previewDepositShares(amount0Desired, amount1Desired)`** — returns the exact `min(fair,spot)` credit, so frontends size `minShares` correctly (× a slippage tolerance).
- NatSpec + readable names on the new/changed functions and the `IV3Provider` surface.

## Tests

- `test_deposit_skewedSpotCreditsFewerShares` — a skewed spot credits fewer shares than fair (fails pre-fix).
- `test_depositWithdraw_cycleNotProfitableAtSkewedSpot` — the cycle no longer extracts fair value.
- `test_deposit_minSharesBackstopsSpotSqueeze` — `minShares` reverts a front-run spot squeeze.
- `test_previewDepositShares_matchesActualMint` — preview == actual mint, unskewed and skewed.
- Existing `test_deposit_minShares_guardsShareSlippage` switched to `previewDepositShares`.

Full V3 suite (SlisBNBV3Provider / WstETHV3 / WbETHV3 / V3Liquidator): **213 passed**.

## Notes

- Stacked on #224 — base is `audit/v3-lp-fixes`. Contains a single commit (`d9ecf86`).
- Deposit-side fix; the existing-holder *withdraw-at-spot* leak (a separate concern) is not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
