### PR TITLE
feat(broker): charge 10% protocol fee on broker revenue via relayer

### DIFF
--- a/src/broker/BrokerInterestRelayer.sol
+++ b/src/broker/BrokerInterestRelayer.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { Id, IMoolah, MarketParams, Market, Position } from "../moolah/interfaces/IMoolah.sol";
 import { IBrokerBase } from "./interfaces/IBroker.sol";
@@ -32,6 +33,14 @@ contract BrokerInterestRelayer is
   // ------- Roles -------
   bytes32 public constant MANAGER = keccak256("MANAGER");
 
+  // ------- Constants -------
+  /// @dev WAD scaling for the fee rate (1e18 == 100%), matching Moolah's market fee semantics
+  uint256 public constant WAD = 1e18;
+  /// @dev maximum protocol fee rate (25%), mirroring Moolah's MAX_FEE
+  uint256 public constant MAX_FEE = 0.25e18;
+  /// @dev default protocol fee rate (10%) applied by initializeV2
+  uint256 public constant DEFAULT_FEE_RATE = 0.1e18;
+
   // ------- State variables -------
   /// @dev Moolah contract
   IMoolah public MOOLAH;
@@ -41,6 +50,12 @@ contract BrokerInterestRelayer is
   EnumerableSet.AddressSet private brokers;
   /// @dev vault token
   address public token;
+
+  // --- V2 storage (appended to preserve layout) ---
+  /// @dev protocol fee rate charged on broker revenue (interest + penalty), WAD-scaled
+  uint256 public feeRate;
+  /// @dev recipient of the protocol fee
+  address public feeRecipient;
 
   // ------- Modifiers -------
   modifier onlyBroker() {
@@ -87,6 +102,23 @@ contract BrokerInterestRelayer is
     token = _token;
   }
 
+  /**
+   * @dev V2 reinitializer: enable the protocol fee on broker revenue at the default 10% rate.
+   *      Must be called atomically via `upgradeToAndCall` by the DEFAULT_ADMIN_ROLE (timelock),
+   *      so the config is set in the same tx the new implementation is wired in.
+   *      The rate can be changed afterwards via `setFeeRate` (MANAGER).
+   * @param _feeRecipient The recipient of the protocol fee
+   */
+  function initializeV2(address _feeRecipient) external reinitializer(2) onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_feeRecipient != address(0), "relayer/zero-address-provided");
+
+    feeRate = DEFAULT_FEE_RATE;
+    feeRecipient = _feeRecipient;
+
+    emit SetFeeRate(0, DEFAULT_FEE_RATE);
+    emit SetFeeRecipient(address(0), _feeRecipient);
+  }
+
   ///////////////////////////////////////
   /////      External functions     /////
   ///////////////////////////////////////
@@ -99,6 +131,14 @@ contract BrokerInterestRelayer is
   function supplyToVault(uint256 amount) external override nonReentrant onlyBroker {
     // transfer interest from broker
     IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+    // skim the protocol fee on incoming revenue (interest + penalty) before it accrues to the vault.
+    // Fee is floored so rounding dust stays with the vault (suppliers), never the fee recipient.
+    uint256 fee = Math.mulDiv(amount, feeRate, WAD, Math.Rounding.Floor);
+    if (fee > 0 && feeRecipient != address(0)) {
+      IERC20(token).safeTransfer(feeRecipient, fee);
+      emit ProtocolFeeCharged(msg.sender, feeRecipient, fee);
+    }
 
     // get minLoan
     uint256 minLoan = MOOLAH.minLoan(MOOLAH.idToMarketParams(IBrokerBase(msg.sender).MARKET_ID()));
@@ -159,6 +199,28 @@ contract BrokerInterestRelayer is
     require(brokers.contains(broker), "broker/same-value-provided");
     brokers.remove(broker);
     emit RemovedBroker(broker);
+  }
+
+  /**
+   * @dev Set the protocol fee rate charged on broker revenue (interest + penalty)
+   * @param _feeRate The new fee rate, WAD-scaled (1e18 == 100%)
+   */
+  function setFeeRate(uint256 _feeRate) external override onlyRole(MANAGER) {
+    require(_feeRate <= MAX_FEE, "relayer/max-fee-exceeded");
+    require(_feeRate != feeRate, "broker/same-value-provided");
+    emit SetFeeRate(feeRate, _feeRate);
+    feeRate = _feeRate;
+  }
+
+  /**
+   * @dev Set the recipient of the protocol fee
+   * @param _feeRecipient The new fee recipient
+   */
+  function setFeeRecipient(address _feeRecipient) external override onlyRole(MANAGER) {
+    require(_feeRecipient != address(0), "relayer/zero-address-provided");
+    require(_feeRecipient != feeRecipient, "broker/same-value-provided");
+    emit SetFeeRecipient(feeRecipient, _feeRecipient);
+    feeRecipient = _feeRecipient;
   }
 
   /// @dev only callable by the DEFAULT_ADMIN_ROLE (must be a TimeLock contract)

--- a/src/broker/interfaces/IBrokerInterestRelayer.sol
+++ b/src/broker/interfaces/IBrokerInterestRelayer.sol
@@ -10,9 +10,25 @@ interface IBrokerInterestRelayer {
    */
   function supplyToVault(uint256 amount) external;
 
+  /**
+   * @dev Set the protocol fee rate charged on broker revenue (interest + penalty).
+   * @param _feeRate The new fee rate, WAD-scaled (1e18 == 100%)
+   */
+  function setFeeRate(uint256 _feeRate) external;
+
+  /**
+   * @dev Set the recipient of the protocol fee.
+   * @param _feeRecipient The new fee recipient
+   */
+  function setFeeRecipient(address _feeRecipient) external;
+
   /// @dev ------- Events
   event AddedBroker(address indexed broker);
   event RemovedBroker(address indexed broker);
   event InterestAccumulated(address indexed broker, uint256 amount);
   event SuppliedToMoolahVault(uint256 amount);
+  /// @dev protocol fee skimmed from a broker's supplied revenue
+  event ProtocolFeeCharged(address indexed broker, address indexed feeRecipient, uint256 fee);
+  event SetFeeRate(uint256 oldFeeRate, uint256 newFeeRate);
+  event SetFeeRecipient(address oldFeeRecipient, address newFeeRecipient);
 }

--- a/test/broker/LendingBroker.t.sol
+++ b/test/broker/LendingBroker.t.sol
@@ -2986,6 +2986,163 @@ contract LendingBrokerTest is Test {
     Position memory posAfter = moolah.position(marketParams.id(), borrower);
     assertLt(posAfter.borrowShares, posBefore.borrowShares, "clean shares should liquidate");
   }
+
+  // ==========================================================================
+  // Relayer protocol fee: 10% cut on broker revenue (interest + penalty)
+  // ==========================================================================
+
+  uint256 constant FEE_WAD = 1e18;
+  address constant FEE_RECIPIENT = address(0xFEE);
+
+  /// @dev enable the protocol fee on the LISUSD relayer via the V2 reinitializer (rate hardcoded to 10%)
+  function _enableRelayerFee(address recipient) internal {
+    vm.prank(ADMIN);
+    relayer.initializeV2(recipient);
+  }
+
+  function test_relayer_initializeV2_setsFeeConfig() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+    assertEq(relayer.feeRate(), relayer.DEFAULT_FEE_RATE(), "feeRate not defaulted to 10%");
+    assertEq(relayer.feeRate(), 0.1e18, "feeRate not 10%");
+    assertEq(relayer.feeRecipient(), FEE_RECIPIENT, "feeRecipient not set");
+  }
+
+  function test_relayer_initializeV2_onlyAdmin() public {
+    vm.prank(MANAGER); // MANAGER lacks DEFAULT_ADMIN_ROLE
+    vm.expectRevert();
+    relayer.initializeV2(FEE_RECIPIENT);
+  }
+
+  function test_relayer_initializeV2_cannotRunTwice() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+    vm.prank(ADMIN);
+    vm.expectRevert(); // reinitializer(2) already consumed
+    relayer.initializeV2(FEE_RECIPIENT);
+  }
+
+  function test_relayer_initializeV2_rejectsZeroRecipient() public {
+    vm.prank(ADMIN);
+    vm.expectRevert(bytes("relayer/zero-address-provided"));
+    relayer.initializeV2(address(0));
+  }
+
+  /// @dev the fee is floored: recipient receives exactly floor(amount * feeRate / WAD),
+  ///      the remainder stays in the relayer/vault flow.
+  function test_relayer_supplyToVault_skimsFee() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+
+    uint256 amount = 1000 ether;
+    uint256 expectedFee = (amount * 0.1e18) / FEE_WAD; // 100 ether
+
+    uint256 before = LISUSD.balanceOf(FEE_RECIPIENT);
+    _triggerInterestFlush(amount);
+    uint256 received = LISUSD.balanceOf(FEE_RECIPIENT) - before;
+
+    assertEq(received, expectedFee, "fee recipient did not receive 10%");
+  }
+
+  /// @dev with no fee configured (default state) the relayer behaves exactly as before.
+  function test_relayer_supplyToVault_noFeeWhenDisabled() public {
+    uint256 before = LISUSD.balanceOf(FEE_RECIPIENT);
+    _triggerInterestFlush(1000 ether);
+    assertEq(LISUSD.balanceOf(FEE_RECIPIENT), before, "no fee should be taken when disabled");
+    assertEq(relayer.feeRate(), 0, "feeRate should default to 0");
+  }
+
+  /// @dev end-to-end: repaying a fixed position early routes 10% of both the accrued
+  ///      interest and the early-repay penalty to the fee recipient.
+  function test_relayer_fixedRepay_feeOnInterestAndPenalty() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+
+    FixedTermAndRate memory term = FixedTermAndRate({ termId: 30, duration: 30 days, apr: 110 * 1e25 });
+    vm.prank(BOT);
+    broker.updateFixedTermAndRate(term, false);
+
+    uint256 fixedAmt = 500 ether;
+    vm.prank(borrower);
+    broker.borrow(fixedAmt, 30);
+
+    skip(10 days); // repay early -> penalty applies
+
+    FixedLoanPosition memory pos = broker.userFixedPositions(borrower)[0];
+    uint256 posId = pos.posId;
+
+    // full close: interest + principal + penalty
+    uint256 repayAmt = broker.getUserTotalDebt(borrower) + 10 ether;
+    (uint256 interestRepaid, uint256 penalty, ) = broker.previewRepayFixedLoanPosition(borrower, repayAmt, posId);
+    assertGt(interestRepaid, 0, "no interest accrued");
+    assertGt(penalty, 0, "no penalty for early repay");
+
+    // interest and penalty are supplied to the relayer in two separate calls,
+    // so the fee is floored on each independently.
+    uint256 expectedFee = (interestRepaid * 0.1e18) / FEE_WAD + (penalty * 0.1e18) / FEE_WAD;
+
+    LISUSD.setBalance(borrower, repayAmt);
+    uint256 feeBefore = LISUSD.balanceOf(FEE_RECIPIENT);
+    vm.startPrank(borrower);
+    IERC20(address(LISUSD)).approve(address(broker), type(uint256).max);
+    broker.repay(repayAmt, posId, borrower);
+    vm.stopPrank();
+
+    assertEq(LISUSD.balanceOf(FEE_RECIPIENT) - feeBefore, expectedFee, "fee on interest+penalty mismatch");
+  }
+
+  /// @dev end-to-end: repaying a dynamic position routes 10% of the accrued interest to the fee recipient.
+  function test_relayer_dynamicRepay_feeOnInterest() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+
+    uint256 amount = 400 ether;
+    vm.prank(borrower);
+    broker.borrow(amount);
+
+    skip(30 days);
+
+    uint256 accruedInterest = broker.getUserTotalDebt(borrower) - amount;
+    assertGt(accruedInterest, 0, "no dynamic interest accrued");
+    uint256 expectedFee = (accruedInterest * 0.1e18) / FEE_WAD;
+
+    LISUSD.setBalance(borrower, accruedInterest); // repay interest only
+    uint256 feeBefore = LISUSD.balanceOf(FEE_RECIPIENT);
+    vm.startPrank(borrower);
+    IERC20(address(LISUSD)).approve(address(broker), type(uint256).max);
+    broker.repay(accruedInterest, borrower);
+    vm.stopPrank();
+
+    assertApproxEqAbs(LISUSD.balanceOf(FEE_RECIPIENT) - feeBefore, expectedFee, 1, "fee on dynamic interest mismatch");
+  }
+
+  function test_relayer_setFeeRate_onlyManager() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+
+    vm.prank(address(0xdead));
+    vm.expectRevert();
+    relayer.setFeeRate(0.2e18);
+
+    vm.prank(MANAGER);
+    relayer.setFeeRate(0.2e18);
+    assertEq(relayer.feeRate(), 0.2e18);
+
+    uint256 tooHigh = relayer.MAX_FEE() + 1;
+    vm.prank(MANAGER);
+    vm.expectRevert(bytes("relayer/max-fee-exceeded"));
+    relayer.setFeeRate(tooHigh);
+  }
+
+  function test_relayer_setFeeRecipient_onlyManager() public {
+    _enableRelayerFee(FEE_RECIPIENT);
+
+    vm.prank(address(0xdead));
+    vm.expectRevert();
+    relayer.setFeeRecipient(address(0xabcd));
+
+    vm.prank(MANAGER);
+    relayer.setFeeRecipient(address(0xabcd));
+    assertEq(relayer.feeRecipient(), address(0xabcd));
+
+    vm.prank(MANAGER);
+    vm.expectRevert(bytes("relayer/zero-address-provided"));
+    relayer.setFeeRecipient(address(0));
+  }
 }
 
 /// @dev Mock swap pair that converts tokenIn -> tokenOut at oracle price.


### PR DESCRIPTION
## Summary

Skims a protocol fee from broker revenue (interest + penalty) inside `BrokerInterestRelayer.supplyToVault`, before it accrues to the vault — mirroring Moolah's market-fee semantics. Since **every** broker revenue path (fixed interest, fixed penalty, dynamic interest, liquidation interest) funnels through the relayer, this single choke point taxes all of it uniformly and exactly once. Principal never flows through the relayer, so it is never taxed.

## Changes

**`BrokerInterestRelayer.sol`**
- Adds `feeRate` (WAD) + `feeRecipient` storage, appended after `token` to preserve the UUPS layout.
- Adds `MAX_FEE = 0.25e18` (mirrors Moolah) and `DEFAULT_FEE_RATE = 0.1e18` (10%).
- `initializeV2(address feeRecipient)`: `reinitializer(2)`, `DEFAULT_ADMIN_ROLE`-gated, hardcodes the 10% rate; must run atomically via `upgradeToAndCall`.
- `setFeeRate` / `setFeeRecipient` (`MANAGER`) for later tuning, both capped/zero-checked.
- Fee is **floored**, so rounding dust stays with the vault (suppliers), never the fee recipient.

**`IBrokerInterestRelayer.sol`**: adds `setFeeRate` / `setFeeRecipient` signatures and `ProtocolFeeCharged` / `SetFeeRate` / `SetFeeRecipient` events.

## Backward compatibility

`feeRate` defaults to `0`, so existing relayer deployments are **unaffected** until `initializeV2` runs. The full broker suite (122 tests) passes unchanged.

## Fee recipient (BSC)

Intended recipient is the Lista **`RevenueDistributor`** `0x34B504A5CF0fF41F8A480580533b6Dda687fa3Da` — the final on-chain sink where Moolah market fees already land as raw tokens (via `LendingFeeRecipient.claimMarketFee`). WBNB / lisUSD / USDT are already on its `tokenWhitelist`. Broker fees are raw ERC20, so they correctly skip the share-based `LendingFeeRecipient` distributor and land directly at the same terminal. Wiring is passed to `initializeV2` at upgrade time (no deploy script in this PR).

> **Note:** the relayer's `feeRecipient` and `LendingFeeRecipient.marketFeeRecipient()` are independent storage — keep them in sync via `setFeeRecipient` if governance ever changes the latter.

## Tests

`test/broker/LendingBroker.t.sol` — init guards (only-admin, no double-run, zero-recipient, default 10%), the fee skim (`supplyToVault`), disabled-fee backward-compat, end-to-end fixed repay (fee on interest **and** penalty), end-to-end dynamic repay (fee on interest), and `setFeeRate`/`setFeeRecipient` permissions.

## Rollout

Upgrade is `upgradeToAndCall(newImpl, initializeV2(feeRecipient))` per relayer proxy, executed by the Timelock (`DEFAULT_ADMIN_ROLE`). Must be applied to **every** relayer proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)