### PR TITLE
feat(market-factory): support bStock markets and wire the liquidation suite

### DIFF
--- a/src/liquidator/IBrokerLiquidator.sol
+++ b/src/liquidator/IBrokerLiquidator.sol
@@ -80,6 +80,10 @@ interface IBrokerLiquidator {
 
   function reflowBlacklist(address token) external view returns (bool);
 
+  function batchSetSmartProviders(address[] calldata providers, bool status) external;
+
+  function smartProviders(address provider) external view returns (bool);
+
   function marketIdToBroker(bytes32 id) external view returns (address);
 
   function brokerToMarketId(address broker) external view returns (bytes32);

--- a/src/liquidator/ILiquidationVault.sol
+++ b/src/liquidator/ILiquidationVault.sol
@@ -25,6 +25,13 @@ interface ILiquidationVault {
   /// @notice Whether an address is a registered liquidator (provideFund allow-list + collect* target).
   function liquidators(address liquidator) external view returns (bool);
 
+  /// @notice Whether a token is on the sell/collect allow-list (sell* legs + BOT collect*).
+  function tokenWhitelist(address token) external view returns (bool);
+
+  /// @notice Add / remove a token from the sell/collect allow-list. Requires MANAGER on the vault.
+  /// @dev Reverts (WhitelistSameStatus) when the token is already in the requested state.
+  function setTokenWhitelist(address token, bool status) external;
+
   event FundProvided(address indexed liquidator, address indexed token, uint256 amount);
   event FundCollected(address indexed liquidator, address indexed token, uint256 amount);
   event LiquidatorSet(address indexed liquidator, bool registered);

--- a/src/moolah/MarketFactory.sol
+++ b/src/moolah/MarketFactory.sol
@@ -14,6 +14,8 @@ import { ISmartProvider } from "../provider/interfaces/IProvider.sol";
 import { IBroker } from "../broker/interfaces/IBroker.sol";
 import { IBrokerLiquidator } from "../liquidator/IBrokerLiquidator.sol";
 import { IRateCalculator } from "../broker/interfaces/IRateCalculator.sol";
+import { ILiquidationVault } from "../liquidator/ILiquidationVault.sol";
+import { IStockOracleSwitch } from "../oracle/interfaces/IStockOracleSwitch.sol";
 
 contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, PausableUpgradeable {
   using MarketParamsLib for MarketParams;
@@ -40,6 +42,12 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
   address public immutable slisBNBProvider; // on ETH: not used (address(0))
   IRateCalculator public rateCalculator;
   IBrokerLiquidator public brokerLiquidator;
+  /// @dev Shared liquidation fund pool. Tokens of every created market are added to its sell/collect
+  ///      allow-list. address(0) disables the wiring (chains where the vault is not deployed yet).
+  ILiquidationVault public liquidationVault;
+  /// @dev Market-hours switch for tokenized stocks. Required only to create a bStock market
+  ///      (`stockCollateral = true`); address(0) disables the wiring.
+  IStockOracleSwitch public stockOracleSwitch;
 
   bytes32 public constant OPERATOR = keccak256("OPERATOR");
   bytes32 public constant PAUSER = keccak256("PAUSER");
@@ -48,6 +56,8 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
   event CommonMarketDeployed(MarketParams marketParams, Id marketId);
   event RateCalculatorUpdated(address indexed oldAddress, address indexed newAddress);
   event BrokerLiquidatorUpdated(address indexed oldAddress, address indexed newAddress);
+  event LiquidationVaultUpdated(address indexed oldAddress, address indexed newAddress);
+  event StockOracleSwitchUpdated(address indexed oldAddress, address indexed newAddress);
 
   /**
    * @dev constructor to set immutable variables
@@ -118,20 +128,23 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
    * @param supplyWhitelist An array of address arrays for the supply whitelist of each market
    * @param liquidatorMarketWhitelist An array of booleans indicating whether to whitelist the market in the liquidator for each market
    * @param liquidatorSmartProviders An array of booleans indicating whether the market is a smart collateral market that requires special provider configuration for each market
+   * @param stockCollaterals An array of booleans indicating whether the collateral token is a tokenized stock (bStock) that must be registered in the StockOracleSwitch for each market
    */
   function batchCreateMarkets(
     MarketParams[] calldata params,
     address[][] calldata liquidatorWhitelist,
     address[][] calldata supplyWhitelist,
     bool[] calldata liquidatorMarketWhitelist,
-    bool[] calldata liquidatorSmartProviders
+    bool[] calldata liquidatorSmartProviders,
+    bool[] calldata stockCollaterals
   ) external onlyRole(OPERATOR) {
     require(params.length > 0, "empty market params");
     require(
       params.length == liquidatorWhitelist.length &&
         params.length == supplyWhitelist.length &&
         params.length == liquidatorMarketWhitelist.length &&
-        params.length == liquidatorSmartProviders.length,
+        params.length == liquidatorSmartProviders.length &&
+        params.length == stockCollaterals.length,
       "array length mismatch"
     );
 
@@ -141,7 +154,8 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
         liquidatorWhitelist[i],
         supplyWhitelist[i],
         liquidatorMarketWhitelist[i],
-        liquidatorSmartProviders[i]
+        liquidatorSmartProviders[i],
+        stockCollaterals[i]
       );
     }
   }
@@ -153,15 +167,24 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
    * @param supplyWhitelist An array of addresses for the supply whitelist of the market
    * @param liquidatorMarketWhitelist A boolean indicating whether to whitelist the market in the liquidator
    * @param liquidatorSmartProvider A boolean indicating whether the market is a smart collateral market that requires special provider configuration
+   * @param stockCollateral A boolean indicating whether the collateral token is a tokenized stock (bStock) that must be registered in the StockOracleSwitch
    */
   function createMarket(
     MarketParams calldata param,
     address[] calldata liquidatorWhitelist,
     address[] calldata supplyWhitelist,
     bool liquidatorMarketWhitelist,
-    bool liquidatorSmartProvider
+    bool liquidatorSmartProvider,
+    bool stockCollateral
   ) external onlyRole(OPERATOR) {
-    _createMarket(param, liquidatorWhitelist, supplyWhitelist, liquidatorMarketWhitelist, liquidatorSmartProvider);
+    _createMarket(
+      param,
+      liquidatorWhitelist,
+      supplyWhitelist,
+      liquidatorMarketWhitelist,
+      liquidatorSmartProvider,
+      stockCollateral
+    );
   }
 
   /**
@@ -193,7 +216,8 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     address[] memory liquidatorWhitelist,
     address[] memory supplyWhitelist,
     bool liquidatorMarketWhitelist,
-    bool liquidatorSmartProvider
+    bool liquidatorSmartProvider,
+    bool stockCollateral
   ) private whenNotPaused {
     Id id = param.id();
     // moolah create market
@@ -210,13 +234,12 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     if (liquidatorMarketWhitelist) {
       liquidator.setMarketWhitelist(Id.unwrap(id), true);
     }
-    // liquidator set token whitelist
-    if (!liquidator.tokenWhitelist(param.loanToken)) {
-      liquidator.setTokenWhitelist(param.loanToken, true);
-    }
-    if (!liquidator.tokenWhitelist(param.collateralToken)) {
-      liquidator.setTokenWhitelist(param.collateralToken, true);
-    }
+    // token whitelist across the liquidation suite (Liquidator / BrokerLiquidator / LiquidationVault).
+    // A smart-collateral LP is excluded from the vault only: the vault cannot sell it, so it is
+    // reflow-blacklisted in _configSmartProvider and only its underlying pair legs are vault-whitelisted.
+    // Whitelisting the LP there would also open the BOT collect* path for it.
+    _whitelistToken(param.loanToken, true);
+    _whitelistToken(param.collateralToken, !liquidatorSmartProvider);
     // revenue distributor set token whitelist
     if (address(revenueDistributor) != address(0) && !revenueDistributor.tokenWhitelist(param.loanToken)) {
       address[] memory tokens = new address[](1);
@@ -249,6 +272,15 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     // if market is smart collateral
     if (liquidatorSmartProvider) {
       _configSmartProvider(id, param.oracle, param.collateralToken);
+    }
+
+    // if collateral is a tokenized stock, register it in the market-hours switch. setStock also opens
+    // the stock; it stays gated by the switch's global market-hours flag, which MANAGER owns.
+    if (stockCollateral) {
+      require(address(stockOracleSwitch) != address(0), "StockOracleSwitch not set");
+      if (!stockOracleSwitch.registered(param.collateralToken)) {
+        stockOracleSwitch.setStock(param.collateralToken, true);
+      }
     }
 
     emit CommonMarketDeployed(param, id);
@@ -296,13 +328,9 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     // rate calculator register broker
     rateCalculator.registerBroker(param.broker, param.ratePerSecond, param.maxRatePerSecond);
 
-    // broker liquidator set token whitelist
-    if (!brokerLiquidator.tokenWhitelist(param.loanToken)) {
-      brokerLiquidator.setTokenWhitelist(param.loanToken, true);
-    }
-    if (!brokerLiquidator.tokenWhitelist(param.collateralToken)) {
-      brokerLiquidator.setTokenWhitelist(param.collateralToken, true);
-    }
+    // token whitelist across the liquidation suite (Liquidator / BrokerLiquidator / LiquidationVault)
+    _whitelistToken(param.loanToken, true);
+    _whitelistToken(param.collateralToken, true);
 
     // broker liquidator set market whitelist
     brokerLiquidator.setMarketToBroker(Id.unwrap(id), param.broker, true);
@@ -327,19 +355,41 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     if (!publicLiquidator.smartProviders(provider)) {
       publicLiquidator.batchSetSmartProviders(smartProviders, true);
     }
-    // set token whitelist for liquidator if not set
+    if (address(brokerLiquidator) != address(0) && !brokerLiquidator.smartProviders(provider)) {
+      brokerLiquidator.batchSetSmartProviders(smartProviders, true);
+    }
+    // the underlying pair legs are what actually gets sold after a smart-collateral liquidation, so
+    // they are whitelisted on the whole suite. A native leg surfaces here as BNB_ADDRESS and is
+    // whitelisted like any other token, which is what collectETH / sellBNB require.
     address token0 = ISmartProvider(provider).token(0);
     address token1 = ISmartProvider(provider).token(1);
-    if (!liquidator.tokenWhitelist(token0)) {
-      liquidator.setTokenWhitelist(token0, true);
-    }
-    if (!liquidator.tokenWhitelist(token1)) {
-      liquidator.setTokenWhitelist(token1, true);
-    }
-    // blacklist the LP collateral from reflow: a wrong-entry plain liquidate must not push un-sellable
-    // LP into the vault. It stays in the liquidator, recoverable via redeemSmartCollateral.
+    _whitelistToken(token0, true);
+    _whitelistToken(token1, true);
+    // blacklist the LP collateral from reflow on every liquidator that reflows into the vault: a
+    // wrong-entry plain liquidate must not push un-sellable LP into the vault. It stays in the
+    // liquidator, recoverable via redeemSmartCollateral. PublicLiquidator has no reflow path.
     if (!liquidator.reflowBlacklist(collateral)) {
       liquidator.setReflowBlacklist(collateral, true);
+    }
+    if (address(brokerLiquidator) != address(0) && !brokerLiquidator.reflowBlacklist(collateral)) {
+      brokerLiquidator.setReflowBlacklist(collateral, true);
+    }
+  }
+
+  /// @dev Whitelist `token` on every contract that can hold or sell it during a liquidation: the
+  ///      Liquidator, the BrokerLiquidator and — when `includeVault` — the LiquidationVault. The
+  ///      latter two are skipped while unwired (address(0)). Every branch reads the current status
+  ///      first because these setters reject a no-op status change.
+  /// @param includeVault false only for a smart-collateral LP, which the vault must never hold.
+  function _whitelistToken(address token, bool includeVault) private {
+    if (!liquidator.tokenWhitelist(token)) {
+      liquidator.setTokenWhitelist(token, true);
+    }
+    if (address(brokerLiquidator) != address(0) && !brokerLiquidator.tokenWhitelist(token)) {
+      brokerLiquidator.setTokenWhitelist(token, true);
+    }
+    if (includeVault && address(liquidationVault) != address(0) && !liquidationVault.tokenWhitelist(token)) {
+      liquidationVault.setTokenWhitelist(token, true);
     }
   }
 
@@ -361,6 +411,26 @@ contract MarketFactory is UUPSUpgradeable, AccessControlEnumerableUpgradeable, P
     require(_brokerLiquidator != address(0), "ZeroAddress");
     emit BrokerLiquidatorUpdated(address(brokerLiquidator), _brokerLiquidator);
     brokerLiquidator = IBrokerLiquidator(_brokerLiquidator);
+  }
+
+  /**
+   * @dev Set the liquidation vault address
+   * @param _liquidationVault The address of the liquidation vault contract
+   */
+  function setLiquidationVault(address _liquidationVault) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_liquidationVault != address(0), "ZeroAddress");
+    emit LiquidationVaultUpdated(address(liquidationVault), _liquidationVault);
+    liquidationVault = ILiquidationVault(_liquidationVault);
+  }
+
+  /**
+   * @dev Set the stock oracle switch address
+   * @param _stockOracleSwitch The address of the stock oracle switch contract
+   */
+  function setStockOracleSwitch(address _stockOracleSwitch) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    require(_stockOracleSwitch != address(0), "ZeroAddress");
+    emit StockOracleSwitchUpdated(address(stockOracleSwitch), _stockOracleSwitch);
+    stockOracleSwitch = IStockOracleSwitch(_stockOracleSwitch);
   }
 
   /**

--- a/src/oracle/StockOracle.sol
+++ b/src/oracle/StockOracle.sol
@@ -5,10 +5,7 @@ import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgr
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import { IOracle, TokenConfig } from "../moolah/interfaces/IOracle.sol";
-
-interface IStockOracleSwitch {
-  function isEnabled(address token) external view returns (bool);
-}
+import { IStockOracleSwitch } from "./interfaces/IStockOracleSwitch.sol";
 
 /// @title StockOracle
 /// @notice Moolah {IOracle} for tokenized-stock (bStock) markets.

--- a/src/oracle/interfaces/IStockOracleSwitch.sol
+++ b/src/oracle/interfaces/IStockOracleSwitch.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.34;
+
+/// @title IStockOracleSwitch
+/// @notice View + config surface of {StockOracleSwitch} used by its consumers ({StockOracle} for
+///         market-hours gating, {MarketFactory} for registering a bStock collateral at market creation).
+interface IStockOracleSwitch {
+  /// @notice Whether `token` is currently enabled (tradable). Unregistered tokens are passthrough (always true).
+  function isEnabled(address token) external view returns (bool);
+
+  /// @notice Whether `token` is a managed stock, i.e. subject to market-hours gating.
+  function registered(address token) external view returns (bool);
+
+  /// @notice Register / un-register a managed stock. Requires MANAGER on the switch.
+  /// @dev Reverts (AlreadySet) when the token is already in the requested state.
+  function setStock(address token, bool isStock) external;
+}

--- a/test/moolah/MarketFactoryTest.sol
+++ b/test/moolah/MarketFactoryTest.sol
@@ -21,6 +21,8 @@ import { MockSmartProvider } from "./mocks/MockSmartProvider.sol";
 import { RateCalculator, RateConfig } from "../../src/broker/RateCalculator.sol";
 import { BrokerLiquidator } from "../../src/liquidator/BrokerLiquidator.sol";
 import { LendingBroker } from "../../src/broker/LendingBroker.sol";
+import { LiquidationVault } from "../../src/liquidator/LiquidationVault.sol";
+import { StockOracleSwitch } from "../../src/oracle/StockOracleSwitch.sol";
 
 contract MarketFactoryTest is Test {
   using MarketParamsLib for MarketParams;
@@ -40,6 +42,8 @@ contract MarketFactoryTest is Test {
   OracleMock oracle;
   RateCalculator rateCalculator;
   BrokerLiquidator brokerLiquidator;
+  LiquidationVault liquidationVault;
+  StockOracleSwitch stockOracleSwitch;
 
   address admin;
   address manager;
@@ -86,6 +90,20 @@ contract MarketFactoryTest is Test {
     );
     brokerLiquidator = BrokerLiquidator(payable(address(brokerLiquidatorProxy)));
 
+    LiquidationVault liquidationVaultImpl = new LiquidationVault();
+    ERC1967Proxy liquidationVaultProxy = new ERC1967Proxy(
+      address(liquidationVaultImpl),
+      abi.encodeWithSelector(liquidationVaultImpl.initialize.selector, admin, manager, pauser, bot)
+    );
+    liquidationVault = LiquidationVault(payable(address(liquidationVaultProxy)));
+
+    StockOracleSwitch stockOracleSwitchImpl = new StockOracleSwitch();
+    ERC1967Proxy stockOracleSwitchProxy = new ERC1967Proxy(
+      address(stockOracleSwitchImpl),
+      abi.encodeWithSelector(stockOracleSwitchImpl.initialize.selector, admin, manager, bot, pauser)
+    );
+    stockOracleSwitch = StockOracleSwitch(address(stockOracleSwitchProxy));
+
     liquidator = new MockLiquidator();
     publicLiquidator = new MockLiquidator();
     listaRevenueDistributor = new MockListaRevenueDistributor();
@@ -121,6 +139,8 @@ contract MarketFactoryTest is Test {
     vm.startPrank(admin);
     marketFactory.setRateCalculator(address(rateCalculator));
     marketFactory.setBrokerLiquidator(address(brokerLiquidator));
+    marketFactory.setLiquidationVault(address(liquidationVault));
+    marketFactory.setStockOracleSwitch(address(stockOracleSwitch));
     vm.stopPrank();
 
     vm.startPrank(manager);
@@ -133,6 +153,8 @@ contract MarketFactoryTest is Test {
     moolah.grantRole(moolah.MANAGER(), address(marketFactory));
     rateCalculator.grantRole(rateCalculator.MANAGER(), address(marketFactory));
     brokerLiquidator.grantRole(brokerLiquidator.MANAGER(), address(marketFactory));
+    liquidationVault.grantRole(liquidationVault.MANAGER(), address(marketFactory));
+    stockOracleSwitch.grantRole(stockOracleSwitch.MANAGER(), address(marketFactory));
     vm.stopPrank();
   }
 
@@ -195,13 +217,16 @@ contract MarketFactoryTest is Test {
     liquidatorSmartProviders[0] = false;
     liquidatorSmartProviders[1] = false;
 
+    bool[] memory stockCollaterals = new bool[](markets.length);
+
     vm.startPrank(operator);
     marketFactory.batchCreateMarkets(
       markets,
       liquidatorWhitelist,
       supplyWhitelist,
       liquidatorMarketWhitelist,
-      liquidatorSmartProviders
+      liquidatorSmartProviders,
+      stockCollaterals
     );
     vm.stopPrank();
 
@@ -308,13 +333,16 @@ contract MarketFactoryTest is Test {
     liquidatorSmartProviders[0] = true;
     liquidatorSmartProviders[1] = true;
 
+    bool[] memory stockCollaterals = new bool[](markets.length);
+
     vm.startPrank(operator);
     marketFactory.batchCreateMarkets(
       markets,
       liquidatorWhitelist,
       supplyWhitelist,
       liquidatorMarketWhitelist,
-      liquidatorSmartProviders
+      liquidatorSmartProviders,
+      stockCollaterals
     );
     vm.stopPrank();
 
@@ -328,6 +356,19 @@ contract MarketFactoryTest is Test {
       address(smartProvider2),
       "Provider mismatch for market 2"
     );
+    assertTrue(liquidationVault.tokenWhitelist(address(token0)), "token0 not whitelisted in vault");
+    assertTrue(liquidationVault.tokenWhitelist(address(token1)), "token1 not whitelisted in vault");
+    // the pair legs and the loan tokens are whitelisted across the whole suite ...
+    assertSuiteWhitelisted(address(token0), true);
+    assertSuiteWhitelisted(address(token1), true);
+    assertSuiteWhitelisted(address(loanToken1), true);
+    assertSuiteWhitelisted(address(loanToken2), true);
+    // ... but the LP itself must never be sellable/collectable by the vault, and must be
+    // reflow-blacklisted on both liquidators that reflow into it
+    assertSmartLpGated(address(collateralToken1));
+    assertSmartLpGated(address(collateralToken2));
+    assertSmartProviderRegistered(address(smartProvider1));
+    assertSmartProviderRegistered(address(smartProvider2));
     assertTrue(
       moolah.flashLoanTokenBlacklist(address(params1.collateralToken)),
       "Collateral token should be blacklisted for flash loan for market 1"
@@ -391,13 +432,16 @@ contract MarketFactoryTest is Test {
     bool[] memory liquidatorSmartProviders = new bool[](1);
     liquidatorSmartProviders[0] = false;
 
+    bool[] memory stockCollaterals = new bool[](markets.length);
+
     vm.startPrank(operator);
     marketFactory.batchCreateMarkets(
       markets,
       liquidatorWhitelist,
       supplyWhitelist,
       liquidatorMarketWhitelist,
-      liquidatorSmartProviders
+      liquidatorSmartProviders,
+      stockCollaterals
     );
     vm.stopPrank();
 
@@ -438,13 +482,16 @@ contract MarketFactoryTest is Test {
     bool[] memory liquidatorSmartProviders = new bool[](1);
     liquidatorSmartProviders[0] = false;
 
+    bool[] memory stockCollaterals = new bool[](markets.length);
+
     vm.startPrank(operator);
     marketFactory.batchCreateMarkets(
       markets,
       liquidatorWhitelist,
       supplyWhitelist,
       liquidatorMarketWhitelist,
-      liquidatorSmartProviders
+      liquidatorSmartProviders,
+      stockCollaterals
     );
     vm.stopPrank();
 
@@ -496,6 +543,245 @@ contract MarketFactoryTest is Test {
       Id.unwrap(id),
       "Market ID mismatch in broker liquidator"
     );
+    assertTrue(liquidationVault.tokenWhitelist(address(loanToken)), "loan token not whitelisted in vault");
+    assertTrue(liquidationVault.tokenWhitelist(address(collateralToken)), "collateral token not whitelisted in vault");
+    // a broker market is liquidated via BrokerLiquidator, but the token whitelist is kept uniform
+    assertSuiteWhitelisted(address(loanToken), true);
+    assertSuiteWhitelisted(address(collateralToken), true);
+  }
+
+  function testCreateStockMarket() public {
+    ERC20Mock loanToken = new ERC20Mock();
+    ERC20Mock stockToken = new ERC20Mock();
+
+    oracle.setPrice(address(loanToken), 1e8);
+    oracle.setPrice(address(stockToken), 1e8);
+
+    MarketParams memory params = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(stockToken),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+
+    vm.prank(operator);
+    marketFactory.createMarket(params, new address[](0), new address[](0), true, false, true);
+
+    assertTrue(stockOracleSwitch.registered(address(stockToken)), "stock not registered in switch");
+    assertTrue(stockOracleSwitch.enabled(address(stockToken)), "stock not enabled in switch");
+    // the loan token is not a managed stock: it must stay unregistered (passthrough in the oracle)
+    assertFalse(stockOracleSwitch.registered(address(loanToken)), "loan token should not be registered");
+    // global market switch is MANAGER-owned and untouched by the factory, so the stock is still gated
+    assertFalse(stockOracleSwitch.globalEnabled(), "factory must not open the global market switch");
+    assertFalse(stockOracleSwitch.isEnabled(address(stockToken)), "stock tradable before global open");
+
+    vm.prank(manager);
+    stockOracleSwitch.setGlobal(true);
+    assertTrue(stockOracleSwitch.isEnabled(address(stockToken)), "stock not tradable after global open");
+  }
+
+  /// @dev setStock reverts (AlreadySet) on a no-op, so an already-registered stock must be skipped.
+  function testCreateStockMarketAlreadyRegistered() public {
+    ERC20Mock loanToken = new ERC20Mock();
+    ERC20Mock stockToken = new ERC20Mock();
+
+    oracle.setPrice(address(loanToken), 1e8);
+    oracle.setPrice(address(stockToken), 1e8);
+
+    // stock already registered (e.g. a second market on the same collateral), and currently closed
+    vm.prank(manager);
+    stockOracleSwitch.setStock(address(stockToken), true);
+    vm.prank(bot);
+    stockOracleSwitch.close(address(stockToken));
+
+    MarketParams memory params = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(stockToken),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+
+    vm.prank(operator);
+    marketFactory.createMarket(params, new address[](0), new address[](0), true, false, true);
+
+    assertTrue(stockOracleSwitch.registered(address(stockToken)), "stock should stay registered");
+    // creating a market must not re-open a stock that ops deliberately closed
+    assertFalse(stockOracleSwitch.enabled(address(stockToken)), "closed stock must not be reopened");
+  }
+
+  function testCreateStockMarketRevertsWhenSwitchNotSet() public {
+    MarketFactory factory = newMarketFactory();
+    vm.startPrank(admin);
+    moolah.grantRole(moolah.OPERATOR(), address(factory));
+    moolah.grantRole(moolah.MANAGER(), address(factory));
+    vm.stopPrank();
+
+    ERC20Mock loanToken = new ERC20Mock();
+    ERC20Mock stockToken = new ERC20Mock();
+    oracle.setPrice(address(loanToken), 1e8);
+    oracle.setPrice(address(stockToken), 1e8);
+
+    MarketParams memory params = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(stockToken),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+
+    vm.prank(operator);
+    vm.expectRevert("StockOracleSwitch not set");
+    factory.createMarket(params, new address[](0), new address[](0), true, false, true);
+  }
+
+  function testCreateMarketWhitelistsLiquidationVaultTokens() public {
+    ERC20Mock loanToken = new ERC20Mock();
+    ERC20Mock collateralToken = new ERC20Mock();
+
+    oracle.setPrice(address(loanToken), 1e8);
+    oracle.setPrice(address(collateralToken), 1e8);
+
+    MarketParams memory params = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(collateralToken),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+
+    vm.prank(operator);
+    marketFactory.createMarket(params, new address[](0), new address[](0), true, false, false);
+
+    // uniform across Liquidator / BrokerLiquidator / LiquidationVault
+    assertSuiteWhitelisted(address(loanToken), true);
+    assertSuiteWhitelisted(address(collateralToken), true);
+  }
+
+  /// @dev setTokenWhitelist reverts (WhitelistSameStatus) on a no-op, so an already-whitelisted token
+  ///      must be skipped — otherwise a second market sharing the loan token bricks creation.
+  function testCreateMarketVaultWhitelistIdempotent() public {
+    ERC20Mock loanToken = new ERC20Mock();
+    ERC20Mock collateralToken1 = new ERC20Mock();
+    ERC20Mock collateralToken2 = new ERC20Mock();
+
+    oracle.setPrice(address(loanToken), 1e8);
+    oracle.setPrice(address(collateralToken1), 1e8);
+    oracle.setPrice(address(collateralToken2), 1e8);
+
+    vm.prank(manager);
+    liquidationVault.setTokenWhitelist(address(loanToken), true);
+
+    MarketParams memory params1 = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(collateralToken1),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+    MarketParams memory params2 = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(collateralToken2),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+
+    vm.startPrank(operator);
+    marketFactory.createMarket(params1, new address[](0), new address[](0), true, false, false);
+    marketFactory.createMarket(params2, new address[](0), new address[](0), true, false, false);
+    vm.stopPrank();
+
+    assertTrue(liquidationVault.tokenWhitelist(address(collateralToken1)), "collateral 1 not whitelisted");
+    assertTrue(liquidationVault.tokenWhitelist(address(collateralToken2)), "collateral 2 not whitelisted");
+  }
+
+  function testCreateMarketSkipsVaultWhenUnset() public {
+    MarketFactory factory = newMarketFactory();
+    vm.startPrank(admin);
+    moolah.grantRole(moolah.OPERATOR(), address(factory));
+    moolah.grantRole(moolah.MANAGER(), address(factory));
+    vm.stopPrank();
+
+    ERC20Mock loanToken = new ERC20Mock();
+    ERC20Mock collateralToken = new ERC20Mock();
+    oracle.setPrice(address(loanToken), 1e8);
+    oracle.setPrice(address(collateralToken), 1e8);
+
+    MarketParams memory params = MarketParams({
+      loanToken: address(loanToken),
+      collateralToken: address(collateralToken),
+      lltv: lltv80,
+      irm: address(irm),
+      oracle: address(oracle)
+    });
+
+    // no liquidationVault wired: creation still succeeds, just without vault whitelisting
+    vm.prank(operator);
+    factory.createMarket(params, new address[](0), new address[](0), true, false, false);
+
+    assertFalse(liquidationVault.tokenWhitelist(address(loanToken)), "vault should be untouched");
+  }
+
+  function testSettersOnlyAdmin() public {
+    address rando = makeAddr("rando");
+
+    vm.startPrank(rando);
+    vm.expectRevert();
+    marketFactory.setLiquidationVault(address(liquidationVault));
+    vm.expectRevert();
+    marketFactory.setStockOracleSwitch(address(stockOracleSwitch));
+    vm.stopPrank();
+
+    vm.startPrank(admin);
+    vm.expectRevert("ZeroAddress");
+    marketFactory.setLiquidationVault(address(0));
+    vm.expectRevert("ZeroAddress");
+    marketFactory.setStockOracleSwitch(address(0));
+    vm.stopPrank();
+  }
+
+  /// @dev `token` must be whitelisted on Liquidator + BrokerLiquidator, and on the vault iff `inVault`.
+  function assertSuiteWhitelisted(address token, bool inVault) private view {
+    assertTrue(liquidator.tokenWhitelist(token), "token not whitelisted on liquidator");
+    assertTrue(brokerLiquidator.tokenWhitelist(token), "token not whitelisted on brokerLiquidator");
+    assertEq(liquidationVault.tokenWhitelist(token), inVault, "vault whitelist state mismatch");
+  }
+
+  /// @dev A smart-collateral LP: never vault-whitelisted, always reflow-blacklisted on both liquidators.
+  function assertSmartLpGated(address lp) private view {
+    assertFalse(liquidationVault.tokenWhitelist(lp), "smart LP must not be whitelisted in vault");
+    assertTrue(liquidator.reflowBlacklist(lp), "smart LP not reflow-blacklisted on liquidator");
+    assertTrue(brokerLiquidator.reflowBlacklist(lp), "smart LP not reflow-blacklisted on brokerLiquidator");
+  }
+
+  /// @dev A smart provider must be registered on every liquidator that can liquidate through it.
+  function assertSmartProviderRegistered(address provider) private view {
+    assertTrue(liquidator.smartProviders(provider), "provider not set on liquidator");
+    assertTrue(publicLiquidator.smartProviders(provider), "provider not set on publicLiquidator");
+    assertTrue(brokerLiquidator.smartProviders(provider), "provider not set on brokerLiquidator");
+  }
+
+  /// @dev A MarketFactory proxy with neither liquidationVault nor stockOracleSwitch wired.
+  function newMarketFactory() private returns (MarketFactory) {
+    MarketFactory impl = new MarketFactory(
+      address(moolah),
+      address(liquidator),
+      address(publicLiquidator),
+      address(listaRevenueDistributor),
+      address(buyBack),
+      address(listaAutoBuyBack),
+      address(WBNB),
+      address(slisBNB),
+      address(bnbProvider),
+      address(slisBNBProvider)
+    );
+    ERC1967Proxy proxy = new ERC1967Proxy(
+      address(impl),
+      abi.encodeWithSelector(impl.initialize.selector, admin, operator, pauser)
+    );
+    return MarketFactory(address(proxy));
   }
 
   function newLendingBroker(address replayer) private returns (LendingBroker) {


### PR DESCRIPTION
## Summary

Two additions to `MarketFactory`, plus a consistency fix the second one surfaced.

**1. bStock market support.** New `stockCollateral` flag on `createMarket` / `stockCollaterals` array on `batchCreateMarkets`. When set, the factory registers the collateral in `StockOracleSwitch` via `setStock`, so a tokenized-stock market is gated by market hours from the moment it exists rather than depending on a follow-up ops step.

The factory deliberately does **not** touch `globalEnabled` — the daily market-hours switch stays MANAGER-owned. An already-registered stock is skipped, because `setStock` reverts `AlreadySet` on a no-op and creating a second market on the same collateral must not reopen a stock ops deliberately closed.

**2. LiquidationVault token whitelist**, wired everywhere the `Liquidator` whitelist was already set.

**3. Uniform whitelisting across all three liquidation contracts.** Auditing (2) showed the factory only ever configured a subset per path. Now collapsed into one `_whitelistToken(token, includeVault)` helper applied to every path:

| | before | after |
|---|---|---|
| common market | Liquidator | Liquidator + BrokerLiquidator + Vault |
| fixed-term market | BrokerLiquidator | Liquidator + BrokerLiquidator + Vault |
| smart-collateral legs | Liquidator | Liquidator + BrokerLiquidator + Vault |
| smart provider registration | Liquidator + PublicLiquidator | + BrokerLiquidator |
| smart LP reflow blacklist | Liquidator | Liquidator + BrokerLiquidator |

One deliberate exception, carried by the `includeVault` flag: a smart-collateral **LP is never vault-whitelisted**. The vault cannot sell it, so it is reflow-blacklisted on both liquidators instead; whitelisting it would also have opened the BOT `collect*` path for it. MANAGER rescue via `collectERC20` still works, since that bypasses `tokenWhitelist`.

## Why this shape

`liquidationVault` and `stockOracleSwitch` are **storage variables with admin setters**, following the existing `rateCalculator` / `brokerLiquidator` pattern rather than new constructor args. The constructor immutables are unchanged, so `deploy_marketFactory_impl.sol` works as-is and ETH can leave both unset (vault whitelisting silently skips; the stock flag reverts loudly).

## Verified against live BSC state

The chosen posture is not invented — it is what ops already maintains by hand, which the factory previously only half-reproduced:

- All 7 `StableSwapLPCollateral` tokens: reflow-blacklisted on **both** liquidators, vault-whitelisted on **none**.
- USDT / lisUSD / WBNB / slisBNB / BTCB / USD1: whitelisted on all three uniformly.
- `BNB_ADDRESS` whitelisted on all three, and the slisBNB/BNB provider's `token(1)` **is** `BNB_ADDRESS` — so native legs need no special case; the generic leg path covers `collectETH` / `sellBNB`.
- `vault.liquidators`: Liquidator ✅, BrokerLiquidator ✅, PublicLiquidator ❌ — correct, PublicLiquidator has no `fundSource` and never reflows.

## Out of scope (flagged, not changed)

- **`publicLiquidator.setMarketWhitelist`** is still never called by the factory. It is `onlyRole(BOT)` and the factory does not hold BOT on PublicLiquidator on mainnet. Enabling public liquidation is also a per-market policy call, not something to imply from `liquidatorMarketWhitelist` — wiring it needs a role grant plus a new flag.
- **`pairWhitelist`** on all four contracts: DEX pools/routers are not derivable from `MarketParams`.

## Deployment prerequisites

MarketFactory already holds `MANAGER` on Liquidator and BrokerLiquidator, so the new calls work. Still required before the upgraded factory can create anything:

1. Grant `MANAGER` to MarketFactory on **LiquidationVault** (`0xEe3aa1AF4Ee231f2e1277A48fc4A2f29A3D7C028`) and **StockOracleSwitch** (`0xb4678C3E8B49d2b95Da48458f98805da193A8498`) — both currently `false` on BSC.
2. Call `setLiquidationVault` / `setStockOracleSwitch`.

Note `switch.globalEnabled` is currently `true` on BSC, so a newly registered bStock goes live immediately rather than waiting for a market-hours open.

⚠️ **Breaking ABI change**: `createMarket` and `batchCreateMarkets` each take one additional argument. Any off-chain caller or script must be updated.

## Test

`forge test --mc MarketFactoryTest` — 12 passed, including 5 new tests:

- `testCreateStockMarket` — registers + enables the stock, leaves `globalEnabled` alone, stock only tradable after MANAGER opens the market
- `testCreateStockMarketAlreadyRegistered` — idempotent, and does **not** reopen a closed stock
- `testCreateStockMarketRevertsWhenSwitchNotSet`
- `testCreateMarketWhitelistsLiquidationVaultTokens` / `testCreateMarketVaultWhitelistIdempotent` / `testCreateMarketSkipsVaultWhenUnset`
- `testSettersOnlyAdmin`

`testCreateSmartProviderMarket` now asserts the full LP posture (not vault-whitelisted, reflow-blacklisted on both liquidators, provider registered on all three, legs whitelisted everywhere).

Full non-fork suite: **966 passed, 0 failed**. `forge build` and `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
