### PR TITLE
feat(provider): assert expectedCenterRate on rebalance

### DIFF
--- a/.github/workflows/upgrade-safety.yaml
+++ b/.github/workflows/upgrade-safety.yaml
@@ -38,11 +38,11 @@ jobs:
       - name: Install upgrade-guard
         run: |
           cargo install --git https://github.com/razww/upgrade-guard \
-            --tag v0.1.1 upgrade-guard --locked
+            --tag v0.1.2 upgrade-guard --locked
 
       # Faster alternative: skip the Rust build, download the prebuilt binary.
       #   - run: |
-      #       gh release download v0.1.1 --repo razww/upgrade-guard \
+      #       gh release download v0.1.2 --repo razww/upgrade-guard \
       #         --pattern 'upgrade-guard-x86_64-linux*' --dir /tmp/ug
       #       ( cd /tmp/ug && sha256sum -c upgrade-guard-x86_64-linux.sha256 )
       #       install -m0755 /tmp/ug/upgrade-guard-x86_64-linux /usr/local/bin/upgrade-guard

--- a/src/provider/interfaces/IV3DexAdapter.sol
+++ b/src/provider/interfaces/IV3DexAdapter.sol
@@ -69,6 +69,9 @@ interface IV3DexAdapter {
   /// @notice Current pool spot price (slot0).
   function spotSqrtPriceX96() external view returns (uint160);
 
+  /// @notice Live LST↔native center rate the next rebalance will use (0 for pure-TWAP pairs).
+  function centerRate() external view returns (uint256);
+
   /// @notice Simulate adding `amount0Desired/amount1Desired` at the current spot price.
   function previewAddLiquidity(
     uint256 amount0Desired,
@@ -147,13 +150,22 @@ interface IV3DexAdapter {
   /// @notice Set the spot-vs-fair deviation gate (onlyRole MANAGER; bps of price, 0 disables).
   function setMaxSpotDeviationBps(uint256 maxSpotDeviationBps) external;
 
-  /// @notice Recenter the position to its range and convert inventory to the optimal ratio.
-  ///         onlyProvider — the provider gates the caller with the BOT role.
+  /// @notice Max |live center rate − BOT-supplied expectedCenterRate| deviation (bps) tolerated on
+  ///         rebalance (0 disables the guard).
+  function maxCenterRateDeviationBps() external view returns (uint256);
+
+  /// @notice Set the center-rate deviation gate (onlyRole MANAGER; bps, 0 disables).
+  function setMaxCenterRateDeviationBps(uint256 maxCenterRateDeviationBps) external;
+
+  /// @notice Recenter the position and convert inventory to the optimal ratio. onlyProvider (the provider
+  ///         gates on BOT). `expectedCenterRate` = the live rate the BOT built against (0 = skip); reverts
+  ///         if it deviates from the on-chain rate by more than `maxCenterRateDeviationBps`.
   function rebalance(
     uint256 minAmount0,
     uint256 minAmount1,
     uint256 minLiquidity,
     uint160 targetSqrtPriceX96,
+    uint256 expectedCenterRate,
     uint256 deadline,
     bytes calldata swapData
   ) external;

--- a/src/provider/v3/SlisBNBV3Provider.sol
+++ b/src/provider/v3/SlisBNBV3Provider.sol
@@ -60,10 +60,11 @@ contract SlisBNBV3Provider is V3Provider {
     uint256 minAmount1,
     uint256 minLiquidity,
     uint160 targetSqrtPriceX96,
+    uint256 expectedCenterRate,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyRole(BOT) nonReentrant {
-    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
+    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, expectedCenterRate, deadline, swapData);
   }
 
   /* ─────────────────── slisBNBx: sync / view ──────────────────────── */

--- a/src/provider/v3/V3DexAdapter.sol
+++ b/src/provider/v3/V3DexAdapter.sol
@@ -118,8 +118,12 @@ abstract contract V3DexAdapter is
   ///      that vector. 0 disables the gate. Default INITIAL_RANGE_BPS (1%).
   uint256 public maxSpotDeviationBps;
 
+  /// @dev Max |live center rate − BOT expectedCenterRate| deviation on rebalance (BPS; 0 = off). Guards
+  ///      the range anchor against a build↔exec rate anomaly the fair-NAV loss caps can't see.
+  uint256 public maxCenterRateDeviationBps;
+
   /// @dev Reserved storage for future base variables (keep subclass storage stable on upgrade).
-  uint256[45] private __gap;
+  uint256[44] private __gap;
 
   /* ───────────────────────────── events ───────────────────────────── */
 
@@ -133,6 +137,7 @@ abstract contract V3DexAdapter is
   event SwapPairWhitelistSet(address indexed swapPair, bool status);
   event MaxSwapLossBpChanged(uint256 maxSwapLossBp);
   event MaxSpotDeviationBpsChanged(uint256 maxSpotDeviationBps);
+  event MaxCenterRateDeviationBpsChanged(uint256 maxCenterRateDeviationBps);
   event CompoundSkippedSpotDeviated(uint160 spotSqrtPriceX96, uint160 fairSqrtPriceX96);
   event CompoundSkippedNoLiquidity(uint256 idleToken0, uint256 idleToken1);
   event IdleCredited(uint256 amount0, uint256 amount1);
@@ -161,6 +166,7 @@ abstract contract V3DexAdapter is
   error InsufficientBalance();
   error InsufficientAmount();
   error SpotDeviationTooHigh();
+  error CenterRateDeviationTooHigh();
   error ZeroAmount();
 
   /* ─────────────────────────── constructor ────────────────────────── */
@@ -383,6 +389,14 @@ abstract contract V3DexAdapter is
     emit MaxSpotDeviationBpsChanged(_maxSpotDeviationBps);
   }
 
+  /// @notice Max relative deviation (BPS) allowed between the live center rate and the BOT-supplied
+  ///         expectedCenterRate on rebalance. 0 disables the guard (default).
+  function setMaxCenterRateDeviationBps(uint256 _maxCenterRateDeviationBps) external onlyRole(MANAGER) {
+    if (_maxCenterRateDeviationBps > BPS) revert InvalidThreshold();
+    maxCenterRateDeviationBps = _maxCenterRateDeviationBps;
+    emit MaxCenterRateDeviationBpsChanged(_maxCenterRateDeviationBps);
+  }
+
   /// @notice Whitelist (or remove) a swap venue the rebalance inventory conversion may call. Backend-built
   ///         calldata can only target whitelisted venues.
   /// @dev Defense-in-depth: a swap venue must never be a token / pool / NPM the adapter holds or trusts,
@@ -410,6 +424,7 @@ abstract contract V3DexAdapter is
     uint256 minAmount1,
     uint256 minLiquidity,
     uint160 targetSqrtPriceX96,
+    uint256 expectedCenterRate,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyProvider nonReentrant {
@@ -420,6 +435,14 @@ abstract contract V3DexAdapter is
     uint256 centerRate = _lstNativeRate();
     bool rateImplied = centerRate != 0;
     if (rateImplied) _requireCenterRateDeviation(centerRate);
+
+    // Assert the live rate still matches the BOT's expectedCenterRate; 0 keeps prior behavior.
+    if (rateImplied && expectedCenterRate != 0 && maxCenterRateDeviationBps != 0) {
+      uint256 delta = centerRate > expectedCenterRate
+        ? centerRate - expectedCenterRate
+        : expectedCenterRate - centerRate;
+      if ((delta * BPS) / expectedCenterRate > maxCenterRateDeviationBps) revert CenterRateDeviationTooHigh();
+    }
 
     (int24 newTickLower, int24 newTickUpper) = _initialTickRange(centerRate);
     int24 oldTickLower = tickLower;
@@ -637,6 +660,11 @@ abstract contract V3DexAdapter is
   function spotSqrtPriceX96() public view returns (uint160 sqrtPriceX96) {
     // Decode only sqrtPriceX96/tick (width-agnostic to feeProtocol uint8/uint32; see IV3PoolMinimal).
     (sqrtPriceX96, ) = IV3PoolMinimal(POOL).slot0();
+  }
+
+  /// @inheritdoc IV3DexAdapter
+  function centerRate() external view returns (uint256) {
+    return _lstNativeRate();
   }
 
   /// @dev True when the pool spot price is within `maxSpotDeviationBps` (bps of price) of the fair price.

--- a/src/provider/v3/V3Provider.sol
+++ b/src/provider/v3/V3Provider.sol
@@ -705,13 +705,22 @@ abstract contract V3Provider is
     uint256 minAmount1,
     uint256 minLiquidity,
     uint160 targetSqrtPriceX96,
+    uint256 expectedCenterRate,
     uint256 deadline,
     bytes calldata swapData
   ) internal {
     uint256 navBefore = _positionValueUsd();
     if (totalSupply() != 0 && navBefore == 0) revert OracleZero();
 
-    IV3DexAdapter(ADAPTER).rebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
+    IV3DexAdapter(ADAPTER).rebalance(
+      minAmount0,
+      minAmount1,
+      minLiquidity,
+      targetSqrtPriceX96,
+      expectedCenterRate,
+      deadline,
+      swapData
+    );
 
     uint256 navAfter = _positionValueUsd();
 

--- a/src/provider/v3/WbETHV3Provider.sol
+++ b/src/provider/v3/WbETHV3Provider.sol
@@ -36,9 +36,10 @@ contract WbETHV3Provider is V3Provider {
     uint256 minAmount1,
     uint256 minLiquidity,
     uint160 targetSqrtPriceX96,
+    uint256 expectedCenterRate,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyRole(BOT) nonReentrant {
-    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
+    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, expectedCenterRate, deadline, swapData);
   }
 }

--- a/src/provider/v3/WstETHV3Provider.sol
+++ b/src/provider/v3/WstETHV3Provider.sol
@@ -35,9 +35,10 @@ contract WstETHV3Provider is V3Provider {
     uint256 minAmount1,
     uint256 minLiquidity,
     uint160 targetSqrtPriceX96,
+    uint256 expectedCenterRate,
     uint256 deadline,
     bytes calldata swapData
   ) external onlyRole(BOT) nonReentrant {
-    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, deadline, swapData);
+    _guardedRebalance(minAmount0, minAmount1, minLiquidity, targetSqrtPriceX96, expectedCenterRate, deadline, swapData);
   }
 }

--- a/test/provider/SlisBNBV3Provider.t.sol
+++ b/test/provider/SlisBNBV3Provider.t.sol
@@ -624,7 +624,7 @@ contract SlisBNBV3ProviderTest is Test {
     // manager cannot rebalance — revert fires on role check before amounts matter.
     vm.prank(manager);
     vm.expectRevert();
-    provider.rebalance(1, 1, 1, 0, block.timestamp, "");
+    provider.rebalance(1, 1, 1, 0, 0, block.timestamp, "");
 
     // Disable the rate-drift guard — a pool swap does NOT move the StakeManager rate, so the
     // default 1% center-rate threshold would block this rebalance with RateDeviationBelowThreshold.
@@ -637,7 +637,7 @@ contract SlisBNBV3ProviderTest is Test {
     uint256 min1 = (total1 * 999) / 1000;
     uint256 oldTokenId = adapter.tokenId();
     vm.prank(bot);
-    provider.rebalance(min0, min1, 0, 0, block.timestamp, "");
+    provider.rebalance(min0, min1, 0, 0, 0, block.timestamp, "");
 
     assertGt(adapter.tokenId(), oldTokenId, "position NFT should be re-minted");
     assertLt(adapter.tickLower(), adapter.tickUpper());
@@ -656,7 +656,7 @@ contract SlisBNBV3ProviderTest is Test {
     uint256 min0 = (total0 * 999) / 1000;
     uint256 min1 = (total1 * 999) / 1000;
     vm.prank(bot);
-    provider.rebalance(min0, min1, 0, 0, block.timestamp, "");
+    provider.rebalance(min0, min1, 0, 0, 0, block.timestamp, "");
 
     // Share count is unchanged after rebalance.
     assertEq(_collateral(user), shares, "shares should be unchanged after rebalance");
@@ -1286,7 +1286,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // Rebalance uses an internally derived range; caller only supplies execution guards.
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
 
@@ -1322,7 +1322,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(address(mockSwap), true, amountIn, (fairOut * 99) / 100, false, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after swap");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "fair swap ~value-neutral");
@@ -1340,7 +1340,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.NotWhitelistedPair.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice Defense-in-depth: a swap venue may never be the position's own tokens / pool / NPM.
@@ -1381,7 +1381,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(STAKE_MANAGER, true, amountIn, (fairOut * 99) / 100, false, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after instantWithdraw conversion");
     assertApproxEqRel(
@@ -1411,7 +1411,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(SwapInventoryLib.InsufficientOutput.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice The other swap direction (sellToken0 = false): sell WBNB → slisBNB, value-neutral.
@@ -1430,7 +1430,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(address(mockSwap), false, amountIn, (fairOut * 99) / 100, false, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "WBNB->slisBNB swap ~value-neutral");
   }
 
@@ -1457,7 +1457,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = abi.encode(STAKE_MANAGER, false, amountIn, (fairOut * 99) / 100, true, inner); // nativeIn=true
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after deposit conversion");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "deposit conversion ~value-neutral");
@@ -1484,7 +1484,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(SwapInventoryLib.InsufficientOutput.selector); // slisBNB received = 0 < amountOutMin
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /* ─────────── rebalance after price leaves range (fully WBNB) ──────── */
@@ -1529,7 +1529,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // Rebalance uses an internally derived range; caller only supplies execution guards.
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
 
@@ -1561,7 +1561,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // minAmount0 = principal0 (exact), minAmount1 = 0 (position has no WBNB).
     vm.prank(bot);
-    provider.rebalance(principal0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(principal0, 0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -1579,7 +1579,7 @@ contract SlisBNBV3ProviderTest is Test {
     // minAmount0 one unit above actual → should revert with NPM slippage check.
     vm.prank(bot);
     vm.expectRevert();
-    provider.rebalance(total0 + 1, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(total0 + 1, 0, 0, 0, 0, block.timestamp, "");
   }
 
   /// @dev When price is above range the position is 100% WBNB (token1).
@@ -1599,7 +1599,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     // minAmount0 = 0 (no slisBNB), minAmount1 = principal1 (exact).
     vm.prank(bot);
-    provider.rebalance(0, principal1, 0, 0, block.timestamp, "");
+    provider.rebalance(0, principal1, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -1617,7 +1617,7 @@ contract SlisBNBV3ProviderTest is Test {
     // minAmount1 one unit above actual → should revert with NPM slippage check.
     vm.prank(bot);
     vm.expectRevert();
-    provider.rebalance(0, total1 + 1, 0, 0, block.timestamp, "");
+    provider.rebalance(0, total1 + 1, 0, 0, 0, block.timestamp, "");
   }
 
   function test_withdraw_minAmount_tooHigh_reverts() public {
@@ -2198,7 +2198,7 @@ contract SlisBNBV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -2213,7 +2213,7 @@ contract SlisBNBV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
 
     assertLt(adapter.tickLower(), adapter.tickUpper(), "tick range remains valid");
   }
@@ -2258,7 +2258,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SwapLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   function test_lossGuard_perSwapCap_passesWithinCap() public {
@@ -2272,7 +2272,7 @@ contract SlisBNBV3ProviderTest is Test {
     bytes memory data = _sellToken0Data(amountIn, (fairOut * 97) / 100, 0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted (3% swap loss within 5% per-swap cap)");
   }
 
@@ -2296,7 +2296,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.RebalanceLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   // ── per-UTC-day cumulative loss cap ──
@@ -2319,7 +2319,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.DailyLossExceeded.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   function test_lossGuard_dailyCap_dailyAccumulatorResetsNextDay() public {
@@ -2337,7 +2337,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     bytes memory data1 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data1);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data1);
     uint256 accumDay1 = provider.dailyLossAccum();
     uint256 day1 = provider.dailyLossDay();
     assertGt(accumDay1, 0, "loss accrued on day 1");
@@ -2346,7 +2346,7 @@ contract SlisBNBV3ProviderTest is Test {
     vm.warp(block.timestamp + 1 days);
     bytes memory data2 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data2);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data2);
 
     assertGt(provider.dailyLossDay(), day1, "UTC day advanced");
     assertLt(provider.dailyLossAccum(), (accumDay1 * 3) / 2, "accumulator reset for the new day (not doubled)");
@@ -2403,7 +2403,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     bytes memory d1 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, d1);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, d1);
     uint256 loss1 = provider.dailyLossAccum();
     assertGt(loss1, 0, "rebalance 1 accrued loss");
 
@@ -2413,14 +2413,14 @@ contract SlisBNBV3ProviderTest is Test {
 
     bytes memory d2 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, d2);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, d2);
     // Proves cumulative `+=` (a `= loss` overwrite would leave accum ≈ loss1, failing this).
     assertGt(provider.dailyLossAccum(), (loss1 * 3) / 2, "same-day loss accumulates across rebalances");
 
     bytes memory d3 = _sellToken0Data(amountIn, (fairOut * 90) / 100, 0);
     vm.prank(bot);
     vm.expectRevert(V3Provider.DailyLossExceeded.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, d3);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, d3);
   }
 
   /// @notice Fail-closed: if the feed returns 0 for a non-empty vault, rebalance must revert (not run
@@ -2432,7 +2432,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.OracleZero.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
   }
 
   /// @notice The per-swap cap also covers the sell-token1 direction (WBNB→slisBNB), exercising `_fairAmount0ForAmount1`.
@@ -2449,7 +2449,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SwapLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /* ───────────── Spot-vs-fair gate when adding liquidity at pool spot ───────────── */
@@ -2706,7 +2706,7 @@ contract SlisBNBV3ProviderTest is Test {
     uint160 badTarget = uint160(uint256(adapter.spotSqrtPriceX96()) * 2); // ~4x price, well beyond ±1%
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
-    provider.rebalance(0, 0, 0, badTarget, block.timestamp, "");
+    provider.rebalance(0, 0, 0, badTarget, 0, block.timestamp, "");
   }
 
   function test_rebalance_passesWhenPoolPriceMatchesTarget() public {
@@ -2717,7 +2717,7 @@ contract SlisBNBV3ProviderTest is Test {
     // Target == the actual pool price ⇒ within the band ⇒ the deviation check passes.
     uint160 target = adapter.spotSqrtPriceX96();
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, target, block.timestamp, "");
+    provider.rebalance(0, 0, 0, target, 0, block.timestamp, "");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "recentered with a matching target");
   }
 
@@ -2731,11 +2731,11 @@ contract SlisBNBV3ProviderTest is Test {
     uint160 bad = uint160(uint256(adapter.spotSqrtPriceX96()) * 2);
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
-    provider.rebalance(0, 0, 0, bad, block.timestamp, "");
+    provider.rebalance(0, 0, 0, bad, 0, block.timestamp, "");
 
     // Same state, target 0 → no price check → succeeds.
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "recentered with target 0");
   }
 
@@ -2749,7 +2749,7 @@ contract SlisBNBV3ProviderTest is Test {
 
     uint160 bad = uint160(uint256(adapter.spotSqrtPriceX96()) * 2);
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, bad, block.timestamp, ""); // gate off → no revert
+    provider.rebalance(0, 0, 0, bad, 0, block.timestamp, ""); // gate off → no revert
     assertLt(adapter.tickLower(), adapter.tickUpper(), "gate disabled: bad target ignored");
   }
 
@@ -2762,7 +2762,7 @@ contract SlisBNBV3ProviderTest is Test {
     uint160 bad = uint160(uint256(adapter.spotSqrtPriceX96()) / 2); // target ~1/4 price of actual → outside band
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
-    provider.rebalance(0, 0, 0, bad, block.timestamp, "");
+    provider.rebalance(0, 0, 0, bad, 0, block.timestamp, "");
   }
 
   /// @dev A target just inside the ±band passes; the same call just outside it reverts.
@@ -2779,10 +2779,10 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
-    provider.rebalance(0, 0, 0, outside, block.timestamp, "");
+    provider.rebalance(0, 0, 0, outside, 0, block.timestamp, "");
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, inside, block.timestamp, "");
+    provider.rebalance(0, 0, 0, inside, 0, block.timestamp, "");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "inside-band target passes");
   }
 
@@ -2798,7 +2798,76 @@ contract SlisBNBV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.SpotDeviationTooHigh.selector);
-    provider.rebalance(0, 0, 0, fairTarget, block.timestamp, "");
+    provider.rebalance(0, 0, 0, fairTarget, 0, block.timestamp, "");
+  }
+
+  /* ─────────── rebalance: expectedCenterRate assertion ─────────── */
+
+  /// @dev Doc-faithful rebalance args (integration guide §4.1) — what the BOT backend actually passes:
+  ///      principal floors from amountsForLiquidity at spot, a live target price, a minLiquidity floor.
+  ///      Empty swapData = recenter-only (no inventory conversion).
+  function _rebalanceArgs() internal view returns (uint256 min0, uint256 min1, uint256 minLiquidity, uint160 target) {
+    target = adapter.spotSqrtPriceX96();
+    uint128 liq = adapter.totalLiquidity();
+    (uint256 p0, uint256 p1) = adapter.amountsForLiquidity(liq, target);
+    min0 = (p0 * 99) / 100;
+    min1 = (p1 * 99) / 100;
+    minLiquidity = (uint256(liq) * 90) / 100;
+  }
+
+  /// @dev With otherwise-valid slippage/target params, a stale expectedCenterRate still reverts — the
+  ///      guard fires before any burn/mint, so a fully-formed rebalance request is blocked.
+  function test_rebalance_revertsOnCenterRateMismatch() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.startPrank(manager);
+    adapter.setCenterRateThresholdBps(0);
+    adapter.setMaxCenterRateDeviationBps(100); // 1% band
+    vm.stopPrank();
+
+    (uint256 min0, uint256 min1, uint256 minLiq, uint160 target) = _rebalanceArgs();
+    uint256 rate = adapter.centerRate();
+    assertGt(rate, 0, "rate known");
+
+    vm.prank(bot); // 2% off → outside band
+    vm.expectRevert(V3DexAdapter.CenterRateDeviationTooHigh.selector);
+    provider.rebalance(min0, min1, minLiq, target, (rate * 102) / 100, block.timestamp, "");
+  }
+
+  /// @dev expectedCenterRate == centerRate() clears the guard; the full recenter (honoring the floors +
+  ///      target) completes, re-mints, and is value-neutral.
+  function test_rebalance_passesWithinCenterRateBand() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.startPrank(manager);
+    adapter.setCenterRateThresholdBps(0);
+    adapter.setMaxCenterRateDeviationBps(100);
+    vm.stopPrank();
+
+    (uint256 min0, uint256 min1, uint256 minLiq, uint160 target) = _rebalanceArgs();
+    uint256 rate = adapter.centerRate();
+    uint256 oldTokenId = adapter.tokenId();
+    uint256 peekBefore = providerOracle.peek(address(provider));
+
+    vm.prank(bot);
+    provider.rebalance(min0, min1, minLiq, target, rate, block.timestamp, "");
+
+    assertGt(adapter.tokenId(), oldTokenId, "recenter re-minted within band");
+    assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "recenter ~value-neutral");
+  }
+
+  /// @dev Default band 0 = guard off: a wrong expectedCenterRate is ignored while the real slippage /
+  ///      target guards still apply and the recenter runs (pre-upgrade behavior).
+  function test_rebalance_centerRateGuardOffByDefault() public {
+    _deposit(user, 10 ether, 10 ether);
+    vm.prank(manager);
+    adapter.setCenterRateThresholdBps(0);
+    assertEq(adapter.maxCenterRateDeviationBps(), 0, "off by default");
+
+    (uint256 min0, uint256 min1, uint256 minLiq, uint160 target) = _rebalanceArgs();
+    uint256 oldTokenId = adapter.tokenId();
+
+    vm.prank(bot); // wrong rate ignored
+    provider.rebalance(min0, min1, minLiq, target, type(uint256).max, block.timestamp, "");
+    assertGt(adapter.tokenId(), oldTokenId, "recenter ran, guard off");
   }
 
   /// @dev setHaircutBps is a no-op when the value is unchanged (no redundant write / misleading event).

--- a/test/provider/SlisBNBV3ProviderRate.t.sol
+++ b/test/provider/SlisBNBV3ProviderRate.t.sol
@@ -328,7 +328,7 @@ contract SlisBNBV3ProviderRateTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
 
     // A no-op recenter — recomputed range equals the live one and the caller supplied no swap, target,
     // or min floors — short-circuits to an in-place compound instead of burning and re-minting the
@@ -348,7 +348,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     uint256 oldTokenId = adapter.tokenId();
     vm.prank(bot);
-    provider.rebalance(0, 0, 1, 0, block.timestamp, ""); // minLiquidity = 1 ⇒ not a no-op
+    provider.rebalance(0, 0, 1, 0, 0, block.timestamp, ""); // minLiquidity = 1 ⇒ not a no-op
 
     assertGt(adapter.tokenId(), oldTokenId, "guarded recenter re-mints");
     assertLt(adapter.tickLower(), adapter.tickUpper(), "range valid");
@@ -359,7 +359,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.RateDeviationBelowThreshold.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
   }
 
   function test_rebalance_revertsAfterDeadline() public {
@@ -367,7 +367,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.DeadlineExpired.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp - 1, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp - 1, "");
   }
 
   function test_rebalance_revertsWhenMinLiquidityTooHigh() public {
@@ -378,7 +378,7 @@ contract SlisBNBV3ProviderRateTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.InsufficientLiquidityMinted.selector);
-    provider.rebalance(0, 0, type(uint256).max, 0, block.timestamp, "");
+    provider.rebalance(0, 0, type(uint256).max, 0, 0, block.timestamp, "");
   }
 
   function _tick() internal view returns (int24 tick) {

--- a/test/provider/WstETHV3Provider.t.sol
+++ b/test/provider/WstETHV3Provider.t.sol
@@ -373,7 +373,7 @@ contract WstETHV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
 
     // No-op recenter (unchanged range, no swap / target / floors) short-circuits to an in-place compound
     // rather than burning and re-minting the identical position: same tokenId, value preserved.
@@ -403,7 +403,7 @@ contract WstETHV3ProviderTest is Test {
     bytes memory data = _swapData(address(mockSwap), true, amountIn, (fairOut * 99) / 100, inner);
 
     vm.prank(bot);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
 
     assertGt(adapter.tokenId(), oldTokenId, "position re-minted after swap");
     assertApproxEqRel(providerOracle.peek(address(provider)), peekBefore, 2e16, "fair swap ~value-neutral");
@@ -435,7 +435,7 @@ contract WstETHV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3Provider.RebalanceLossTooHigh.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice Linchpin: the backend-supplied `amountOutMin` is enforced on the measured output. A venue
@@ -457,7 +457,7 @@ contract WstETHV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(SwapInventoryLib.InsufficientOutput.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /// @notice The adapter only allows whitelisted swap venues; a non-whitelisted target reverts before
@@ -474,7 +474,7 @@ contract WstETHV3ProviderTest is Test {
 
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.NotWhitelistedPair.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp, data);
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, data);
   }
 
   /* ─────────────────────── access control / config ─────────────────────── */
@@ -482,7 +482,7 @@ contract WstETHV3ProviderTest is Test {
   function test_rebalance_onlyBot() public {
     _deposit(10 ether, 10 ether);
     vm.expectRevert();
-    provider.rebalance(0, 0, 0, 0, block.timestamp, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp, "");
   }
 
   function test_rebalance_revertsAfterDeadline() public {
@@ -491,7 +491,7 @@ contract WstETHV3ProviderTest is Test {
     adapter.setCenterRateThresholdBps(0);
     vm.prank(bot);
     vm.expectRevert(V3DexAdapter.DeadlineExpired.selector);
-    provider.rebalance(0, 0, 0, 0, block.timestamp - 1, "");
+    provider.rebalance(0, 0, 0, 0, 0, block.timestamp - 1, "");
   }
 
   function test_setSwapPairWhitelist_onlyManager() public {


### PR DESCRIPTION
## 📄 Description

Adds a BOT-asserted center-rate guard to `rebalance`. The BOT reads the live LST↔native rate via the new
`adapter.centerRate()` view and passes it back as `expectedCenterRate`; if the on-chain rate deviates from
it by more than `maxCenterRateDeviationBps`, the call reverts (`CenterRateDeviationTooHigh`).

## 🧠 Rationale

The range center comes from the on-chain LST↔native rate, but the fair-NAV loss caps measure the rebalance
before/after in that **same rate frame** — so a rate anomaly between the BOT's build and on-chain execution
is invisible to them, and the position could be recentered (and inventory converted) around a bad anchor.
This guard bounds the anchor independently, symmetric with the existing `targetSqrtPriceX96` spot-deviation
gate. Both sides opt in (`expectedCenterRate != 0` per-call, `maxCenterRateDeviationBps != 0` globally); `0`
preserves prior behavior, so it's backward-compatible and storage is append-only (upgrade-safe).

## 🧪 Example / Testing

Doc-faithful counter-tests in `SlisBNBV3Provider.t.sol` (real slippage/target floors, not zeros):
- `test_rebalance_revertsOnCenterRateMismatch` — otherwise-valid params + a 2%-off `expectedCenterRate` still reverts (guard fires before any burn/mint).
- `test_rebalance_passesWithinCenterRateBand` — `expectedCenterRate == centerRate()` clears the guard; the full recenter completes and stays value-neutral.
- `test_rebalance_centerRateGuardOffByDefault` — default band `0` ignores a wrong rate while the real slippage/target guards still apply.

Full provider suite green (`forge test --match-path "test/provider/*"` → 376 passed; needs `BSC_RPC`/`ETH_RPC`).

## 🧬 Changes Summary

* `rebalance` gains an `expectedCenterRate` param (adapter, `IV3DexAdapter`, `V3Provider._guardedRebalance`, and the slisBNB/wstETH/wbETH wrappers); the assertion fires before any mint.
* New `maxCenterRateDeviationBps` storage (append-only) + MANAGER setter + event; new `CenterRateDeviationTooHigh` error.
* New `centerRate()` view (adapter + interface) so the BOT can read the live rate to pass back.
* All existing rebalance call sites pass `0` (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
