### PR TITLE
feat(utils): MoolahVaultAccount — principal-baselined account for the protocol lisUSD vault position

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -46,7 +46,7 @@ jobs:
             forge-build-
 
       - name: Run unit tests
-        run: forge test -vvv --no-match-contract "ETHProviderTest|BNBProviderTest|SmartProviderTest|SlisBNBxMinterTest|AlpahIrmMainnetTest|OracleAdaptorTest|PTLinearDiscount|MoolahVaultFactoryTest|EthPhase2ForkTest"
+        run: forge test -vvv --no-match-contract "ETHProviderTest|BNBProviderTest|SmartProviderTest|SlisBNBxMinterTest|AlpahIrmMainnetTest|OracleAdaptorTest|PTLinearDiscount|MoolahVaultFactoryTest|EthPhase2ForkTest|MoolahVaultAccountForkTest"
         env:
           ETH_RPC: ${{ secrets.ETH_RPC }}
           BSC_RPC: ${{ secrets.BSC_RPC }}
@@ -86,7 +86,7 @@ jobs:
             forge-rpc-
 
       - name: Run fork tests
-        run: forge test -vvv --match-contract "ETHProviderTest|BNBProviderTest|SmartProviderTest|SlisBNBxMinterTest|AlpahIrmMainnetTest|OracleAdaptorTest|PTLinearDiscount|MoolahVaultFactoryTest|EthPhase2ForkTest"
+        run: forge test -vvv --match-contract "ETHProviderTest|BNBProviderTest|SmartProviderTest|SlisBNBxMinterTest|AlpahIrmMainnetTest|OracleAdaptorTest|PTLinearDiscount|MoolahVaultFactoryTest|EthPhase2ForkTest|MoolahVaultAccountForkTest"
         env:
           ETH_RPC: ${{ secrets.ETH_RPC }}
           BSC_RPC: ${{ secrets.BSC_RPC }}

--- a/script/utils/deploy_moolahVaultAccount.s.sol
+++ b/script/utils/deploy_moolahVaultAccount.s.sol
@@ -68,6 +68,9 @@ contract DeployMoolahVaultAccount is DeployBase {
     require(account.getRoleMemberCount(account.PAUSER()) == 1, "pauser count");
     require(!account.hasRole(account.DEFAULT_ADMIN_ROLE(), deployer), "deployer is admin");
     require(!account.hasRole(account.MANAGER(), deployer), "deployer is manager");
+    // MANAGER administers BOT and PAUSER so a leaked key can be rotated without a 24h proposal
+    require(account.getRoleAdmin(account.BOT()) == account.MANAGER(), "bot role admin");
+    require(account.getRoleAdmin(account.PAUSER()) == account.MANAGER(), "pauser role admin");
     require(address(account.vault()) == vault, "vault");
     require(account.principalOwner() == principalOwner, "principalOwner");
     require(account.principal() == principal, "principal");

--- a/script/utils/deploy_moolahVaultAccount.s.sol
+++ b/script/utils/deploy_moolahVaultAccount.s.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { MoolahVaultAccount } from "../../src/utils/MoolahVaultAccount.sol";
+
+contract DeployMoolahVaultAccount is DeployBase {
+  address admin = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253; // protocol TimeLock
+  address manager = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // B0c6
+  address bot = 0x91fC4BA20685339781888eCA3E9E1c12d40F0e13;
+  address pauser = 0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8;
+
+  address vault = 0xE03D86e5Baa3509AC4A059A41737bAa8169B6529; // lisUSD MoolahVault
+  address principalOwner = 0x8d388136d578dCD791D081c6042284CED6d9B0c6; // B0c6
+  uint256 principal = 28_300_000 ether;
+
+  address lsrPool = 0x37DB1AE9B24055D1F9fE973Aea40B7EB2995D0Bf; // LisUSDPoolSet
+  address usdtBuyback = 0x3b99A4177E3f430590A8473f353dD87a5a2e1BfC;
+
+  address[] yieldRecipients;
+
+  // ERC-1967 implementation slot: bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
+  bytes32 constant IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    address deployer = vm.addr(deployerPrivateKey);
+    console.log("Deployer: ", deployer);
+
+    yieldRecipients.push(lsrPool);
+    yieldRecipients.push(usdtBuyback);
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    // Deploy MoolahVaultAccount implementation
+    MoolahVaultAccount impl = new MoolahVaultAccount();
+    console.log("MoolahVaultAccount implementation: ", address(impl));
+
+    // Deploy MoolahVaultAccount proxy, initialized straight to the final role holders. The initialize
+    // calldata rides in the proxy constructor, so no block exists in which this proxy is deployed but
+    // uninitialized. abi.encodeCall (not encodeWithSelector) type-checks the arguments at compile time.
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeCall(
+        MoolahVaultAccount.initialize,
+        (admin, manager, bot, pauser, vault, principalOwner, principal, yieldRecipients)
+      )
+    );
+    console.log("MoolahVaultAccount proxy: ", address(proxy));
+
+    vm.stopBroadcast();
+
+    // Self-check outside the broadcast: view calls, no transactions, no gas. A wrong value in the table
+    // above stops the run here instead of shipping.
+    MoolahVaultAccount account = MoolahVaultAccount(address(proxy));
+    require(address(uint160(uint256(vm.load(address(proxy), IMPL_SLOT)))) == address(impl), "impl slot");
+    require(account.hasRole(account.DEFAULT_ADMIN_ROLE(), admin), "admin");
+    require(account.hasRole(account.MANAGER(), manager), "manager");
+    require(account.hasRole(account.BOT(), bot), "bot");
+    require(account.hasRole(account.PAUSER(), pauser), "pauser");
+    require(account.getRoleMemberCount(account.DEFAULT_ADMIN_ROLE()) == 1, "admin count");
+    require(account.getRoleMemberCount(account.MANAGER()) == 1, "manager count");
+    require(account.getRoleMemberCount(account.BOT()) == 1, "bot count");
+    require(account.getRoleMemberCount(account.PAUSER()) == 1, "pauser count");
+    require(!account.hasRole(account.DEFAULT_ADMIN_ROLE(), deployer), "deployer is admin");
+    require(!account.hasRole(account.MANAGER(), deployer), "deployer is manager");
+    require(address(account.vault()) == vault, "vault");
+    require(account.principalOwner() == principalOwner, "principalOwner");
+    require(account.principal() == principal, "principal");
+    require(account.getYieldRecipients().length == 2, "recipients");
+  }
+}

--- a/script/utils/deploy_moolahVaultAccount_impl.s.sol
+++ b/script/utils/deploy_moolahVaultAccount_impl.s.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 import "forge-std/Script.sol";
 import { DeployBase } from "../DeployBase.sol";
 
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
 import { MoolahVaultAccount } from "../../src/utils/MoolahVaultAccount.sol";
 
 /// @dev deploys a new implementation only. The TimeLock then calls
@@ -25,12 +27,18 @@ contract DeployMoolahVaultAccountImpl is DeployBase {
     address deployer = vm.addr(deployerPrivateKey);
     address[] memory recipients = new address[](1);
     recipients[0] = deployer;
-    (bool initializable, ) = address(impl).call(
+    (bool initializable, bytes memory ret) = address(impl).call(
       abi.encodeCall(
         MoolahVaultAccount.initialize,
         (deployer, deployer, deployer, deployer, deployer, deployer, 1, recipients)
       )
     );
     require(!initializable, "implementation must not be initializable");
+    // It has to fail for the RIGHT reason. `_vault` is `deployer`, an EOA, so an implementation with
+    // no _disableInitializers() would still revert here — at IMoolahVault(_vault).asset() — and the
+    // check above would pass on a broken implementation. Only InvalidInitialization proves the
+    // initializer was burned before any argument was touched.
+    require(ret.length >= 4, "implementation reverted without a reason");
+    require(bytes4(ret) == Initializable.InvalidInitialization.selector, "initializer was not burned");
   }
 }

--- a/script/utils/deploy_moolahVaultAccount_impl.s.sol
+++ b/script/utils/deploy_moolahVaultAccount_impl.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import "forge-std/Script.sol";
+import { DeployBase } from "../DeployBase.sol";
+
+import { MoolahVaultAccount } from "../../src/utils/MoolahVaultAccount.sol";
+
+/// @dev deploys a new implementation only. The TimeLock then calls
+///      proxy.upgradeToAndCall(newImpl, "") — this script must never touch the proxy.
+contract DeployMoolahVaultAccountImpl is DeployBase {
+  function run() public {
+    uint256 deployerPrivateKey = _deployerKey();
+    console.log("Deployer: ", vm.addr(deployerPrivateKey));
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    MoolahVaultAccount impl = new MoolahVaultAccount();
+    console.log("MoolahVaultAccount implementation: ", address(impl));
+
+    vm.stopBroadcast();
+
+    // The constructor must have burned the initializer. Outside the broadcast this is a local call, not
+    // a transaction: an implementation that can still be initialized never ships.
+    address deployer = vm.addr(deployerPrivateKey);
+    address[] memory recipients = new address[](1);
+    recipients[0] = deployer;
+    (bool initializable, ) = address(impl).call(
+      abi.encodeCall(
+        MoolahVaultAccount.initialize,
+        (deployer, deployer, deployer, deployer, deployer, deployer, 1, recipients)
+      )
+    );
+    require(!initializable, "implementation must not be initializable");
+  }
+}

--- a/src/utils/MoolahVaultAccount.sol
+++ b/src/utils/MoolahVaultAccount.sol
@@ -30,8 +30,9 @@ import { IMoolahVault } from "moolah-vault/interfaces/IMoolahVault.sol";
 ///         can already pull the entire principal back to itself through `withdrawPrincipal`. What no
 ///         MANAGER call can do is choose a destination — principal and the emergency exit pay
 ///         `principalOwner`, yield pays whitelisted recipients, and `setPrincipalOwner` is
-///         DEFAULT_ADMIN_ROLE-only. BOT's admin is MANAGER rather than DEFAULT_ADMIN_ROLE because
-///         rotating a leaked bot key must not wait on a 24h TimeLock proposal.
+///         DEFAULT_ADMIN_ROLE-only. BOT's and PAUSER's admin is MANAGER rather than
+///         DEFAULT_ADMIN_ROLE because rotating a leaked bot key — or revoking a pauser key that is
+///         holding the contract down — must not wait on a 24h TimeLock proposal.
 ///      4. `principal` is raised by MANAGER (`depositPrincipal`, `increasePrincipal`) and lowered
 ///         only against funds actually leaving (`withdrawPrincipal`, `emergencyWithdraw`), with one
 ///         exception: `emergencyWithdraw` resets it to 0, because it always empties the position and
@@ -119,7 +120,7 @@ contract MoolahVaultAccount is
   /// @dev initialize contract. Roles are granted to their FINAL holders; the deployer takes none.
   /// @dev permissionless by design — note 1 in the contract header.
   /// @param admin DEFAULT_ADMIN_ROLE — upgrades, setPrincipalOwner, role administration
-  /// @param manager MANAGER — principal movement, recipient whitelist, unpause
+  /// @param manager MANAGER — principal movement, recipient whitelist, unpause, BOT/PAUSER admin
   /// @param bot BOT — claimYield
   /// @param pauser PAUSER — pause
   /// @param _vault the MoolahVault whose shares this contract holds
@@ -153,8 +154,10 @@ contract MoolahVaultAccount is
     _grantRole(MANAGER, manager);
     _grantRole(BOT, bot);
     _grantRole(PAUSER, pauser);
-    // so MANAGER can rotate the bot key without a TimeLock proposal
+    // so MANAGER can rotate the bot key, or revoke a pauser key that is holding the contract down,
+    // without a TimeLock proposal
     _setRoleAdmin(BOT, MANAGER);
+    _setRoleAdmin(PAUSER, MANAGER);
 
     vault = IMoolahVault(_vault);
     asset = IERC20(IMoolahVault(_vault).asset());
@@ -202,10 +205,13 @@ contract MoolahVaultAccount is
   }
 
   /// @dev redeem principal to principalOwner. The caller cannot name a destination.
-  /// @dev deliberately NOT whenNotPaused — pause must not trap the owner's principal at exactly the
-  ///      moment someone wants it out.
+  /// @dev whenNotPaused: a halted contract must not let principal leave piecemeal. Pause is not only
+  ///      a bot kill-switch — it is also the state an incident puts this contract in, and while it
+  ///      holds, the only sanctioned exit is `emergencyWithdraw`, which takes the whole position back
+  ///      to principalOwner in one move and cannot be walked down amount by amount. MANAGER holds
+  ///      `unpause`, so this is a speed bump for MANAGER, not a trap.
   /// @dev checks-effects-interactions: principal is decremented before the vault call.
-  function withdrawPrincipal(uint256 assets) external onlyRole(MANAGER) nonReentrant {
+  function withdrawPrincipal(uint256 assets) external onlyRole(MANAGER) nonReentrant whenNotPaused {
     require(assets > 0, ZeroAmount());
     require(assets <= principal, ExceedsPrincipal());
 
@@ -217,24 +223,30 @@ contract MoolahVaultAccount is
 
   /// @dev raise the principal baseline without moving funds. Vault shares can be transferred in by a
   ///      plain ERC20 transfer, which bypasses depositPrincipal — that position would otherwise read
-  ///      as harvestable yield and be paid out as such. This is the correction for it, and the way a
-  ///      top-up is recorded when it arrives as shares instead of lisUSD.
+  ///      as harvestable yield and be paid out as such. This is how a top-up is recorded when it
+  ///      arrives as shares instead of lisUSD.
+  /// @dev NOT part of the launch. At launch the baseline comes from `initialize` and B0c6 only
+  ///      transfers its shares in — calling this on top of that would count the same corpus twice,
+  ///      and the baseline cannot be lowered again. There are exactly two sanctioned ways to move the
+  ///      baseline afterwards:
+  ///        1. `depositPrincipal` / `withdrawPrincipal` — lisUSD in or out, baseline follows the funds
+  ///           in the same call, nothing to pair up;
+  ///        2. a share transfer plus this call, in ONE transaction.
+  /// @dev for route 2 the pairing is mandatory: a Safe MultiSend batch, never two separate Safe
+  ///      transactions. Nothing on-chain can enforce it — a plain ERC20 share transfer has no hook to
+  ///      intercept. Split across two transactions, the whole transferred position reads as claimable
+  ///      yield in between, and a BOT harvest landing in that window pays the corpus out as yield to a
+  ///      whitelisted destination.
   /// @dev MANAGER-only and raise-only — notes 4 and 5 in the contract header. Raising the baseline
   ///      can only shrink claimableYield(), so it cannot widen what BOT may take, and it redirects
   ///      nothing: withdrawPrincipal still pays principalOwner only.
   /// @dev no nonReentrant and no whenNotPaused: no external call, no fund movement, and a correction
   ///      that only shrinks claimableYield() must stay available during an incident.
-  /// @param assets the COST BASIS of the position being recorded — the lisUSD that was paid for those
-  ///        shares — never their current `vault.convertToAssets(shares)` value. The two differ by
-  ///        exactly the yield already accrued on them: at launch 28,274,743 shares were worth
-  ///        28,492,314 but cost 28,300,000, and recording the market value would have swallowed the
-  ///        192,314 backlog into principal, out of BOT's reach forever. That is why the amount is a
-  ///        parameter and is not computed on-chain — the cost basis does not exist on-chain.
-  /// @dev the share transfer and this call MUST go in ONE transaction — a Safe MultiSend batch, never
-  ///      two separate Safe transactions. Nothing on-chain can enforce the pairing: a plain ERC20
-  ///      share transfer has no hook to intercept. Split across two transactions, the whole
-  ///      transferred position reads as claimable yield in between, and a BOT harvest landing in that
-  ///      window pays the corpus out as yield to a whitelisted destination.
+  /// @param assets the COST BASIS of the shares being recorded — the lisUSD that was paid for them —
+  ///        never their current `vault.convertToAssets(shares)` value. The two differ by exactly the
+  ///        yield already accrued on them, and recording the market value would swallow that backlog
+  ///        into principal, out of BOT's reach forever. That is why the amount is a parameter and is
+  ///        not computed on-chain — the cost basis does not exist on-chain.
   function increasePrincipal(uint256 assets) external onlyRole(MANAGER) {
     require(assets > 0, ZeroAmount());
 

--- a/src/utils/MoolahVaultAccount.sol
+++ b/src/utils/MoolahVaultAccount.sol
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { IMoolahVault } from "moolah-vault/interfaces/IMoolahVault.sol";
+
+/// @title MoolahVaultAccount
+/// @author Lista DAO
+/// @notice Owns the protocol's lisUSD MoolahVault position, records the principal explicitly, and
+///         harvests only the surplus above it to a whitelisted set of destinations.
+/// @dev Deliberate design choices, written down here so they are not re-reported as findings:
+///      1. `initialize` is permissionless and this implementation is generic. The constructor calls
+///         `_disableInitializers()`, so the implementation itself can never be initialized, and every
+///         proxy has its own storage — a third party pointing their own proxy at this implementation
+///         cannot reach this instance. Which proxy is the protocol's is established by its role
+///         holders and the address registry, not by the code.
+///      2. `_authorizeUpgrade` has an empty body on purpose: the authorization IS the
+///         `onlyRole(DEFAULT_ADMIN_ROLE)` modifier, and DEFAULT_ADMIN_ROLE is the protocol TimeLock.
+///         Every other upgradeable contract in this repo is written the same way.
+///      3. MANAGER is the role admin of BOT and also owns the recipient whitelist, so a compromised
+///         MANAGER key can add its own address and grant itself BOT — that surface is accepted, not
+///         overlooked, and `emergencyWithdraw` puts the whole position within its reach in one call.
+///         MANAGER is B0c6, which is also `principalOwner`: the multisig that owns these funds and
+///         can already pull the entire principal back to itself through `withdrawPrincipal`. What no
+///         MANAGER call can do is choose a destination — principal and the emergency exit pay
+///         `principalOwner`, yield pays whitelisted recipients, and `setPrincipalOwner` is
+///         DEFAULT_ADMIN_ROLE-only. BOT's admin is MANAGER rather than DEFAULT_ADMIN_ROLE because
+///         rotating a leaked bot key must not wait on a 24h TimeLock proposal.
+///      4. `principal` is raised by MANAGER (`depositPrincipal`, `increasePrincipal`) and lowered
+///         only against funds actually leaving (`withdrawPrincipal`, `emergencyWithdraw`), with one
+///         exception: `emergencyWithdraw` resets it to 0, because it always empties the position and
+///         an empty position has no baseline to keep. That reset cannot be used to turn principal
+///         into harvestable yield: it only fires once the whole position has left, which leaves
+///         `claimableYield()` at 0 too. Nothing else can lower the baseline — doing so on a position
+///         that stays is the one action that would turn principal into harvestable yield.
+///      5. `increasePrincipal` is not bounded by `totalAssets()`. Raising the baseline can only
+///         shrink `claimableYield()`, so it can never widen what BOT may take, and after a loss the
+///         position legitimately sits below `principal`.
+///      6. After an exact claim the position can sit up to one share-wei's worth of assets BELOW
+///         `principal`, because `vault.withdraw` burns ceil-rounded shares. That deficit is a floor,
+///         not a ratchet: `claimableYield()` is 0 until NAV recovers, so further claims cannot
+///         deepen it, and BOT can never reach it.
+///      7. There is no ERC20 rescue and no sweep. `claimYield` withdraws exactly what it pays out,
+///         so nothing accumulates here in normal operation; anything sent here by mistake is ignored
+///         by every accounting view and recovered, if ever, by upgrade.
+///      8. `payments` may name one destination twice and may carry zero-amount entries. Amounts are
+///         the backend's decision; the contract enforces only that every destination is whitelisted
+///         and that the total does not exceed `claimableYield()`. A zero-amount entry is still
+///         whitelist-checked.
+///      9. No exit lets its caller name a destination: principal and emergency exits pay
+///         `principalOwner`, yield pays whitelisted recipients. Read with note 3, that means a
+///         compromised MANAGER can redirect the surplus but never the corpus, and a compromised BOT
+///         can move the surplus only to addresses MANAGER has already approved.
+contract MoolahVaultAccount is
+  UUPSUpgradeable,
+  AccessControlEnumerableUpgradeable,
+  PausableUpgradeable,
+  ReentrancyGuardUpgradeable
+{
+  using SafeERC20 for IERC20;
+
+  /// @param to destination, must be whitelisted
+  /// @param amount lisUSD
+  struct Payment {
+    address to;
+    uint256 amount;
+  }
+
+  /// @dev the vault whose shares this contract holds. Fixed at init on purpose: there is no setter,
+  ///      and a second vault means a second proxy.
+  IMoolahVault public vault;
+  /// @dev cached `vault.asset()`. The vault sets its asset once, in its own initializer, and exposes
+  ///      no setter, so this cannot go stale.
+  IERC20 public asset;
+  /// @dev the only address the principal and emergency exits can pay
+  address public principalOwner;
+  uint256 public principal;
+  mapping(address => bool) public isYieldRecipient;
+  address[] private yieldRecipients;
+
+  bytes32 public constant MANAGER = keccak256("MANAGER"); // manager role
+  bytes32 public constant BOT = keccak256("BOT"); // bot role
+  bytes32 public constant PAUSER = keccak256("PAUSER"); // pauser role
+
+  event PrincipalDeposited(address indexed from, uint256 assets, uint256 principal);
+  event PrincipalWithdrawn(address indexed to, uint256 assets, uint256 principal);
+  event PrincipalIncreased(uint256 assets, uint256 principal);
+  event EmergencyWithdrawn(address indexed to, uint256 shares);
+  event YieldClaimed(uint256 total, uint256 claimableAtCall);
+  event YieldPaid(address indexed to, uint256 amount);
+  event AddYieldRecipient(address indexed to);
+  event RemoveYieldRecipient(address indexed to);
+  event SetPrincipalOwner(address indexed principalOwner);
+
+  error ZeroAddress();
+  error ZeroAmount();
+  error AlreadySet();
+  error NoYieldRecipient();
+  error NotYieldRecipient();
+  error DuplicateRecipient();
+  error RecipientNotFound();
+  error ExceedsPrincipal();
+  error ExceedsClaimable();
+  error ZeroShares();
+  error WithdrawShortfall();
+  error SharesRemaining();
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @dev initialize contract. Roles are granted to their FINAL holders; the deployer takes none.
+  /// @dev permissionless by design — note 1 in the contract header.
+  /// @param admin DEFAULT_ADMIN_ROLE — upgrades, setPrincipalOwner, role administration
+  /// @param manager MANAGER — principal movement, recipient whitelist, unpause
+  /// @param bot BOT — claimYield
+  /// @param pauser PAUSER — pause
+  /// @param _vault the MoolahVault whose shares this contract holds
+  /// @param _principalOwner the only address principal can be withdrawn to
+  /// @param _principal starting principal, lisUSD. May exceed the position value at init.
+  /// @param _yieldRecipients initial claimYield destinations, must be non-empty
+  function initialize(
+    address admin,
+    address manager,
+    address bot,
+    address pauser,
+    address _vault,
+    address _principalOwner,
+    uint256 _principal,
+    address[] calldata _yieldRecipients
+  ) external initializer {
+    require(admin != address(0), ZeroAddress());
+    require(manager != address(0), ZeroAddress());
+    require(bot != address(0), ZeroAddress());
+    require(pauser != address(0), ZeroAddress());
+    require(_vault != address(0), ZeroAddress());
+    require(_principalOwner != address(0), ZeroAddress());
+    // an empty list deploys a contract whose claimYield reverts on every call
+    require(_yieldRecipients.length > 0, NoYieldRecipient());
+
+    __AccessControl_init();
+    __Pausable_init();
+    __ReentrancyGuard_init();
+
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    _grantRole(MANAGER, manager);
+    _grantRole(BOT, bot);
+    _grantRole(PAUSER, pauser);
+    // so MANAGER can rotate the bot key without a TimeLock proposal
+    _setRoleAdmin(BOT, MANAGER);
+
+    vault = IMoolahVault(_vault);
+    asset = IERC20(IMoolahVault(_vault).asset());
+    principalOwner = _principalOwner;
+    principal = _principal;
+
+    for (uint256 i = 0; i < _yieldRecipients.length; ++i) {
+      _addYieldRecipient(_yieldRecipients[i]);
+    }
+  }
+
+  /// @dev current lisUSD value of the position. C3: convertToAssets, not
+  ///      totalAssets * shares / totalSupply, so accrued-but-unminted fee shares are netted out.
+  function totalAssets() public view returns (uint256) {
+    return vault.convertToAssets(vault.balanceOf(address(this)));
+  }
+
+  /// @dev NAV surplus above principal. Clamps at 0 — C1 means the position value can fall.
+  function claimableYield() public view returns (uint256) {
+    uint256 assets = totalAssets();
+    return assets > principal ? assets - principal : 0;
+  }
+
+  /// @dev backend dry-run. `claimable` is the accounting figure; `claimableNow` is what a claim in
+  ///      this block can actually take. They differ exactly when the vault is liquidity-starved.
+  function previewClaim() external view returns (uint256 claimable, uint256 withdrawable, uint256 claimableNow) {
+    claimable = claimableYield();
+    withdrawable = vault.maxWithdraw(address(this));
+    claimableNow = Math.min(claimable, withdrawable);
+  }
+
+  /// @dev pull lisUSD from the caller and supply it to the vault, raising principal by the same
+  ///      nominal amount. Requires this contract on the vault's deposit whitelist.
+  function depositPrincipal(uint256 assets) external onlyRole(MANAGER) nonReentrant whenNotPaused {
+    require(assets > 0, ZeroAmount());
+
+    asset.safeTransferFrom(msg.sender, address(this), assets);
+    asset.forceApprove(address(vault), assets);
+    uint256 shares = vault.deposit(assets, address(this));
+    // a deposit too small to mint a share must not raise principal for free
+    require(shares > 0, ZeroShares());
+    principal += assets;
+
+    emit PrincipalDeposited(msg.sender, assets, principal);
+  }
+
+  /// @dev redeem principal to principalOwner. The caller cannot name a destination.
+  /// @dev deliberately NOT whenNotPaused — pause must not trap the owner's principal at exactly the
+  ///      moment someone wants it out.
+  /// @dev checks-effects-interactions: principal is decremented before the vault call.
+  function withdrawPrincipal(uint256 assets) external onlyRole(MANAGER) nonReentrant {
+    require(assets > 0, ZeroAmount());
+    require(assets <= principal, ExceedsPrincipal());
+
+    principal -= assets;
+    vault.withdraw(assets, principalOwner, address(this));
+
+    emit PrincipalWithdrawn(principalOwner, assets, principal);
+  }
+
+  /// @dev raise the principal baseline without moving funds. Vault shares can be transferred in by a
+  ///      plain ERC20 transfer, which bypasses depositPrincipal — that position would otherwise read
+  ///      as harvestable yield and be paid out as such. This is the correction for it, and the way a
+  ///      top-up is recorded when it arrives as shares instead of lisUSD.
+  /// @dev MANAGER-only and raise-only — notes 4 and 5 in the contract header. Raising the baseline
+  ///      can only shrink claimableYield(), so it cannot widen what BOT may take, and it redirects
+  ///      nothing: withdrawPrincipal still pays principalOwner only.
+  /// @dev no nonReentrant and no whenNotPaused: no external call, no fund movement, and a correction
+  ///      that only shrinks claimableYield() must stay available during an incident.
+  /// @param assets the COST BASIS of the position being recorded — the lisUSD that was paid for those
+  ///        shares — never their current `vault.convertToAssets(shares)` value. The two differ by
+  ///        exactly the yield already accrued on them: at launch 28,274,743 shares were worth
+  ///        28,492,314 but cost 28,300,000, and recording the market value would have swallowed the
+  ///        192,314 backlog into principal, out of BOT's reach forever. That is why the amount is a
+  ///        parameter and is not computed on-chain — the cost basis does not exist on-chain.
+  /// @dev the share transfer and this call MUST go in ONE transaction — a Safe MultiSend batch, never
+  ///      two separate Safe transactions. Nothing on-chain can enforce the pairing: a plain ERC20
+  ///      share transfer has no hook to intercept. Split across two transactions, the whole
+  ///      transferred position reads as claimable yield in between, and a BOT harvest landing in that
+  ///      window pays the corpus out as yield to a whitelisted destination.
+  function increasePrincipal(uint256 assets) external onlyRole(MANAGER) {
+    require(assets > 0, ZeroAmount());
+
+    principal += assets;
+
+    emit PrincipalIncreased(assets, principal);
+  }
+
+  /// @dev harvest NAV surplus and fan it out. Costs and residual are the caller's decision; the
+  ///      contract enforces only that every destination is whitelisted and that the total does not
+  ///      exceed claimableYield().
+  /// @dev one vault.withdraw for the whole total, then plain transfers. Each withdraw-queue walk is
+  ///      independently all-or-nothing (C2), so one walk beats N.
+  /// @dev duplicate destinations and zero-amount entries are allowed — note 8 in the contract header.
+  /// @param payments destinations and amounts, lisUSD
+  /// @return total the amount harvested
+  function claimYield(
+    Payment[] calldata payments
+  ) external onlyRole(BOT) nonReentrant whenNotPaused returns (uint256 total) {
+    uint256 len = payments.length;
+    for (uint256 i = 0; i < len; ++i) {
+      require(isYieldRecipient[payments[i].to], NotYieldRecipient());
+      total += payments[i].amount;
+    }
+    require(total > 0, ZeroAmount());
+
+    uint256 claimable = claimableYield();
+    require(total <= claimable, ExceedsClaimable());
+
+    uint256 balanceBefore = asset.balanceOf(address(this));
+    vault.withdraw(total, address(this), address(this));
+    // the vault is upgradeable — never pay out of a balance the withdraw did not deliver
+    require(asset.balanceOf(address(this)) >= balanceBefore + total, WithdrawShortfall());
+
+    for (uint256 i = 0; i < len; ++i) {
+      uint256 amount = payments[i].amount;
+      if (amount == 0) continue;
+      asset.safeTransfer(payments[i].to, amount);
+      emit YieldPaid(payments[i].to, amount);
+    }
+
+    emit YieldClaimed(total, claimable);
+  }
+
+  /// @dev hand the entire position to principalOwner as vault shares — the one exit that ignores the
+  ///      principal/yield split, because the shares carry both.
+  /// @dev MANAGER only — B0c6, which is also principalOwner. Deliberate: an exit gated behind a 24h
+  ///      TimeLock proposal is not an emergency exit, and the funds are B0c6's own. The role change
+  ///      buys speed and independence from queue liquidity, not a new destination: the shares can only
+  ///      go to principalOwner, and `setPrincipalOwner` stays DEFAULT_ADMIN_ROLE-only (notes 3, 4).
+  ///      DEFAULT_ADMIN_ROLE keeps the upgrade key and administers MANAGER, so it can grant itself
+  ///      MANAGER and take this route if B0c6 is unavailable.
+  /// @dev NOT whenNotPaused — the incident that pauses this contract is the reason to call it.
+  /// @dev no arguments, and it transfers the shares instead of redeeming them. Both are deliberate.
+  ///      Always taking the whole balance means a Safe transaction signed hours before it executes
+  ///      cannot carry a stale amount. Transferring shares means the exit never walks the withdraw
+  ///      queue, so it is NOT bounded by C2: withdrawPrincipal and claimYield can both revert
+  ///      NotEnoughLiquidity() while this call still succeeds — which is exactly the state an
+  ///      emergency is likely to find. principalOwner redeems on its own schedule afterwards.
+  /// @dev the destination is principalOwner, never a caller-supplied address — same rule as
+  ///      withdrawPrincipal, so no exit in this contract lets its caller pick where funds go.
+  /// @dev principal is zeroed before the external call (state first) and unconditionally: the position
+  ///      is empty afterwards, and an empty position has no baseline to keep (note 4).
+  /// @dev the balance is re-read after the transfer because the vault is upgradeable: an ERC20
+  ///      transfer that returns true without moving anything would otherwise leave the baseline at 0
+  ///      with the position still held here. SafeERC20 checks the return value, not the effect.
+  /// @return shares the vault shares sent to principalOwner
+  function emergencyWithdraw() external onlyRole(MANAGER) nonReentrant returns (uint256 shares) {
+    shares = vault.balanceOf(address(this));
+    require(shares > 0, ZeroShares());
+
+    principal = 0;
+
+    IERC20(address(vault)).safeTransfer(principalOwner, shares);
+    require(vault.balanceOf(address(this)) == 0, SharesRemaining());
+
+    emit EmergencyWithdrawn(principalOwner, shares);
+  }
+
+  /// @dev get all whitelisted claimYield destinations
+  function getYieldRecipients() external view returns (address[] memory) {
+    return yieldRecipients;
+  }
+
+  /// @dev add a claimYield destination
+  function addYieldRecipient(address to) external onlyRole(MANAGER) {
+    _addYieldRecipient(to);
+  }
+
+  /// @dev remove a claimYield destination
+  function removeYieldRecipient(address to) external onlyRole(MANAGER) {
+    require(isYieldRecipient[to], RecipientNotFound());
+    // initialize forbids an empty list; hold that invariant at runtime too
+    require(yieldRecipients.length > 1, NoYieldRecipient());
+    delete isYieldRecipient[to];
+
+    uint256 len = yieldRecipients.length;
+    for (uint256 i = 0; i < len; ++i) {
+      if (yieldRecipients[i] == to) {
+        yieldRecipients[i] = yieldRecipients[len - 1];
+        yieldRecipients.pop();
+        break;
+      }
+    }
+
+    emit RemoveYieldRecipient(to);
+  }
+
+  /// @dev change the address principal is withdrawn to. DEFAULT_ADMIN only — MANAGER must not be
+  ///      able to redirect principal away from the multisig.
+  function setPrincipalOwner(address _principalOwner) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_principalOwner != address(0), ZeroAddress());
+    require(_principalOwner != principalOwner, AlreadySet());
+    principalOwner = _principalOwner;
+
+    emit SetPrincipalOwner(_principalOwner);
+  }
+
+  function pause() external onlyRole(PAUSER) {
+    _pause();
+  }
+
+  function unpause() external onlyRole(MANAGER) {
+    _unpause();
+  }
+
+  function _addYieldRecipient(address to) private {
+    require(to != address(0), ZeroAddress());
+    require(!isYieldRecipient[to], DuplicateRecipient());
+    isYieldRecipient[to] = true;
+    yieldRecipients.push(to);
+
+    emit AddYieldRecipient(to);
+  }
+
+  /// @dev empty body on purpose — note 2 in the contract header. The authorization is the modifier.
+  function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/test/utils/MoolahVaultAccount.t.sol
+++ b/test/utils/MoolahVaultAccount.t.sol
@@ -1,0 +1,886 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import { ERC20Mock } from "moolah-vault/mocks/ERC20Mock.sol";
+import { MoolahVaultAccount } from "../../src/utils/MoolahVaultAccount.sol";
+import { MockYieldVault } from "./mocks/MockYieldVault.sol";
+
+contract MoolahVaultAccountTest is Test {
+  MoolahVaultAccount public impl;
+  MoolahVaultAccount public manager;
+  MockYieldVault public vaultMock;
+  ERC20Mock public token;
+
+  address admin = makeAddr("admin");
+  address managerSafe = makeAddr("managerSafe");
+  address bot = makeAddr("bot");
+  address pauser = makeAddr("pauser");
+  address lsr = makeAddr("lsr");
+  address buyback = makeAddr("buyback");
+  address stranger = makeAddr("stranger");
+
+  uint256 constant PRINCIPAL = 1_000_000 ether;
+  bytes32 constant MANAGER_ROLE = keccak256("MANAGER");
+  bytes32 constant BOT_ROLE = keccak256("BOT");
+  bytes32 constant PAUSER_ROLE = keccak256("PAUSER");
+
+  function setUp() public {
+    token = new ERC20Mock("Mock lisUSD", "mLisUSD");
+    vaultMock = new MockYieldVault(IERC20(address(token)));
+
+    // Deployed once, in setUp, and reused by _deploy. Deploying the implementation inside _deploy
+    // would make vm.expectRevert consume the implementation's successful CREATE instead of the
+    // proxy's reverting one, so the zero-address tests would pass for the wrong reason.
+    impl = new MoolahVaultAccount();
+
+    manager = _deploy(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, _twoRecipients());
+
+    // give the manager a position worth exactly PRINCIPAL
+    token.mint(address(this), PRINCIPAL);
+    token.approve(address(vaultMock), PRINCIPAL);
+    vaultMock.deposit(PRINCIPAL, address(manager));
+  }
+
+  function _deploy(
+    address _admin,
+    address _manager,
+    address _bot,
+    address _pauser,
+    address _vault,
+    address _principalOwner,
+    uint256 _principal,
+    address[] memory _recipients
+  ) internal returns (MoolahVaultAccount) {
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeCall(
+        MoolahVaultAccount.initialize,
+        (_admin, _manager, _bot, _pauser, _vault, _principalOwner, _principal, _recipients)
+      )
+    );
+    return MoolahVaultAccount(address(proxy));
+  }
+
+  function _twoRecipients() internal view returns (address[] memory r) {
+    r = new address[](2);
+    r[0] = lsr;
+    r[1] = buyback;
+  }
+
+  function _oneRecipient(address to) internal pure returns (address[] memory r) {
+    r = new address[](1);
+    r[0] = to;
+  }
+
+  // ----------------------------------------------------------------- initialize
+
+  function test_initialize_setsState() public view {
+    assertEq(address(manager.vault()), address(vaultMock));
+    assertEq(address(manager.asset()), address(token));
+    assertEq(manager.principalOwner(), managerSafe);
+    assertEq(manager.principal(), PRINCIPAL);
+    assertTrue(manager.isYieldRecipient(lsr));
+    assertTrue(manager.isYieldRecipient(buyback));
+    assertFalse(manager.isYieldRecipient(stranger));
+  }
+
+  function test_initialize_grantsRoles() public view {
+    assertTrue(manager.hasRole(bytes32(0), admin));
+    assertTrue(manager.hasRole(MANAGER_ROLE, managerSafe));
+    assertTrue(manager.hasRole(BOT_ROLE, bot));
+    assertTrue(manager.hasRole(PAUSER_ROLE, pauser));
+    // the deployer holds nothing — initialize grants the final holders directly
+    assertFalse(manager.hasRole(bytes32(0), address(this)));
+    assertFalse(manager.hasRole(MANAGER_ROLE, address(this)));
+  }
+
+  function test_initialize_setsBotRoleAdminToManager() public {
+    assertEq(manager.getRoleAdmin(BOT_ROLE), MANAGER_ROLE);
+
+    address newBot = makeAddr("newBot");
+    vm.prank(managerSafe);
+    manager.grantRole(BOT_ROLE, newBot);
+    assertTrue(manager.hasRole(BOT_ROLE, newBot));
+  }
+
+  function test_initialize_revertsOnZeroAddress() public {
+    address[] memory r = _twoRecipients();
+    address[6] memory args = [admin, managerSafe, bot, pauser, address(vaultMock), managerSafe];
+
+    for (uint256 i = 0; i < 6; ++i) {
+      address[6] memory a = args;
+      a[i] = address(0);
+      vm.expectRevert(MoolahVaultAccount.ZeroAddress.selector);
+      _deploy(a[0], a[1], a[2], a[3], a[4], a[5], PRINCIPAL, r);
+    }
+  }
+
+  function test_initialize_revertsOnEmptyYieldRecipients() public {
+    address[] memory empty = new address[](0);
+    vm.expectRevert(MoolahVaultAccount.NoYieldRecipient.selector);
+    _deploy(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, empty);
+  }
+
+  function test_initialize_revertsOnZeroYieldRecipient() public {
+    vm.expectRevert(MoolahVaultAccount.ZeroAddress.selector);
+    _deploy(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, _oneRecipient(address(0)));
+  }
+
+  function test_initialize_revertsOnDuplicateYieldRecipient() public {
+    address[] memory dup = new address[](2);
+    dup[0] = lsr;
+    dup[1] = lsr;
+    vm.expectRevert(MoolahVaultAccount.DuplicateRecipient.selector);
+    _deploy(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, dup);
+  }
+
+  function test_reinitialize_reverts() public {
+    vm.expectRevert(Initializable.InvalidInitialization.selector);
+    manager.initialize(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, _twoRecipients());
+  }
+
+  // ------------------------------------------------------------------ recipients
+
+  function test_addYieldRecipient() public {
+    vm.prank(managerSafe);
+    manager.addYieldRecipient(stranger);
+
+    assertTrue(manager.isYieldRecipient(stranger));
+    address[] memory list = manager.getYieldRecipients();
+    assertEq(list.length, 3);
+    assertEq(list[2], stranger);
+  }
+
+  function test_addYieldRecipient_revertsOnDuplicate() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.DuplicateRecipient.selector);
+    manager.addYieldRecipient(lsr);
+  }
+
+  function test_addYieldRecipient_revertsOnZero() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.ZeroAddress.selector);
+    manager.addYieldRecipient(address(0));
+  }
+
+  function test_addYieldRecipient_onlyManager() public {
+    vm.prank(stranger);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER_ROLE)
+    );
+    manager.addYieldRecipient(stranger);
+  }
+
+  function test_removeYieldRecipient_swapAndPop() public {
+    // remove the FIRST of two, so the swap-and-pop actually moves an element
+    vm.prank(managerSafe);
+    manager.removeYieldRecipient(lsr);
+
+    assertFalse(manager.isYieldRecipient(lsr));
+    assertTrue(manager.isYieldRecipient(buyback));
+    address[] memory list = manager.getYieldRecipients();
+    assertEq(list.length, 1);
+    assertEq(list[0], buyback);
+  }
+
+  function test_removeYieldRecipient_revertsIfAbsent() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.RecipientNotFound.selector);
+    manager.removeYieldRecipient(stranger);
+  }
+
+  /// @dev initialize forbids an empty whitelist, so the runtime must not be able to reach one — an
+  ///      empty list would make every claimYield call revert until MANAGER added an address back.
+  function test_removeYieldRecipient_revertsOnLast() public {
+    vm.startPrank(managerSafe);
+    manager.removeYieldRecipient(lsr);
+    vm.expectRevert(MoolahVaultAccount.NoYieldRecipient.selector);
+    manager.removeYieldRecipient(buyback);
+    vm.stopPrank();
+  }
+
+  function test_removeYieldRecipient_onlyManager() public {
+    vm.prank(stranger);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER_ROLE)
+    );
+    manager.removeYieldRecipient(lsr);
+  }
+
+  // ------------------------------------------------------------------ principalOwner
+
+  function test_setPrincipalOwner() public {
+    address newOwner = makeAddr("newOwner");
+    vm.prank(admin);
+    manager.setPrincipalOwner(newOwner);
+    assertEq(manager.principalOwner(), newOwner);
+  }
+
+  /// @dev MANAGER must NOT be able to redirect principal.
+  function test_setPrincipalOwner_onlyAdmin() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, managerSafe, bytes32(0))
+    );
+    manager.setPrincipalOwner(stranger);
+  }
+
+  function test_setPrincipalOwner_revertsOnZeroAndSame() public {
+    vm.startPrank(admin);
+    vm.expectRevert(MoolahVaultAccount.ZeroAddress.selector);
+    manager.setPrincipalOwner(address(0));
+    vm.expectRevert(MoolahVaultAccount.AlreadySet.selector);
+    manager.setPrincipalOwner(managerSafe);
+    vm.stopPrank();
+  }
+
+  // ------------------------------------------------------------------ pause / upgrade
+
+  function test_pause_onlyPauser_unpause_onlyManager() public {
+    vm.prank(stranger);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, PAUSER_ROLE)
+    );
+    manager.pause();
+
+    vm.prank(pauser);
+    manager.pause();
+    assertTrue(manager.paused());
+
+    // the pauser cannot unpause — asymmetric by design
+    vm.prank(pauser);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, pauser, MANAGER_ROLE)
+    );
+    manager.unpause();
+
+    vm.prank(managerSafe);
+    manager.unpause();
+    assertFalse(manager.paused());
+  }
+
+  function test_upgrade_onlyAdmin() public {
+    MoolahVaultAccount newImpl = new MoolahVaultAccount();
+
+    vm.prank(managerSafe);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, managerSafe, bytes32(0))
+    );
+    manager.upgradeToAndCall(address(newImpl), "");
+
+    vm.prank(admin);
+    manager.upgradeToAndCall(address(newImpl), "");
+    assertEq(manager.principal(), PRINCIPAL); // state survived
+  }
+  // ------------------------------------------------------------------ views
+
+  function test_totalAssets_matchesConvertToAssets() public view {
+    assertEq(manager.totalAssets(), vaultMock.convertToAssets(vaultMock.balanceOf(address(manager))));
+    assertEq(manager.totalAssets(), PRINCIPAL);
+  }
+
+  function test_claimableYield_zeroAtPrincipal() public view {
+    assertEq(manager.claimableYield(), 0);
+  }
+
+  function test_claimableYield_afterAccrue() public {
+    vaultMock.accrue(1_000 ether);
+    // the manager holds every share, so the whole accrual is its surplus
+    assertEq(manager.claimableYield(), 1_000 ether);
+    assertEq(manager.totalAssets(), PRINCIPAL + 1_000 ether);
+  }
+
+  /// @dev C1: NAV is not monotonic. claimableYield must clamp at 0 and resume unaided.
+  function test_claimableYield_clampsAfterLoss_andRecovers() public {
+    vaultMock.accrue(1_000 ether);
+    assertEq(manager.claimableYield(), 1_000 ether);
+
+    vaultMock.loss(3_000 ether); // NAV now 2_000 below principal
+    assertLt(manager.totalAssets(), manager.principal());
+    assertEq(manager.claimableYield(), 0);
+
+    vaultMock.accrue(2_500 ether); // back above principal
+    assertEq(manager.claimableYield(), 500 ether);
+  }
+
+  function test_previewClaim_clampsToWithdrawable() public {
+    vaultMock.accrue(1_000 ether);
+
+    (uint256 claimable, uint256 withdrawable, uint256 claimableNow) = manager.previewClaim();
+    assertEq(claimable, 1_000 ether);
+    assertEq(withdrawable, vaultMock.maxWithdraw(address(manager)));
+    assertEq(claimableNow, 1_000 ether);
+
+    vaultMock.setLiquidity(400 ether);
+    (claimable, withdrawable, claimableNow) = manager.previewClaim();
+    assertEq(claimable, 1_000 ether); // unchanged — this is the accounting figure
+    assertEq(withdrawable, 400 ether);
+    assertEq(claimableNow, 400 ether); // clamped — this is what a claim can actually take
+  }
+
+  function test_getYieldRecipients_returnsSeeded() public view {
+    address[] memory list = manager.getYieldRecipients();
+    assertEq(list.length, 2);
+    assertEq(list[0], lsr);
+    assertEq(list[1], buyback);
+  }
+  // ------------------------------------------------------------------ principal
+
+  function _fundManagerSafe(uint256 amount) internal {
+    token.mint(managerSafe, amount);
+    vm.prank(managerSafe);
+    token.approve(address(manager), amount);
+  }
+
+  function test_depositPrincipal_increasesPrincipalAndPosition() public {
+    _fundManagerSafe(500 ether);
+
+    vm.prank(managerSafe);
+    manager.depositPrincipal(500 ether);
+
+    assertEq(manager.principal(), PRINCIPAL + 500 ether);
+    assertEq(manager.totalAssets(), PRINCIPAL + 500 ether);
+    assertEq(token.balanceOf(managerSafe), 0);
+    assertEq(token.balanceOf(address(manager)), 0); // nothing left behind
+  }
+
+  /// @dev deposit mints floor shares while principal takes the full nominal, so the rounding always
+  ///      goes against claimable — it can never be used to over-harvest.
+  function test_depositPrincipal_roundingIsConservative() public {
+    vaultMock.accrue(333 ether); // share price now above 1.0
+    uint256 claimableBefore = manager.claimableYield();
+
+    _fundManagerSafe(777 ether);
+    vm.prank(managerSafe);
+    manager.depositPrincipal(777 ether);
+
+    assertLe(manager.claimableYield(), claimableBefore);
+  }
+
+  /// @dev a deposit too small to mint a share must revert, not raise principal for free.
+  function test_depositPrincipal_revertsOnZeroShares() public {
+    vaultMock.accrue(PRINCIPAL); // share price now 2.0, so 1 wei of assets mints 0 shares
+    _fundManagerSafe(1);
+
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.ZeroShares.selector);
+    manager.depositPrincipal(1);
+  }
+
+  function test_depositPrincipal_revertsOnZero() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.ZeroAmount.selector);
+    manager.depositPrincipal(0);
+  }
+
+  function test_depositPrincipal_onlyManager() public {
+    token.mint(stranger, 1 ether);
+    vm.startPrank(stranger);
+    token.approve(address(manager), 1 ether);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER_ROLE)
+    );
+    manager.depositPrincipal(1 ether);
+    vm.stopPrank();
+  }
+
+  function test_depositPrincipal_revertsWhenNotWhitelisted() public {
+    vaultMock.setWhitelistEnabled(true); // the manager is not on the list
+    _fundManagerSafe(200 ether);
+
+    vm.prank(managerSafe);
+    vm.expectRevert("NotWhiteList");
+    manager.depositPrincipal(100 ether);
+
+    vaultMock.setWhiteList(address(manager), true);
+    vm.prank(managerSafe);
+    manager.depositPrincipal(100 ether);
+    assertEq(manager.principal(), PRINCIPAL + 100 ether);
+  }
+
+  function test_depositPrincipal_revertsWhenPaused() public {
+    _fundManagerSafe(100 ether);
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(managerSafe);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    manager.depositPrincipal(100 ether);
+  }
+
+  function test_withdrawPrincipal_sendsToPrincipalOwner() public {
+    vm.prank(managerSafe);
+    manager.withdrawPrincipal(400 ether);
+
+    assertEq(manager.principal(), PRINCIPAL - 400 ether);
+    assertEq(token.balanceOf(managerSafe), 400 ether);
+    assertEq(token.balanceOf(address(manager)), 0);
+  }
+
+  /// @dev the caller cannot name a destination — a compromised MANAGER key can only push funds back
+  ///      to the multisig. Proven by moving principalOwner and observing where the funds land.
+  function test_withdrawPrincipal_ignoresCallerAsDestination() public {
+    address newOwner = makeAddr("newOwner");
+    vm.prank(admin);
+    manager.setPrincipalOwner(newOwner);
+
+    vm.prank(managerSafe);
+    manager.withdrawPrincipal(250 ether);
+
+    assertEq(token.balanceOf(newOwner), 250 ether);
+    assertEq(token.balanceOf(managerSafe), 0);
+  }
+
+  function test_withdrawPrincipal_revertsAbovePrincipal() public {
+    vaultMock.accrue(1_000 ether); // plenty of assets, but principal is the cap
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.ExceedsPrincipal.selector);
+    manager.withdrawPrincipal(PRINCIPAL + 1);
+  }
+
+  function test_withdrawPrincipal_revertsOnZero() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.ZeroAmount.selector);
+    manager.withdrawPrincipal(0);
+  }
+
+  function test_withdrawPrincipal_onlyManager() public {
+    vm.prank(stranger);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER_ROLE)
+    );
+    manager.withdrawPrincipal(1 ether);
+  }
+
+  /// @dev shares can arrive as a plain ERC20 transfer, which bypasses depositPrincipal entirely.
+  ///      Without the correction the transferred position reads as harvestable yield.
+  function test_increasePrincipal_correctsDirectShareTransfer() public {
+    token.mint(address(this), 700 ether);
+    token.approve(address(vaultMock), 700 ether);
+    uint256 shares = vaultMock.deposit(700 ether, address(this));
+    vaultMock.transfer(address(manager), shares);
+
+    assertEq(manager.claimableYield(), 700 ether); // reads as yield, is principal
+
+    vm.prank(managerSafe);
+    manager.increasePrincipal(700 ether);
+
+    assertEq(manager.principal(), PRINCIPAL + 700 ether);
+    assertEq(manager.claimableYield(), 0);
+  }
+
+  function test_increasePrincipal_revertsOnZero() public {
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.ZeroAmount.selector);
+    manager.increasePrincipal(0);
+  }
+
+  function test_increasePrincipal_onlyManager() public {
+    vm.prank(stranger);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER_ROLE)
+    );
+    manager.increasePrincipal(1 ether);
+  }
+
+  /// @dev a correction that only shrinks claimableYield must stay available during an incident.
+  function test_increasePrincipal_worksWhenPaused() public {
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(managerSafe);
+    manager.increasePrincipal(100 ether);
+    assertEq(manager.principal(), PRINCIPAL + 100 ether);
+  }
+
+  /// @dev pause exists to stop the bot, not to trap the owner's principal.
+  function test_withdrawPrincipal_worksWhenPaused() public {
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(managerSafe);
+    manager.withdrawPrincipal(100 ether);
+    assertEq(token.balanceOf(managerSafe), 100 ether);
+  }
+  // ------------------------------------------------------------------ claimYield
+
+  function _pay(address to, uint256 amount) internal pure returns (MoolahVaultAccount.Payment[] memory p) {
+    p = new MoolahVaultAccount.Payment[](1);
+    p[0] = MoolahVaultAccount.Payment({ to: to, amount: amount });
+  }
+
+  function _pay2(
+    address to1,
+    uint256 a1,
+    address to2,
+    uint256 a2
+  ) internal pure returns (MoolahVaultAccount.Payment[] memory p) {
+    p = new MoolahVaultAccount.Payment[](2);
+    p[0] = MoolahVaultAccount.Payment({ to: to1, amount: a1 });
+    p[1] = MoolahVaultAccount.Payment({ to: to2, amount: a2 });
+  }
+
+  function test_claimYield_singleRecipient() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    uint256 total = manager.claimYield(_pay(lsr, 600 ether));
+
+    assertEq(total, 600 ether);
+    assertEq(token.balanceOf(lsr), 600 ether);
+    assertEq(manager.claimableYield(), 400 ether);
+    assertEq(manager.principal(), PRINCIPAL); // untouched
+  }
+
+  function test_claimYield_splitsAcrossTwoRecipients() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    uint256 total = manager.claimYield(_pay2(lsr, 440 ether, buyback, 560 ether));
+
+    assertEq(total, 1_000 ether);
+    assertEq(token.balanceOf(lsr), 440 ether);
+    assertEq(token.balanceOf(buyback), 560 ether);
+    assertEq(manager.claimableYield(), 0);
+  }
+
+  function test_claimYield_leavesNoResidue() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    manager.claimYield(_pay2(lsr, 1 ether, buyback, 999 ether));
+
+    assertEq(token.balanceOf(address(manager)), 0);
+  }
+
+  function test_claimYield_revertsOnEmptyArray() public {
+    vaultMock.accrue(1_000 ether);
+    MoolahVaultAccount.Payment[] memory empty = new MoolahVaultAccount.Payment[](0);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.ZeroAmount.selector);
+    manager.claimYield(empty);
+  }
+
+  function test_claimYield_revertsOnAllZeroAmounts() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.ZeroAmount.selector);
+    manager.claimYield(_pay2(lsr, 0, buyback, 0));
+  }
+
+  function test_claimYield_skipsZeroAmountLeg() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    uint256 total = manager.claimYield(_pay2(lsr, 0, buyback, 700 ether));
+
+    assertEq(total, 700 ether);
+    assertEq(token.balanceOf(lsr), 0);
+    assertEq(token.balanceOf(buyback), 700 ether);
+  }
+
+  function test_claimYield_revertsAboveClaimable() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.ExceedsClaimable.selector);
+    manager.claimYield(_pay(lsr, 1_000 ether + 1));
+  }
+
+  function test_claimYield_revertsOnUnlistedRecipient() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.NotYieldRecipient.selector);
+    manager.claimYield(_pay(stranger, 100 ether));
+  }
+
+  /// @dev the whole call must roll back — a valid first leg must not survive an invalid second.
+  function test_claimYield_revertsOnUnlistedSecondRecipient_rollsBack() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.NotYieldRecipient.selector);
+    manager.claimYield(_pay2(lsr, 500 ether, stranger, 100 ether));
+
+    assertEq(token.balanceOf(lsr), 0);
+    assertEq(manager.claimableYield(), 1_000 ether);
+  }
+
+  /// @dev a zero-amount leg still has to name a whitelisted address.
+  function test_claimYield_revertsOnUnlistedZeroAmountLeg() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.NotYieldRecipient.selector);
+    manager.claimYield(_pay2(buyback, 100 ether, stranger, 0));
+  }
+
+  function test_claimYield_revertsAfterRecipientRemoved() public {
+    vaultMock.accrue(1_000 ether);
+    vm.prank(managerSafe);
+    manager.removeYieldRecipient(lsr);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.NotYieldRecipient.selector);
+    manager.claimYield(_pay(lsr, 100 ether));
+  }
+
+  /// @dev C2 stand-in: no clamping. A short vault reverts and the bot retries next cycle.
+  function test_claimYield_revertsWhenLiquidityShort() public {
+    vaultMock.accrue(1_000 ether);
+    vaultMock.setLiquidity(300 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(); // ERC4626ExceededMaxWithdraw; the real NotEnoughLiquidity() is fork-tested
+    manager.claimYield(_pay(lsr, 800 ether));
+
+    // and the amount previewClaim reports as available does go through
+    (, , uint256 claimableNow) = manager.previewClaim();
+    assertEq(claimableNow, 300 ether);
+    vm.prank(bot);
+    manager.claimYield(_pay(lsr, claimableNow));
+    assertEq(token.balanceOf(lsr), 300 ether);
+  }
+
+  /// @dev the vault is upgradeable. A withdraw that delivers less than it was asked for must revert
+  ///      the claim, not top the difference up out of lisUSD donated to this contract.
+  function test_claimYield_revertsWhenWithdrawUnderDelivers() public {
+    vaultMock.accrue(1_000 ether);
+    token.mint(address(manager), 500 ether); // donated balance a claim must never spend
+    vaultMock.setWithdrawShortfall(1 ether);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.WithdrawShortfall.selector);
+    manager.claimYield(_pay(lsr, 800 ether));
+
+    vaultMock.setWithdrawShortfall(0);
+    vm.prank(bot);
+    manager.claimYield(_pay(lsr, 800 ether));
+    assertEq(token.balanceOf(lsr), 800 ether);
+    assertEq(token.balanceOf(address(manager)), 500 ether); // donation untouched
+  }
+
+  function test_claimYield_onlyBot() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(managerSafe); // MANAGER is not BOT
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, managerSafe, BOT_ROLE)
+    );
+    manager.claimYield(_pay(lsr, 100 ether));
+  }
+
+  function test_claimYield_revertsWhenPaused() public {
+    vaultMock.accrue(1_000 ether);
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(bot);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+    manager.claimYield(_pay(lsr, 100 ether));
+  }
+
+  /// @dev principal is not reachable through the yield path: a second claim on unchanged NAV has
+  ///      nothing to take. Assert the residual against the vault's own preview arithmetic, not
+  ///      against `principal - 1` — the dust bound is one share-wei's worth of assets.
+  function test_claimYield_twiceOnUnchangedNav() public {
+    vaultMock.accrue(1_000 ether);
+    uint256 claimable = manager.claimableYield();
+
+    uint256 expectedRemaining = vaultMock.totalAssets() - claimable;
+
+    vm.prank(bot);
+    manager.claimYield(_pay(lsr, claimable));
+
+    assertEq(manager.totalAssets(), expectedRemaining);
+    assertLe(expectedRemaining, manager.principal());
+    // the shortfall is bounded by one share's asset value, not by 1 wei
+    assertGe(expectedRemaining + vaultMock.convertToAssets(1) + 1, manager.principal());
+    assertEq(manager.claimableYield(), 0);
+
+    vm.prank(bot);
+    vm.expectRevert(MoolahVaultAccount.ExceedsClaimable.selector);
+    manager.claimYield(_pay(lsr, 1));
+  }
+
+  /// @dev the dust deficit is a floor, not a ratchet: repeated accrue-and-drain rounds must not
+  ///      deepen it. Asserted against the share-value bound each round, so the check does not depend
+  ///      on which round happens to be worst.
+  function test_claimYield_dustFloorDoesNotDeepen() public {
+    vaultMock.accrue(1_000 ether);
+
+    for (uint256 round = 0; round < 5; ++round) {
+      uint256 claimable = manager.claimableYield();
+      if (claimable > 0) {
+        vm.prank(bot);
+        manager.claimYield(_pay(buyback, claimable));
+      }
+
+      uint256 assets = manager.totalAssets();
+      uint256 deficit = manager.principal() > assets ? manager.principal() - assets : 0;
+      assertLe(deficit, vaultMock.convertToAssets(1) + 1);
+
+      vaultMock.accrue(137 ether);
+    }
+  }
+
+  /// @dev lisUSD sent here by mistake is not swept by a claim and does not inflate claimableYield.
+  function test_claimYield_ignoresDonatedAsset() public {
+    vaultMock.accrue(1_000 ether);
+    token.mint(address(manager), 42 ether);
+    assertEq(manager.claimableYield(), 1_000 ether);
+
+    vm.prank(bot);
+    manager.claimYield(_pay(lsr, 1_000 ether));
+
+    assertEq(token.balanceOf(lsr), 1_000 ether);
+    assertEq(token.balanceOf(address(manager)), 42 ether); // still there
+  }
+
+  function test_claimYield_emitsEvents() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.expectEmit(true, false, false, true, address(manager));
+    emit MoolahVaultAccount.YieldPaid(lsr, 300 ether);
+    vm.expectEmit(true, false, false, true, address(manager));
+    emit MoolahVaultAccount.YieldPaid(buyback, 200 ether);
+    vm.expectEmit(false, false, false, true, address(manager));
+    emit MoolahVaultAccount.YieldClaimed(500 ether, 1_000 ether);
+
+    vm.prank(bot);
+    manager.claimYield(_pay2(lsr, 300 ether, buyback, 200 ether));
+  }
+
+  function test_claimYield_duplicateRecipientEntries() public {
+    vaultMock.accrue(1_000 ether);
+
+    vm.prank(bot);
+    uint256 total = manager.claimYield(_pay2(lsr, 100 ether, lsr, 250 ether));
+
+    assertEq(total, 350 ether);
+    assertEq(token.balanceOf(lsr), 350 ether);
+  }
+  // ------------------------------------------------------------------ emergencyWithdraw
+
+  /// @dev the whole position leaves at once as shares — principal and yield ride out together — and
+  ///      the baseline resets to 0. No argument: the call always takes the entire share balance.
+  function test_emergencyWithdraw_movesAllSharesToPrincipalOwner() public {
+    vaultMock.accrue(1_000 ether);
+    uint256 held = vaultMock.balanceOf(address(manager));
+
+    vm.prank(managerSafe);
+    uint256 shares = manager.emergencyWithdraw();
+
+    assertEq(shares, held);
+    assertEq(vaultMock.balanceOf(managerSafe), held);
+    assertEq(vaultMock.balanceOf(address(manager)), 0);
+    assertEq(manager.principal(), 0);
+    assertEq(manager.totalAssets(), 0);
+    assertEq(manager.claimableYield(), 0);
+    assertEq(token.balanceOf(managerSafe), 0); // shares moved, not lisUSD
+  }
+
+  /// @dev the decisive property: a share transfer never walks the withdraw queue, so the exit works
+  ///      with the vault fully illiquid — exactly where withdrawPrincipal and claimYield revert.
+  function test_emergencyWithdraw_worksWithZeroLiquidity() public {
+    vaultMock.accrue(1_000 ether);
+    vaultMock.setLiquidity(0);
+    uint256 held = vaultMock.balanceOf(address(manager));
+
+    vm.prank(managerSafe);
+    uint256 shares = manager.emergencyWithdraw();
+
+    assertEq(shares, held);
+    assertEq(vaultMock.balanceOf(managerSafe), held);
+    assertEq(vaultMock.balanceOf(address(manager)), 0);
+    assertEq(manager.principal(), 0);
+  }
+
+  /// @dev the caller cannot name a destination — the exit follows principalOwner, like withdrawPrincipal.
+  function test_emergencyWithdraw_paysPrincipalOwnerNotCaller() public {
+    address newOwner = makeAddr("newOwner");
+    uint256 held = vaultMock.balanceOf(address(manager));
+
+    vm.prank(admin);
+    manager.setPrincipalOwner(newOwner);
+
+    vm.prank(managerSafe);
+    uint256 shares = manager.emergencyWithdraw();
+
+    assertEq(shares, held);
+    assertEq(vaultMock.balanceOf(newOwner), held);
+    assertEq(vaultMock.balanceOf(admin), 0);
+    assertEq(vaultMock.balanceOf(managerSafe), 0); // the caller keeps nothing
+  }
+
+  /// @dev MANAGER-gated. DEFAULT_ADMIN_ROLE is deliberately NOT accepted directly: it administers
+  ///      MANAGER, so its route is to grant itself the role first.
+  function test_emergencyWithdraw_onlyManager() public {
+    vm.prank(stranger);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, MANAGER_ROLE)
+    );
+    manager.emergencyWithdraw();
+
+    vm.prank(admin);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, MANAGER_ROLE)
+    );
+    manager.emergencyWithdraw();
+  }
+
+  /// @dev the pause an incident triggers must not block the exit that same incident calls for.
+  function test_emergencyWithdraw_worksWhenPaused() public {
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(managerSafe);
+    manager.emergencyWithdraw();
+    assertEq(manager.principal(), 0);
+  }
+
+  /// @dev after a loss the position is worth less than the baseline. The exit still moves every share
+  ///      and still resets the baseline to 0 — an empty position has no baseline to keep — and that is
+  ///      the one write-down in the contract (note 4).
+  function test_emergencyWithdraw_afterLossResetsBaseline() public {
+    vaultMock.loss(200_000 ether); // NAV now 200k below principal
+    assertEq(manager.claimableYield(), 0);
+    uint256 held = vaultMock.balanceOf(address(manager));
+
+    vm.prank(managerSafe);
+    uint256 shares = manager.emergencyWithdraw();
+
+    assertEq(shares, held);
+    assertLt(vaultMock.convertToAssets(shares), PRINCIPAL);
+    assertEq(manager.principal(), 0);
+    assertEq(vaultMock.balanceOf(address(manager)), 0);
+  }
+
+  /// @dev the vault is upgradeable. A share transfer that returns true without moving anything must
+  ///      revert, instead of leaving the baseline at 0 with the position still sitting here.
+  function test_emergencyWithdraw_revertsWhenSharesDoNotMove() public {
+    vaultMock.setTransferNoop(true);
+
+    vm.prank(managerSafe);
+    vm.expectRevert(MoolahVaultAccount.SharesRemaining.selector);
+    manager.emergencyWithdraw();
+  }
+
+  function test_emergencyWithdraw_revertsWithNoShares() public {
+    vm.startPrank(managerSafe);
+    manager.emergencyWithdraw();
+    vm.expectRevert(MoolahVaultAccount.ZeroShares.selector);
+    manager.emergencyWithdraw();
+    vm.stopPrank();
+  }
+}

--- a/test/utils/MoolahVaultAccount.t.sol
+++ b/test/utils/MoolahVaultAccount.t.sol
@@ -110,6 +110,40 @@ contract MoolahVaultAccountTest is Test {
     assertTrue(manager.hasRole(BOT_ROLE, newBot));
   }
 
+  function test_initialize_setsPauserRoleAdminToManager() public {
+    assertEq(manager.getRoleAdmin(PAUSER_ROLE), MANAGER_ROLE);
+
+    // a pauser key holding the contract down must be revocable without a 24h TimeLock proposal
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(managerSafe);
+    manager.revokeRole(PAUSER_ROLE, pauser);
+    assertFalse(manager.hasRole(PAUSER_ROLE, pauser));
+
+    address newPauser = makeAddr("newPauser");
+    vm.prank(managerSafe);
+    manager.grantRole(PAUSER_ROLE, newPauser);
+    assertTrue(manager.hasRole(PAUSER_ROLE, newPauser));
+
+    vm.prank(managerSafe);
+    manager.unpause();
+
+    vm.prank(pauser);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, pauser, PAUSER_ROLE)
+    );
+    manager.pause();
+  }
+
+  /// @dev the implementation must refuse initialization because its initializer is burned, not
+  ///      because some argument happened to be unusable. deploy_moolahVaultAccount_impl.s.sol
+  ///      asserts this selector for the same reason.
+  function test_implementation_revertsWithInvalidInitialization() public {
+    vm.expectRevert(Initializable.InvalidInitialization.selector);
+    impl.initialize(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, _twoRecipients());
+  }
+
   function test_initialize_revertsOnZeroAddress() public {
     address[] memory r = _twoRecipients();
     address[6] memory args = [admin, managerSafe, bot, pauser, address(vaultMock), managerSafe];
@@ -500,14 +534,25 @@ contract MoolahVaultAccountTest is Test {
     assertEq(manager.principal(), PRINCIPAL + 100 ether);
   }
 
-  /// @dev pause exists to stop the bot, not to trap the owner's principal.
-  function test_withdrawPrincipal_worksWhenPaused() public {
+  /// @dev a halted contract must not let principal leave piecemeal. The only exit while paused is
+  ///      emergencyWithdraw, which takes the whole position back to principalOwner in one move.
+  function test_withdrawPrincipal_revertsWhenPaused() public {
     vm.prank(pauser);
     manager.pause();
 
     vm.prank(managerSafe);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     manager.withdrawPrincipal(100 ether);
-    assertEq(token.balanceOf(managerSafe), 100 ether);
+
+    // the emergency exit stays open
+    vm.prank(managerSafe);
+    manager.emergencyWithdraw();
+    assertEq(vaultMock.balanceOf(address(manager)), 0);
+    assertEq(manager.principal(), 0);
+
+    // and it works again once MANAGER lifts the pause
+    vm.prank(managerSafe);
+    manager.unpause();
   }
   // ------------------------------------------------------------------ claimYield
 

--- a/test/utils/MoolahVaultAccountFork.t.sol
+++ b/test/utils/MoolahVaultAccountFork.t.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IMoolahVault } from "moolah-vault/interfaces/IMoolahVault.sol";
+import { ErrorsLib } from "moolah-vault/libraries/ErrorsLib.sol";
+import { MoolahVaultAccount } from "../../src/utils/MoolahVaultAccount.sol";
+
+contract MoolahVaultAccountForkTest is Test {
+  uint256 constant FORK_BLOCK = 116_433_631;
+
+  IMoolahVault constant VAULT = IMoolahVault(0xE03D86e5Baa3509AC4A059A41737bAa8169B6529);
+  IERC20 constant LISUSD = IERC20(0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5);
+  address constant B0C6 = 0x8d388136d578dCD791D081c6042284CED6d9B0c6;
+  address constant LENDING_TIMELOCK = 0x2e2807F88C381Cb0CC55c808a751fC1E3fcCbb85;
+  address constant PROTOCOL_TIMELOCK = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
+  address constant LSR_POOL = 0x37DB1AE9B24055D1F9fE973Aea40B7EB2995D0Bf;
+  address constant USDT_BUYBACK = 0x3b99A4177E3f430590A8473f353dD87a5a2e1BfC;
+  address constant BOT_EOA = 0x91fC4BA20685339781888eCA3E9E1c12d40F0e13;
+  address constant PAUSER_EOA = 0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8;
+
+  uint256 constant PRINCIPAL = 28_300_000 ether;
+
+  MoolahVaultAccount manager;
+
+  function setUp() public {
+    vm.createSelectFork(vm.envString("BSC_RPC"), FORK_BLOCK);
+
+    address[] memory recipients = new address[](2);
+    recipients[0] = LSR_POOL;
+    recipients[1] = USDT_BUYBACK;
+
+    MoolahVaultAccount impl = new MoolahVaultAccount();
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeCall(
+        MoolahVaultAccount.initialize,
+        (PROTOCOL_TIMELOCK, B0C6, BOT_EOA, PAUSER_EOA, address(VAULT), B0C6, PRINCIPAL, recipients)
+      )
+    );
+    manager = MoolahVaultAccount(address(proxy));
+
+    // launch step 3: B0c6 transfers the whole position in, with no contract-side hook
+    uint256 shares = VAULT.balanceOf(B0C6);
+    vm.prank(B0C6);
+    VAULT.transfer(address(manager), shares);
+    assertEq(VAULT.balanceOf(address(manager)), shares);
+    assertEq(VAULT.balanceOf(B0C6), 0);
+  }
+
+  /// @dev the position transfer needs no whitelist: the vault gates only deposit/mint receivers.
+  function test_fork_positionTransferNeedsNoWhitelist() public view {
+    assertFalse(VAULT.isWhiteList(address(manager)));
+    assertGt(VAULT.balanceOf(address(manager)), 0);
+  }
+
+  function test_fork_backlogMatchesExpectation() public view {
+    uint256 assets = manager.totalAssets();
+    assertApproxEqAbs(assets, 28_492_314.211909e18, 1e18);
+
+    uint256 claimable = manager.claimableYield();
+    assertEq(claimable, assets - PRINCIPAL);
+    assertApproxEqAbs(claimable, 192_314.21e18, 1e18);
+
+    // C3 with the live fee (1e17): the naive share of totalAssets ignores accrued-but-unminted fee
+    // shares and reads ~29.6 lisUSD high. totalAssets() must be the lower, fee-adjusted figure.
+    uint256 shares = VAULT.balanceOf(address(manager));
+    uint256 naive = (VAULT.totalAssets() * shares) / VAULT.totalSupply();
+    assertLt(assets, naive);
+    assertApproxEqAbs(naive - assets, 29.6e18, 1e18);
+  }
+
+  function test_fork_previewClaimReportsRealLiquidity() public view {
+    (uint256 claimable, uint256 withdrawable, uint256 claimableNow) = manager.previewClaim();
+    assertGt(withdrawable, 0);
+    // ~9.96M of queue liquidity against a ~192k backlog, so nothing is clamped at this block
+    assertGt(withdrawable, claimable);
+    assertEq(claimableNow, claimable);
+  }
+
+  /// @dev the headline flow: split the real backlog between the live LSR pool and the live Buyback.
+  function test_fork_claimYieldSplitsBacklogAcrossBothDestinations() public {
+    uint256 claimable = manager.claimableYield();
+    uint256 toLsr = 50_000e18;
+    uint256 toBuyback = claimable - toLsr;
+
+    uint256 lsrBefore = LISUSD.balanceOf(LSR_POOL);
+    uint256 buybackBefore = LISUSD.balanceOf(USDT_BUYBACK);
+
+    MoolahVaultAccount.Payment[] memory p = new MoolahVaultAccount.Payment[](2);
+    p[0] = MoolahVaultAccount.Payment({ to: LSR_POOL, amount: toLsr });
+    p[1] = MoolahVaultAccount.Payment({ to: USDT_BUYBACK, amount: toBuyback });
+
+    vm.prank(BOT_EOA);
+    uint256 total = manager.claimYield(p);
+
+    assertEq(total, claimable);
+    assertEq(LISUSD.balanceOf(LSR_POOL) - lsrBefore, toLsr);
+    assertEq(LISUSD.balanceOf(USDT_BUYBACK) - buybackBefore, toBuyback);
+    assertEq(LISUSD.balanceOf(address(manager)), 0);
+
+    // principal is intact up to the share-price dust bound
+    uint256 assets = manager.totalAssets();
+    assertLe(assets, PRINCIPAL);
+    assertGe(assets + VAULT.convertToAssets(1) + 1, PRINCIPAL);
+    assertEq(manager.claimableYield(), 0);
+  }
+
+  function test_fork_claimYieldRevertsAboveClaimable() public {
+    uint256 claimable = manager.claimableYield();
+
+    MoolahVaultAccount.Payment[] memory p = new MoolahVaultAccount.Payment[](1);
+    p[0] = MoolahVaultAccount.Payment({ to: USDT_BUYBACK, amount: claimable + 1 ether });
+
+    vm.prank(BOT_EOA);
+    vm.expectRevert(MoolahVaultAccount.ExceedsClaimable.selector);
+    manager.claimYield(p);
+  }
+
+  /// @dev C2 with the real selector: a withdrawal beyond queue liquidity reverts, never partially fills.
+  function test_fork_withdrawPrincipalRevertsBeyondLiquidity() public {
+    uint256 withdrawable = VAULT.maxWithdraw(address(manager));
+    assertLt(withdrawable, PRINCIPAL); // the position is mostly lent out, so this is a real ceiling
+
+    vm.prank(B0C6);
+    vm.expectRevert(ErrorsLib.NotEnoughLiquidity.selector);
+    manager.withdrawPrincipal(withdrawable + 1_000 ether);
+
+    // and just at the ceiling succeeds
+    uint256 before = LISUSD.balanceOf(B0C6);
+    vm.prank(B0C6);
+    manager.withdrawPrincipal(withdrawable);
+    assertEq(LISUSD.balanceOf(B0C6) - before, withdrawable);
+    assertEq(manager.principal(), PRINCIPAL - withdrawable);
+  }
+
+  /// @dev the emergency exit hands over shares, so it does not touch the withdraw queue: it moves the
+  ///      whole ~28.27M position at this block even though maxRedeem is far below it — the same state
+  ///      in which withdrawPrincipal and claimYield revert NotEnoughLiquidity().
+  function test_fork_emergencyWithdrawMovesSharesAtAnyLiquidity() public {
+    uint256 held = VAULT.balanceOf(address(manager));
+    assertLt(VAULT.maxRedeem(address(manager)), held); // the position is mostly lent out
+
+    vm.prank(B0C6);
+    uint256 shares = manager.emergencyWithdraw();
+
+    assertEq(shares, held);
+    assertEq(VAULT.balanceOf(B0C6), held);
+    assertEq(VAULT.balanceOf(address(manager)), 0);
+    assertEq(manager.principal(), 0);
+    assertEq(manager.claimableYield(), 0);
+    assertEq(LISUSD.balanceOf(address(manager)), 0);
+  }
+
+  /// @dev depositPrincipal is the one path that needs the vault whitelist, and only the Lending
+  ///      TimeLock can grant it.
+  function test_fork_depositPrincipalNeedsWhitelist() public {
+    uint256 amount = 1_000 ether;
+    deal(address(LISUSD), B0C6, amount);
+    vm.prank(B0C6);
+    LISUSD.approve(address(manager), amount);
+
+    vm.prank(B0C6);
+    vm.expectRevert(ErrorsLib.NotWhiteList.selector);
+    manager.depositPrincipal(amount);
+
+    vm.prank(LENDING_TIMELOCK);
+    VAULT.setWhiteList(address(manager), true);
+
+    vm.prank(B0C6);
+    manager.depositPrincipal(amount);
+    assertEq(manager.principal(), PRINCIPAL + amount);
+  }
+}

--- a/test/utils/mocks/MockYieldVault.sol
+++ b/test/utils/mocks/MockYieldVault.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import { ERC20Mock } from "moolah-vault/mocks/ERC20Mock.sol";
+
+/// @dev Minimal stand-in for MoolahVault. Reproduces the three behaviours the manager must survive:
+///      a liquidity ceiling below the position value, a deposit whitelist on the receiver only, and
+///      NAV that can move in both directions.
+contract MockYieldVault is ERC4626 {
+  using Math for uint256;
+  /// @dev caps maxWithdraw, standing in for the real vault's withdraw-queue liquidity
+  uint256 public liquidity = type(uint256).max;
+
+  /// @dev makes withdraw deliver less than the assets it burned shares for — stands in for a vault
+  ///      upgrade that changes withdraw semantics
+  uint256 public withdrawShortfall;
+
+  bool public whitelistEnabled;
+  mapping(address => bool) public isWhiteList;
+
+  constructor(IERC20 asset_) ERC4626(asset_) ERC20("Mock Vault", "mVLT") {}
+
+  function setLiquidity(uint256 _liquidity) external {
+    liquidity = _liquidity;
+  }
+
+  function setWithdrawShortfall(uint256 amount) external {
+    withdrawShortfall = amount;
+  }
+
+  /// @dev makes a share transfer a no-op that still returns true — stands in for a vault upgrade that
+  ///      breaks transfers. SafeERC20 cannot catch that; emergencyWithdraw's balance check can.
+  bool public transferNoop;
+
+  function setTransferNoop(bool enabled) external {
+    transferNoop = enabled;
+  }
+
+  function transfer(address to, uint256 value) public override(ERC20, IERC20) returns (bool) {
+    if (transferNoop) return true;
+    return super.transfer(to, value);
+  }
+
+  function setWhitelistEnabled(bool enabled) external {
+    whitelistEnabled = enabled;
+  }
+
+  function setWhiteList(address account, bool enabled) external {
+    isWhiteList[account] = enabled;
+  }
+
+  /// @dev raise NAV without minting shares — the mock's "yield accrued"
+  function accrue(uint256 amount) external {
+    ERC20Mock(asset()).mint(address(this), amount);
+  }
+
+  /// @dev lower NAV without burning shares — stands in for a loss or a lockBuffer dip (C1)
+  function loss(uint256 amount) external {
+    ERC20Mock(asset()).burn(address(this), amount);
+  }
+
+  function _convertToShares(uint256 assets, Math.Rounding rounding) internal view override returns (uint256) {
+    uint256 supply = totalSupply();
+    return supply == 0 ? assets : assets.mulDiv(supply, totalAssets(), rounding);
+  }
+
+  function _convertToAssets(uint256 shares, Math.Rounding rounding) internal view override returns (uint256) {
+    uint256 supply = totalSupply();
+    return supply == 0 ? shares : shares.mulDiv(totalAssets(), supply, rounding);
+  }
+
+  function maxWithdraw(address owner) public view override returns (uint256) {
+    return Math.min(super.maxWithdraw(owner), liquidity);
+  }
+
+  /// @dev the liquidity ceiling has to bind the redeem path too, or emergencyWithdraw would look
+  ///      unbounded here. Skipped when uncapped, because converting type(uint256).max overflows.
+  function maxRedeem(address owner) public view override returns (uint256) {
+    if (liquidity == type(uint256).max) return super.maxRedeem(owner);
+    return Math.min(super.maxRedeem(owner), convertToShares(liquidity));
+  }
+
+  /// @dev the real vault gates only the receiver of deposit/mint; withdraw/redeem/transfer are open
+  function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
+    if (whitelistEnabled) require(isWhiteList[receiver], "NotWhiteList");
+    super._deposit(caller, receiver, assets, shares);
+  }
+
+  /// @dev burns the full shares but delivers `assets - withdrawShortfall`
+  function _withdraw(
+    address caller,
+    address receiver,
+    address owner,
+    uint256 assets,
+    uint256 shares
+  ) internal override {
+    uint256 delivered = assets > withdrawShortfall ? assets - withdrawShortfall : 0;
+    super._withdraw(caller, receiver, owner, delivered, shares);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `MoolahVaultAccount`, an upgradeable account contract that holds the protocol's own lisUSD `MoolahVault` position behind an explicit `principal` baseline, so a bot can harvest only the surplus above that baseline to whitelisted destinations. Today the position sits directly in the B0c6 multisig, which means every yield sweep is a manual multisig transaction and there is no on-chain record of what part of the position is corpus and what part is yield.

## Change type

- [x] New contract
- [ ] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [x] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `MoolahVaultAccount` | `src/utils/MoolahVaultAccount.sol` | new |
| `DeployMoolahVaultAccount` | `script/utils/deploy_moolahVaultAccount.s.sol` | new |
| `DeployMoolahVaultAccountImpl` | `script/utils/deploy_moolahVaultAccount_impl.s.sol` | new |
| `MockYieldVault` | `test/utils/mocks/MockYieldVault.sol` | new (test only) |
| `MoolahVaultAccountTest` | `test/utils/MoolahVaultAccount.t.sol` | new (test only) |
| `MoolahVaultAccountForkTest` | `test/utils/MoolahVaultAccountFork.t.sol` | new (test only) |

No existing contract is modified. The only non-Solidity change is `.github/workflows/unit-tests.yaml`, which adds `MoolahVaultAccountForkTest` to both the `--no-match-contract` list of the unit job and the `--match-contract` list of the fork job.

## Interface changes

All new — this is a new contract.

**Roles**

| Role | Holder at deployment | Powers |
|------|----------------------|--------|
| `DEFAULT_ADMIN_ROLE` | protocol TimeLock | `_authorizeUpgrade`, `setPrincipalOwner`, MANAGER administration |
| `MANAGER` | B0c6 multisig | principal in/out, principal correction, recipient whitelist, emergency exit, `unpause`, BOT/PAUSER administration |
| `BOT` | harvest bot EOA | `claimYield` only |
| `PAUSER` | pauser Safe `0xEEfe…5Bd8`, 1-of-15 | `pause` only |

**External / public functions**

- `initialize(address admin, address manager, address bot, address pauser, address vault, address principalOwner, uint256 principal, address[] yieldRecipients)`
- `totalAssets() view returns (uint256)` — `vault.convertToAssets(vault.balanceOf(this))`
- `claimableYield() view returns (uint256)` — `max(0, totalAssets() - principal)`
- `previewClaim() view returns (uint256 claimable, uint256 withdrawable, uint256 claimableNow)`
- `depositPrincipal(uint256 assets)` — `MANAGER`, `nonReentrant`, `whenNotPaused`
- `withdrawPrincipal(uint256 assets)` — `MANAGER`, `nonReentrant`, `whenNotPaused`
- `increasePrincipal(uint256 assets)` — `MANAGER`; raises the baseline when the position is topped up as shares instead of assets
- `claimYield(Payment[] payments)` — `BOT`, `nonReentrant`, `whenNotPaused`; one `vault.withdraw` plus a `safeTransfer` fan-out
- `emergencyWithdraw() returns (uint256 shares)` — `MANAGER`, `nonReentrant`; transfers **all vault shares** to `principalOwner` and zeroes `principal`
- `getYieldRecipients() view returns (address[])`, `addYieldRecipient(address)`, `removeYieldRecipient(address)` — `MANAGER`
- `setPrincipalOwner(address)` — `DEFAULT_ADMIN_ROLE`
- `pause()` — `PAUSER`; `unpause()` — `MANAGER`

**Events:** `PrincipalDeposited`, `PrincipalWithdrawn`, `PrincipalIncreased`, `EmergencyWithdrawn`, `YieldClaimed`, `YieldPaid`, `AddYieldRecipient`, `RemoveYieldRecipient`, `SetPrincipalOwner`.

**Errors:** `ZeroAddress`, `ZeroAmount`, `AlreadySet`, `NoYieldRecipient`, `NotYieldRecipient`, `DuplicateRecipient`, `RecipientNotFound`, `ExceedsPrincipal`, `ExceedsClaimable`, `ZeroShares`, `WithdrawShortfall`, `SharesRemaining`.

## Storage layout

N/A for collision analysis — new contract, first deployment, no prior implementation to be compatible with.

For future upgrades: the contract inherits `UUPSUpgradeable`, `AccessControlEnumerableUpgradeable`, `PausableUpgradeable` and `ReentrancyGuardUpgradeable` from `openzeppelin-contracts-upgradeable` **v5.2.0**, all of which use ERC-7201 namespaced storage (e.g. `AccessControlEnumerableStorageLocation = 0xc1f6…2000`), so no parent occupies a sequential slot and no `__gap` is required. This contract's own variables occupy slots 0-5 in declaration order:

```
0  vault             IMoolahVault
1  asset             IERC20
2  principalOwner    address
3  principal         uint256
4  isYieldRecipient  mapping(address => bool)
5  yieldRecipients   address[]  (private)
```

New variables in a future implementation must be appended after `yieldRecipients`.

## Access control

New contract, so every gate is new. Points a reviewer should check deliberately:

- `_authorizeUpgrade` is `onlyRole(DEFAULT_ADMIN_ROLE)` and empty; the upgrade key is the protocol TimeLock, not the multisig.
- `emergencyWithdraw` is `onlyRole(MANAGER)`, not `DEFAULT_ADMIN_ROLE`. A 24-hour TimeLock-gated exit is not an emergency exit, and the funds are `principalOwner`'s own corpus. The destination is pinned to `principalOwner` and cannot be passed in; `setPrincipalOwner` remains `DEFAULT_ADMIN_ROLE`-only, so MANAGER cannot redirect the exit. DEFAULT_ADMIN keeps the upgrade key and MANAGER role administration, so it can self-grant if B0c6 is unavailable.
- `emergencyWithdraw` is **not** `whenNotPaused` — the incident that pauses this contract is the reason to call it. `withdrawPrincipal` **is** `whenNotPaused`: a halted contract must not let principal leave piecemeal, so while the pause holds the emergency exit is the only route out, and it cannot be walked down amount by amount. MANAGER holds `unpause`, so this is a speed bump for MANAGER rather than a trap.
- MANAGER administers BOT **and** PAUSER, so a leaked bot key or a pauser key holding the contract down can be rotated at multisig speed instead of waiting on a 24-hour TimeLock proposal. DEFAULT_ADMIN_ROLE still administers MANAGER, so nothing leaves the TimeLock's reach.
- `claimYield` can only pay whitelisted destinations, and the whitelist is `MANAGER`-only.
- The constructor calls `_disableInitializers()`, so the implementation itself can never be initialized.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | New contract, first deployment. Parents use ERC-7201 namespaced storage (OZ upgradeable v5.2.0); own variables occupy slots 0-5 with room to append. |
| Fund safety | 🟡 Low | The contract will custody ≈28.5 M lisUSD from day one. Corpus can only leave to `principalOwner`; yield can only leave to whitelisted destinations, capped by `claimableYield()`. `principal` is an explicit baseline that never floats with NAV, so a NAV drop cannot be harvested as yield. `initialize` sets the baseline at deployment, so the launch share transfer needs nothing else — `increasePrincipal` is NOT part of the launch, and calling it on top would count the same corpus twice against a baseline that cannot be lowered again. Residual operational risk applies to LATER share top-ups only: there the share transfer and `increasePrincipal` must ride in ONE Safe MultiSend, or the whole transferred position reads as claimable yield in between. Documented in NatSpec on `increasePrincipal`. |
| Access control | 🟡 Low | Four bare-name roles, one holder each at deployment, deployer holds none. MANAGER can force the position back to `principalOwner` at will but cannot change that destination. Upgrade authority sits with the TimeLock. |
| External call safety | 🟢 None | Only calls the lisUSD `MoolahVault` and `SafeERC20` transfers of lisUSD / vault shares. All state-changing entrypoints are `nonReentrant`. `principal` is zeroed before the share transfer in `emergencyWithdraw`, and the post-transfer balance is re-read (`SharesRemaining`) because SafeERC20 checks the return value, not the effect. |

Deployment-time front-running is closed structurally, which is the direct answer to the 2026-05-25 lisAster proxy hijack (root cause: a non-atomic deploy script that left a front-runnable window between deployment and initialization / ownership transfer):

1. `initialize` calldata rides in the `ERC1967Proxy` constructor, so no block exists in which the proxy is deployed but uninitialized.
2. The implementation burns its initializer in its constructor; the `_impl` script asserts this with a local `call`.
3. Roles go straight to their final holders in `initialize` — no `grantRole` / `revokeRole` window, and the deployer never holds a role.
4. `abi.encodeCall` type-checks the initializer arguments at compile time, and the post-broadcast `require` block asserts the resulting state.

## Deployment

- **Chain:** BSC mainnet (chain id 56).
- **Scripts:** `script/utils/deploy_moolahVaultAccount.s.sol:DeployMoolahVaultAccount` deploys implementation plus initialized `ERC1967Proxy` in one run; `script/utils/deploy_moolahVaultAccount_impl.s.sol:DeployMoolahVaultAccountImpl` deploys an implementation only, for later TimeLock-driven upgrades (it must never touch the proxy).
- **Env vars:** no new ones. `PRIVATE_KEY` via the existing `DeployBase._deployerKey()`; `BSC_RPC` for the fork tests.
- **Dry run (no `--broadcast`), both scripts SIMULATION COMPLETE:**

```
deploy_moolahVaultAccount        gas 3,957,380  ≈ 0.000197869 BNB
deploy_moolahVaultAccount_impl   gas 2,949,857  ≈ 0.00014749285 BNB
```

The post-broadcast self-checks run inside the simulation: ERC-1967 implementation slot, all four role holders, member count 1 per role, deployer holds neither DEFAULT_ADMIN nor MANAGER, `vault` / `principalOwner` / `principal`, and two seeded yield recipients.

**Not in this PR:** the two operational steps that follow deployment — whitelisting the proxy on the vault through the Lending TimeLock (24-hour `schedule` → `execute`), and moving ≈28.27 M shares out of B0c6. The share transfer is the whole of that step: `initialize` has already set `principal` to 28,300,000, so `increasePrincipal` must NOT be called at launch. An audit is planned before that share transfer.

## Test plan

- [x] `forge test --mc MoolahVaultAccountTest` → `74 passed; 0 failed; 0 skipped`
- [x] `forge test --mc MoolahVaultAccountForkTest` → `8 passed; 0 failed; 0 skipped` (BSC fork at block 116,433,631)
- [x] `npm run check` → `All matched files use Prettier code style!`
- [x] Both deploy scripts simulate against BSC mainnet without `--broadcast` and pass their own `require` self-checks
- [x] Fork tests assert the real vault's behaviour with exact selectors: `ErrorsLib.NotEnoughLiquidity` on an over-liquidity withdrawal, `NotWhiteList` on an un-whitelisted deposit, and that a share transfer into this contract needs no whitelist
- [x] Fork test confirms `emergencyWithdraw` moves shares at any liquidity level — a share transfer never walks the withdraw queue, so the exit is not bounded by vault liquidity

Local caveat, unrelated to this PR: `test/utils/PositionMigrator.t.sol` cannot compile in a git worktree because the `lib/lista-dao-contracts.git` submodule is not materialized there, so local runs used `--skip PositionMigrator.t.sol`. CI checks out submodules normally and is unaffected.
