### PR TITLE
fix(utils): MoolahVaultAccount audit follow-up

### DIFF
--- a/script/utils/deploy_moolahVaultAccount.s.sol
+++ b/script/utils/deploy_moolahVaultAccount.s.sol
@@ -68,6 +68,9 @@ contract DeployMoolahVaultAccount is DeployBase {
     require(account.getRoleMemberCount(account.PAUSER()) == 1, "pauser count");
     require(!account.hasRole(account.DEFAULT_ADMIN_ROLE(), deployer), "deployer is admin");
     require(!account.hasRole(account.MANAGER(), deployer), "deployer is manager");
+    // MANAGER administers BOT and PAUSER so a leaked key can be rotated without a 24h proposal
+    require(account.getRoleAdmin(account.BOT()) == account.MANAGER(), "bot role admin");
+    require(account.getRoleAdmin(account.PAUSER()) == account.MANAGER(), "pauser role admin");
     require(address(account.vault()) == vault, "vault");
     require(account.principalOwner() == principalOwner, "principalOwner");
     require(account.principal() == principal, "principal");

--- a/script/utils/deploy_moolahVaultAccount_impl.s.sol
+++ b/script/utils/deploy_moolahVaultAccount_impl.s.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 import "forge-std/Script.sol";
 import { DeployBase } from "../DeployBase.sol";
 
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
 import { MoolahVaultAccount } from "../../src/utils/MoolahVaultAccount.sol";
 
 /// @dev deploys a new implementation only. The TimeLock then calls
@@ -25,12 +27,18 @@ contract DeployMoolahVaultAccountImpl is DeployBase {
     address deployer = vm.addr(deployerPrivateKey);
     address[] memory recipients = new address[](1);
     recipients[0] = deployer;
-    (bool initializable, ) = address(impl).call(
+    (bool initializable, bytes memory ret) = address(impl).call(
       abi.encodeCall(
         MoolahVaultAccount.initialize,
         (deployer, deployer, deployer, deployer, deployer, deployer, 1, recipients)
       )
     );
     require(!initializable, "implementation must not be initializable");
+    // It has to fail for the RIGHT reason. `_vault` is `deployer`, an EOA, so an implementation with
+    // no _disableInitializers() would still revert here — at IMoolahVault(_vault).asset() — and the
+    // check above would pass on a broken implementation. Only InvalidInitialization proves the
+    // initializer was burned before any argument was touched.
+    require(ret.length >= 4, "implementation reverted without a reason");
+    require(bytes4(ret) == Initializable.InvalidInitialization.selector, "initializer was not burned");
   }
 }

--- a/src/utils/MoolahVaultAccount.sol
+++ b/src/utils/MoolahVaultAccount.sol
@@ -30,8 +30,9 @@ import { IMoolahVault } from "moolah-vault/interfaces/IMoolahVault.sol";
 ///         can already pull the entire principal back to itself through `withdrawPrincipal`. What no
 ///         MANAGER call can do is choose a destination — principal and the emergency exit pay
 ///         `principalOwner`, yield pays whitelisted recipients, and `setPrincipalOwner` is
-///         DEFAULT_ADMIN_ROLE-only. BOT's admin is MANAGER rather than DEFAULT_ADMIN_ROLE because
-///         rotating a leaked bot key must not wait on a 24h TimeLock proposal.
+///         DEFAULT_ADMIN_ROLE-only. BOT's and PAUSER's admin is MANAGER rather than
+///         DEFAULT_ADMIN_ROLE because rotating a leaked bot key — or revoking a pauser key that is
+///         holding the contract down — must not wait on a 24h TimeLock proposal.
 ///      4. `principal` is raised by MANAGER (`depositPrincipal`, `increasePrincipal`) and lowered
 ///         only against funds actually leaving (`withdrawPrincipal`, `emergencyWithdraw`), with one
 ///         exception: `emergencyWithdraw` resets it to 0, because it always empties the position and
@@ -119,7 +120,7 @@ contract MoolahVaultAccount is
   /// @dev initialize contract. Roles are granted to their FINAL holders; the deployer takes none.
   /// @dev permissionless by design — note 1 in the contract header.
   /// @param admin DEFAULT_ADMIN_ROLE — upgrades, setPrincipalOwner, role administration
-  /// @param manager MANAGER — principal movement, recipient whitelist, unpause
+  /// @param manager MANAGER — principal movement, recipient whitelist, unpause, BOT/PAUSER admin
   /// @param bot BOT — claimYield
   /// @param pauser PAUSER — pause
   /// @param _vault the MoolahVault whose shares this contract holds
@@ -153,8 +154,10 @@ contract MoolahVaultAccount is
     _grantRole(MANAGER, manager);
     _grantRole(BOT, bot);
     _grantRole(PAUSER, pauser);
-    // so MANAGER can rotate the bot key without a TimeLock proposal
+    // so MANAGER can rotate the bot key, or revoke a pauser key that is holding the contract down,
+    // without a TimeLock proposal
     _setRoleAdmin(BOT, MANAGER);
+    _setRoleAdmin(PAUSER, MANAGER);
 
     vault = IMoolahVault(_vault);
     asset = IERC20(IMoolahVault(_vault).asset());
@@ -202,10 +205,13 @@ contract MoolahVaultAccount is
   }
 
   /// @dev redeem principal to principalOwner. The caller cannot name a destination.
-  /// @dev deliberately NOT whenNotPaused — pause must not trap the owner's principal at exactly the
-  ///      moment someone wants it out.
+  /// @dev whenNotPaused: a halted contract must not let principal leave piecemeal. Pause is not only
+  ///      a bot kill-switch — it is also the state an incident puts this contract in, and while it
+  ///      holds, the only sanctioned exit is `emergencyWithdraw`, which takes the whole position back
+  ///      to principalOwner in one move and cannot be walked down amount by amount. MANAGER holds
+  ///      `unpause`, so this is a speed bump for MANAGER, not a trap.
   /// @dev checks-effects-interactions: principal is decremented before the vault call.
-  function withdrawPrincipal(uint256 assets) external onlyRole(MANAGER) nonReentrant {
+  function withdrawPrincipal(uint256 assets) external onlyRole(MANAGER) nonReentrant whenNotPaused {
     require(assets > 0, ZeroAmount());
     require(assets <= principal, ExceedsPrincipal());
 
@@ -217,24 +223,30 @@ contract MoolahVaultAccount is
 
   /// @dev raise the principal baseline without moving funds. Vault shares can be transferred in by a
   ///      plain ERC20 transfer, which bypasses depositPrincipal — that position would otherwise read
-  ///      as harvestable yield and be paid out as such. This is the correction for it, and the way a
-  ///      top-up is recorded when it arrives as shares instead of lisUSD.
+  ///      as harvestable yield and be paid out as such. This is how a top-up is recorded when it
+  ///      arrives as shares instead of lisUSD.
+  /// @dev NOT part of the launch. At launch the baseline comes from `initialize` and B0c6 only
+  ///      transfers its shares in — calling this on top of that would count the same corpus twice,
+  ///      and the baseline cannot be lowered again. There are exactly two sanctioned ways to move the
+  ///      baseline afterwards:
+  ///        1. `depositPrincipal` / `withdrawPrincipal` — lisUSD in or out, baseline follows the funds
+  ///           in the same call, nothing to pair up;
+  ///        2. a share transfer plus this call, in ONE transaction.
+  /// @dev for route 2 the pairing is mandatory: a Safe MultiSend batch, never two separate Safe
+  ///      transactions. Nothing on-chain can enforce it — a plain ERC20 share transfer has no hook to
+  ///      intercept. Split across two transactions, the whole transferred position reads as claimable
+  ///      yield in between, and a BOT harvest landing in that window pays the corpus out as yield to a
+  ///      whitelisted destination.
   /// @dev MANAGER-only and raise-only — notes 4 and 5 in the contract header. Raising the baseline
   ///      can only shrink claimableYield(), so it cannot widen what BOT may take, and it redirects
   ///      nothing: withdrawPrincipal still pays principalOwner only.
   /// @dev no nonReentrant and no whenNotPaused: no external call, no fund movement, and a correction
   ///      that only shrinks claimableYield() must stay available during an incident.
-  /// @param assets the COST BASIS of the position being recorded — the lisUSD that was paid for those
-  ///        shares — never their current `vault.convertToAssets(shares)` value. The two differ by
-  ///        exactly the yield already accrued on them: at launch 28,274,743 shares were worth
-  ///        28,492,314 but cost 28,300,000, and recording the market value would have swallowed the
-  ///        192,314 backlog into principal, out of BOT's reach forever. That is why the amount is a
-  ///        parameter and is not computed on-chain — the cost basis does not exist on-chain.
-  /// @dev the share transfer and this call MUST go in ONE transaction — a Safe MultiSend batch, never
-  ///      two separate Safe transactions. Nothing on-chain can enforce the pairing: a plain ERC20
-  ///      share transfer has no hook to intercept. Split across two transactions, the whole
-  ///      transferred position reads as claimable yield in between, and a BOT harvest landing in that
-  ///      window pays the corpus out as yield to a whitelisted destination.
+  /// @param assets the COST BASIS of the shares being recorded — the lisUSD that was paid for them —
+  ///        never their current `vault.convertToAssets(shares)` value. The two differ by exactly the
+  ///        yield already accrued on them, and recording the market value would swallow that backlog
+  ///        into principal, out of BOT's reach forever. That is why the amount is a parameter and is
+  ///        not computed on-chain — the cost basis does not exist on-chain.
   function increasePrincipal(uint256 assets) external onlyRole(MANAGER) {
     require(assets > 0, ZeroAmount());
 

--- a/test/utils/MoolahVaultAccount.t.sol
+++ b/test/utils/MoolahVaultAccount.t.sol
@@ -110,6 +110,40 @@ contract MoolahVaultAccountTest is Test {
     assertTrue(manager.hasRole(BOT_ROLE, newBot));
   }
 
+  function test_initialize_setsPauserRoleAdminToManager() public {
+    assertEq(manager.getRoleAdmin(PAUSER_ROLE), MANAGER_ROLE);
+
+    // a pauser key holding the contract down must be revocable without a 24h TimeLock proposal
+    vm.prank(pauser);
+    manager.pause();
+
+    vm.prank(managerSafe);
+    manager.revokeRole(PAUSER_ROLE, pauser);
+    assertFalse(manager.hasRole(PAUSER_ROLE, pauser));
+
+    address newPauser = makeAddr("newPauser");
+    vm.prank(managerSafe);
+    manager.grantRole(PAUSER_ROLE, newPauser);
+    assertTrue(manager.hasRole(PAUSER_ROLE, newPauser));
+
+    vm.prank(managerSafe);
+    manager.unpause();
+
+    vm.prank(pauser);
+    vm.expectRevert(
+      abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, pauser, PAUSER_ROLE)
+    );
+    manager.pause();
+  }
+
+  /// @dev the implementation must refuse initialization because its initializer is burned, not
+  ///      because some argument happened to be unusable. deploy_moolahVaultAccount_impl.s.sol
+  ///      asserts this selector for the same reason.
+  function test_implementation_revertsWithInvalidInitialization() public {
+    vm.expectRevert(Initializable.InvalidInitialization.selector);
+    impl.initialize(admin, managerSafe, bot, pauser, address(vaultMock), managerSafe, PRINCIPAL, _twoRecipients());
+  }
+
   function test_initialize_revertsOnZeroAddress() public {
     address[] memory r = _twoRecipients();
     address[6] memory args = [admin, managerSafe, bot, pauser, address(vaultMock), managerSafe];
@@ -500,14 +534,25 @@ contract MoolahVaultAccountTest is Test {
     assertEq(manager.principal(), PRINCIPAL + 100 ether);
   }
 
-  /// @dev pause exists to stop the bot, not to trap the owner's principal.
-  function test_withdrawPrincipal_worksWhenPaused() public {
+  /// @dev a halted contract must not let principal leave piecemeal. The only exit while paused is
+  ///      emergencyWithdraw, which takes the whole position back to principalOwner in one move.
+  function test_withdrawPrincipal_revertsWhenPaused() public {
     vm.prank(pauser);
     manager.pause();
 
     vm.prank(managerSafe);
+    vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
     manager.withdrawPrincipal(100 ether);
-    assertEq(token.balanceOf(managerSafe), 100 ether);
+
+    // the emergency exit stays open
+    vm.prank(managerSafe);
+    manager.emergencyWithdraw();
+    assertEq(vaultMock.balanceOf(address(manager)), 0);
+    assertEq(manager.principal(), 0);
+
+    // and it works again once MANAGER lifts the pause
+    vm.prank(managerSafe);
+    manager.unpause();
   }
   // ------------------------------------------------------------------ claimYield
 


### PR DESCRIPTION
## Summary

Follow-up to `moolah#229` from its audit. Four changes, no new contract and no new external function: `withdrawPrincipal` now respects the pause, MANAGER becomes the role admin of PAUSER, `increasePrincipal`'s NatSpec is corrected on what the launch sequence actually is, and the implementation deploy script's initializer-lock self-check is made non-vacuous.

Targets `feat/moolah-vault-account` rather than `master` so `moolah#229` keeps its own review history.

## Change type

- [ ] New contract
- [ ] Upgrade (existing proxy)
- [x] Bug fix
- [ ] Gas optimization
- [x] Configuration change (role-admin topology)
- [x] Migration / deploy script
- [x] Test

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `MoolahVaultAccount` | `src/utils/MoolahVaultAccount.sol` | modified (pre-deployment; nothing is live yet) |
| `DeployMoolahVaultAccount` | `script/utils/deploy_moolahVaultAccount.s.sol` | modified |
| `DeployMoolahVaultAccountImpl` | `script/utils/deploy_moolahVaultAccount_impl.s.sol` | modified |
| `MoolahVaultAccountTest` | `test/utils/MoolahVaultAccount.t.sol` | modified (test only) |

## 1. `withdrawPrincipal` is now `whenNotPaused`

A halted contract must not let principal leave piecemeal. While the pause holds, the only sanctioned exit is `emergencyWithdraw`, which takes the whole position back to `principalOwner` in one move and cannot be walked down amount by amount.

`emergencyWithdraw` deliberately stays outside the pause — the incident that pauses this contract is the reason to call it — and MANAGER holds `unpause`, so this is a speed bump for MANAGER rather than a trap on the corpus.

This inverts the previous stance, and `test_withdrawPrincipal_worksWhenPaused` was inverted to `test_withdrawPrincipal_revertsWhenPaused`, which also asserts the emergency exit still works while paused and that MANAGER can lift the pause afterwards.

## 2. MANAGER is now the role admin of PAUSER

`_setRoleAdmin(PAUSER, MANAGER)` joins the existing `_setRoleAdmin(BOT, MANAGER)`.

PAUSER at `0xEEfebb1546d88EA0909435DF6f615084DD3c5Bd8` is a Safe with `getThreshold() == 1` over 15 owners (the PR #229 body describes it as an EOA; it is not). Any one of fifteen keys can therefore halt `claimYield` and `depositPrincipal`. Revoking such a key must not wait on a 24-hour TimeLock proposal, which is the same argument that already put BOT's administration with MANAGER.

DEFAULT_ADMIN_ROLE (the protocol TimeLock) still administers MANAGER, so nothing is removed from the TimeLock's reach.

The main deploy script's post-deploy self-check now asserts both edges:

```solidity
require(account.getRoleAdmin(account.BOT()) == account.MANAGER(), "bot role admin");
require(account.getRoleAdmin(account.PAUSER()) == account.MANAGER(), "pauser role admin");
```

## 3. `increasePrincipal` NatSpec corrected — it is not part of the launch

The old NatSpec read as if the launch share transfer had to be paired with `increasePrincipal` in one MultiSend. It does not, and doing it would be harmful: `initialize` already sets `principal` to 28,300,000, so calling `increasePrincipal(28_300_000e18)` after the share transfer would count the same corpus twice. The baseline cannot be lowered again — there is no setter, `withdrawPrincipal` would revert because the vault cannot deliver 56.6 M, and only `emergencyWithdraw` (which empties the position and forces the whole launch to be redone) or an upgrade recovers it. `claimableYield()` would read 0 for good.

The doc now states that the baseline comes from `initialize`, that B0c6 only transfers shares at launch, and that there are exactly two sanctioned ways to move the baseline afterwards:

1. `depositPrincipal` / `withdrawPrincipal` — lisUSD in or out, the baseline follows the funds in the same call, nothing to pair up;
2. a share transfer plus `increasePrincipal`, in ONE transaction — this is where the Safe MultiSend requirement applies.

No code change; the on-chain behaviour is unchanged and deliberately unguarded, because raising the baseline can only shrink `claimableYield()` and a bound on it would break legitimate top-ups after a loss.

## 4. The implementation deploy script's initializer-lock check was vacuous

`deploy_moolahVaultAccount_impl.s.sol` asserted the freshly deployed implementation cannot be initialized, by calling `initialize` with `deployer` in every address slot. Because `_vault` is then an EOA, `initialize` reverts at `IMoolahVault(_vault).asset()` — so `require(!initializable)` holds whether or not the constructor burned the initializer. An implementation with no `_disableInitializers()` would have cleared the check.

It now also asserts the revert reason:

```solidity
require(ret.length >= 4, "implementation reverted without a reason");
require(bytes4(ret) == Initializable.InvalidInitialization.selector, "initializer was not burned");
```

`InvalidInitialization` can only come from the `initializer` modifier, which runs before any argument is touched.

Verified both directions during the audit: a stub with the same `initialize` prologue and no initializer lock reverts with empty returndata, so the new assertion rejects it, while the real implementation reverts with `InvalidInitialization` and passes. `test_implementation_revertsWithInvalidInitialization` pins the selector in the unit suite.

## Interface changes

No signature changes. Behavioural changes:

| Function | Before | After |
|---|---|---|
| `withdrawPrincipal` | callable while paused | reverts `EnforcedPause` while paused |
| `getRoleAdmin(PAUSER)` | `DEFAULT_ADMIN_ROLE` | `MANAGER` |

## Storage layout

Unchanged — no state variable added, removed or reordered. `forge inspect MoolahVaultAccount storage-layout` still reports slots 0-5 as `vault`, `asset`, `principalOwner`, `principal`, `isYieldRecipient`, `yieldRecipients`.

## Access control

- `withdrawPrincipal` gains `whenNotPaused`; `emergencyWithdraw` does not.
- MANAGER gains administration of PAUSER. MANAGER already administered BOT and already owned the recipient whitelist, and MANAGER is `principalOwner`, so this does not put any new fund path within its reach — it only lets it rotate a pause key at multisig speed.
- DEFAULT_ADMIN_ROLE still holds the upgrade key, `setPrincipalOwner`, and administration of MANAGER.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | No storage change; nothing deployed yet either |
| Fund safety | 🟢 None | No new fund path. `withdrawPrincipal` is strictly more restricted than before; the emergency exit is untouched |
| Access control | 🟡 Low | PAUSER administration moves from the TimeLock to MANAGER (B0c6, 3-of-6). Deliberate: it buys pause-key rotation speed and mirrors BOT |
| External call safety | 🟢 None | No external call added |

## Test plan

- [x] `forge test --mc MoolahVaultAccountTest` → `74 passed; 0 failed; 0 skipped` (72 before; `test_initialize_setsPauserRoleAdminToManager` and `test_implementation_revertsWithInvalidInitialization` added, `test_withdrawPrincipal_worksWhenPaused` inverted in place)
- [x] `forge test --mc MoolahVaultAccountForkTest` → `8 passed; 0 failed; 0 skipped` (BSC fork at block 116,433,631)
- [x] `npm run check` → `All matched files use Prettier code style!`
- [x] `script/utils/deploy_moolahVaultAccount.s.sol` simulates on BSC mainnet without `--broadcast`, `SIMULATION COMPLETE`, gas 4,000,742 — the two new role-admin assertions pass
- [x] `script/utils/deploy_moolahVaultAccount_impl.s.sol` simulates on BSC mainnet without `--broadcast`, `SIMULATION COMPLETE`, gas 2,961,101 — the new selector assertion passes

Local caveat carried over from `moolah#229`: `test/utils/PositionMigrator.t.sol` cannot compile in a git worktree because the `lib/lista-dao-contracts.git` submodule is not materialized there, so local runs used `--skip PositionMigrator.t.sol`. CI checks out submodules normally and is unaffected.

## Audit findings not acted on

- **`withdrawPrincipal` has no delivery check** (`claimYield` re-reads the asset balance, `emergencyWithdraw` re-reads the share balance, `withdrawPrincipal` does neither). Closed as won't-fix: `MoolahVault` is a first-party contract and its logic is trusted, so the scenario requires an adversarial upgrade of the vault by the same protocol TimeLock that already holds this contract's upgrade key.
- **The main deploy script's `require` self-checks run after `vm.stopBroadcast()`**, so with `--broadcast` a wrong constant is already on-chain when a check trips. Accepted: the value is in the dry run, which is always performed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
